### PR TITLE
Regroup runtime and config changes after upstream reset

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,34 @@
+# nginx coding style for C modules
+# Based on nginx source conventions: 4-space indent, 80-col limit,
+# aligned struct members and macros (nginx hallmark style).
+BasedOnStyle: LLVM
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ColumnLimit: 80
+BreakBeforeBraces: Linux
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+IndentCaseLabels: false
+SpaceBeforeParens: ControlStatements
+PointerAlignment: Right
+AlignConsecutiveDeclarations:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: false
+AlignConsecutiveMacros:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: false
+AlignConsecutiveAssignments: false
+AlignTrailingComments:
+  Kind: Always
+  OverEmptyLines: 0
+SortIncludes: false
+ReflowComments: false
+BreakBeforeTernaryOperators: true
+AlwaysBreakAfterReturnType: None
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceInEmptyParentheses: false

--- a/filter/config
+++ b/filter/config
@@ -13,7 +13,7 @@ if [ -n "$ZSTD_INC" -o -n "$ZSTD_LIB" ]; then
     # we try the static shared library firstly
     ngx_zstd_opt_I="-I$ZSTD_INC -DZSTD_STATIC_LINKING_ONLY"
     ngx_zstd_opt_L="$ZSTD_LIB/libzstd.a"
-    SAVED_CC_TAST_FLAGS=$CC_TEST_FLAGS
+    SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
     CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
     SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
     NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
@@ -21,15 +21,15 @@ if [ -n "$ZSTD_INC" -o -n "$ZSTD_LIB" ]; then
     . auto/feature
 
     # restore
-    CC_TEST_FLAGS=$SAVED_CC_TAST_FLAGS
+    CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
     NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
 
     if [ $ngx_found = no ]; then
         # then try the dynamic shared library
         ngx_feature="ZStandard dynamic library in $ZSTD_INC and $ZSTD_LIB"
-        ngx_zstd_opt_L="-L$ZSTD_LIB -lzstd -Wl,-rpath, $ZSTD_LIB"
+        ngx_zstd_opt_L="-L$ZSTD_LIB -lzstd -Wl,-rpath,$ZSTD_LIB"
 
-        SAVED_CC_TAST_FLAGS=$CC_TEST_FLAGS
+        SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
         CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
         SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
         NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
@@ -37,7 +37,7 @@ if [ -n "$ZSTD_INC" -o -n "$ZSTD_LIB" ]; then
         . auto/feature
 
         # restore
-        CC_TEST_FLAGS=$SAVED_CC_TAST_FLAGS
+        CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
         NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
 
         if [ $ngx_found = no ]; then
@@ -55,7 +55,7 @@ else
     ngx_zstd_opt_I=
     ngx_zstd_opt_L="-lzstd"
 
-    SAVED_CC_TAST_FLAGS=$CC_TEST_FLAGS
+    SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
     CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
     SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
     NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
@@ -63,38 +63,48 @@ else
     . auto/feature
 
     # restore
-    CC_TEST_FLAGS=$SAVED_CC_TAST_FLAGS
+    CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
     NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
 
     if [ $ngx_found = no ]; then
+        # Dynamic auto-discovery failed. Try pkg-config (portable across
+        # Linux, FreeBSD, OpenBSD, Gentoo, Rocky/RHEL) before giving up.
+        # Note: -l:libzstd.a is GNU ld only and not used here.
+        ngx_pkgconf=
+        if command -v pkgconf > /dev/null 2>&1; then
+            ngx_pkgconf=pkgconf
+        elif command -v pkg-config > /dev/null 2>&1; then
+            ngx_pkgconf=pkg-config
+        fi
 
-        ngx_feature="ZStandard static library"
-        ngx_zstd_opt_I="-DZSTD_STATIC_LINKING_ONLY"
-        ngx_zstd_opt_L="-l:libzstd.a"
-        SAVED_CC_TAST_FLAGS=$CC_TEST_FLAGS
-        CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
-        SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
-        NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
+        if [ -n "$ngx_pkgconf" ] && $ngx_pkgconf --exists libzstd 2>/dev/null; then
+            ngx_feature="ZStandard library via pkg-config"
+            ngx_zstd_opt_I="$($ngx_pkgconf --cflags libzstd)"
+            ngx_zstd_opt_L="$($ngx_pkgconf --libs libzstd)"
 
-        . auto/feature
+            SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
+            CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
+            SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
+            NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
+
+            . auto/feature
+
+            # restore
+            CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
+            NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
+        fi
 
         if [ $ngx_found = no ]; then
             cat << END
             $0: error: ngx_http_zstd_filter_module requires the ZStandard library.
+            Install libzstd-dev (Debian/Ubuntu), zstd-devel (RHEL/Rocky),
+            dev-libs/zstd (Gentoo), or security/zstd (FreeBSD/OpenBSD ports),
+            or set ZSTD_INC and ZSTD_LIB to the library location.
 END
             exit 1
         fi
-
-        # restore
-        CC_TEST_FLAGS=$SAVED_CC_TAST_FLAGS
-        NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
-
-        cat << END
-        $0: warning: ngx_http_zstd_filter_module uses advanced ZStandard APIs (which are still considered experimental) while you are trying to link the dynamic shared library.
-END
     fi
 
-    # TODO we need more tries for the different OS port.
 fi
 
 NGX_LD_OPT="$ngx_zstd_opt_L $NGX_LD_OPT"

--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -10,10 +10,10 @@
 
 #include <zstd.h>
 
+#include "../ngx_http_zstd_common.h"
 
-#define NGX_HTTP_ZSTD_FILTER_COMPRESS       0
-#define NGX_HTTP_ZSTD_FILTER_FLUSH          1
-#define NGX_HTTP_ZSTD_FILTER_END            2
+
+#define NGX_HTTP_ZSTD_MAX_DICT_SIZE  (10 * 1024 * 1024)  /* 10 MB limit */
 
 
 typedef struct {
@@ -26,16 +26,24 @@ typedef struct {
     ngx_int_t                    level;
     ssize_t                      min_length;
     ssize_t                      max_length;
+    ssize_t                      target_cblock_size;  /* Issue #38: ZSTD_c_targetCBlockSize */
 
     ngx_hash_t                   types;
 
     ngx_bufs_t                   bufs;
 
     ngx_array_t                 *types_keys;
-    ngx_array_t                 *bypass;
 
     ZSTD_CDict                  *dict;
 } ngx_http_zstd_loc_conf_t;
+
+
+/* PR #49: Action state machine for compression lifecycle */
+typedef enum {
+    NGX_HTTP_ZSTD_FILTER_COMPRESS = 0,
+    NGX_HTTP_ZSTD_FILTER_FLUSH    = 1,
+    NGX_HTTP_ZSTD_FILTER_END      = 2,
+} ngx_http_zstd_action_t;
 
 
 typedef struct {
@@ -52,20 +60,20 @@ typedef struct {
     ZSTD_inBuffer                buffer_in;
     ZSTD_outBuffer               buffer_out;
 
-    ZSTD_CStream                *cstream;
-
     ngx_http_request_t          *request;
+    ZSTD_CCtx                   *cctx;
 
     size_t                       bytes_in;
     size_t                       bytes_out;
 
-    unsigned                     action:2;
-    unsigned                     last_action:2;
     unsigned                     last:1;
     unsigned                     redo:1;
     unsigned                     flush:1;
     unsigned                     done:1;
     unsigned                     nomem:1;
+
+    /* PR #49: Action state machine (COMPRESS, FLUSH, or END) */
+    ngx_http_zstd_action_t       action;
 } ngx_http_zstd_ctx_t;
 
 
@@ -83,36 +91,28 @@ static ngx_str_t  ngx_http_zstd_ratio = ngx_string("zstd_ratio");
 static ngx_int_t ngx_http_zstd_header_filter(ngx_http_request_t *r);
 static ngx_int_t ngx_http_zstd_body_filter(ngx_http_request_t *r,
     ngx_chain_t *in);
-
 static ngx_int_t ngx_http_zstd_filter_add_data(ngx_http_request_t *r,
     ngx_http_zstd_ctx_t *ctx);
 static ngx_int_t ngx_http_zstd_filter_get_buf(ngx_http_request_t *r,
     ngx_http_zstd_ctx_t *ctx);
-static ZSTD_CStream *ngx_http_zstd_filter_create_cstream(ngx_http_request_t *r,
+static ngx_int_t ngx_http_zstd_filter_init_cctx(ngx_http_request_t *r,
     ngx_http_zstd_ctx_t *ctx);
 static ngx_int_t ngx_http_zstd_filter_compress(ngx_http_request_t *r,
     ngx_http_zstd_ctx_t *ctx);
-
-static ngx_int_t ngx_http_zstd_ok(ngx_http_request_t *r);
-static ngx_int_t ngx_http_zstd_accept_encoding(ngx_str_t *ae);
-static ngx_uint_t ngx_http_zstd_quantity(u_char *p, u_char *last);
-
 static ngx_int_t ngx_http_zstd_filter_init(ngx_conf_t *cf);
-static void *ngx_http_zstd_create_main_conf(ngx_conf_t *cf);
+static void * ngx_http_zstd_create_main_conf(ngx_conf_t *cf);
 static char *ngx_http_zstd_init_main_conf(ngx_conf_t *cf, void *conf);
 static void *ngx_http_zstd_create_loc_conf(ngx_conf_t *cf);
 static char *ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent,
     void *child);
-
 static ngx_int_t ngx_http_zstd_add_variables(ngx_conf_t *cf);
 static ngx_int_t ngx_http_zstd_ratio_variable(ngx_http_request_t *r,
     ngx_http_variable_value_t *vv, uintptr_t data);
-
-static void *ngx_http_zstd_filter_alloc(void *opaque, size_t size);
-static void ngx_http_zstd_filter_free(void *opaque, void *address);
 static char *ngx_http_zstd_comp_level(ngx_conf_t *cf, void *post, void *data);
-
-static char *ngx_http_zstd_set_num_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+static char *ngx_conf_zstd_set_num_slot_with_negatives(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf);
+static void ngx_http_zstd_cleanup_dict(void *data);
+static void ngx_http_zstd_cleanup_cctx(void *data);
 
 
 static ngx_http_zstd_comp_level_bounds_t  ngx_http_zstd_comp_level_bounds = {
@@ -132,7 +132,7 @@ static ngx_command_t  ngx_http_zstd_filter_commands[] = {
 
     { ngx_string("zstd_comp_level"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
-      ngx_http_zstd_set_num_slot,
+      ngx_conf_zstd_set_num_slot_with_negatives,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_zstd_loc_conf_t, level),
       &ngx_http_zstd_comp_level_bounds },
@@ -152,7 +152,7 @@ static ngx_command_t  ngx_http_zstd_filter_commands[] = {
       NULL },
 
     { ngx_string("zstd_min_length"),
-      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_1MORE,
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_size_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_zstd_loc_conf_t, min_length),
@@ -165,11 +165,11 @@ static ngx_command_t  ngx_http_zstd_filter_commands[] = {
       offsetof(ngx_http_zstd_loc_conf_t, max_length),
       NULL },
 
-    { ngx_string("zstd_bypass"),
-      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_1MORE,
-      ngx_http_set_predicate_slot,
+    { ngx_string("zstd_target_cblock_size"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_size_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
-      offsetof(ngx_http_zstd_loc_conf_t, bypass),
+      offsetof(ngx_http_zstd_loc_conf_t, target_cblock_size),
       NULL },
 
     { ngx_string("zstd_dict_file"),
@@ -205,10 +205,10 @@ ngx_module_t  ngx_http_zstd_filter_module = {
     NGX_HTTP_MODULE,                        /* module type */
     NULL,                                   /* init master */
     NULL,                                   /* init module */
-    NULL,                                   /* init process */
+    NULL,                                 /* init process */
     NULL,                                   /* init thread */
     NULL,                                   /* exit thread */
-    NULL,                                   /* exit process */
+    NULL,                                 /* exit process */
     NULL,                                   /* exit master */
     NGX_MODULE_V1_PADDING
 };
@@ -233,25 +233,14 @@ ngx_http_zstd_header_filter(ngx_http_request_t *r)
        || (r->headers_out.content_encoding
            && r->headers_out.content_encoding->value.len)
        || (r->headers_out.content_length_n != -1
-           && (r->headers_out.content_length_n < zlcf->min_length
-               || (zlcf->max_length > 0
-                   && r->headers_out.content_length_n > zlcf->max_length)))
+           && r->headers_out.content_length_n < zlcf->min_length)
+       || (zlcf->max_length != NGX_CONF_UNSET
+           && r->headers_out.content_length_n != -1
+           && r->headers_out.content_length_n > zlcf->max_length)
        || ngx_http_test_content_type(r, &zlcf->types) == NULL
        || r->header_only)
     {
         return ngx_http_next_header_filter(r);
-    }
-
-    switch (ngx_http_test_predicates(r, zlcf->bypass)) {
-
-    case NGX_ERROR:
-        return NGX_ERROR;
-
-    case NGX_DECLINED:
-        return ngx_http_next_header_filter(r);
-
-    default: /* NGX_OK */
-        break;
     }
 
     r->gzip_vary = 1;
@@ -293,7 +282,6 @@ ngx_http_zstd_header_filter(ngx_http_request_t *r)
 static ngx_int_t
 ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 {
-    size_t                rv;
     ngx_int_t             flush, rc;
     ngx_chain_t          *cl;
     ngx_http_zstd_ctx_t  *ctx;
@@ -308,9 +296,9 @@ ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "http zstd filter");
 
-    if (ctx->cstream == NULL) {
-        ctx->cstream = ngx_http_zstd_filter_create_cstream(r, ctx);
-        if (ctx->cstream == NULL) {
+    if (!ctx->last && ctx->buffer_in.src == NULL) {
+        /* First call: configure the reused CCtx for this request. */
+        if (ngx_http_zstd_filter_init_cctx(r, ctx) != NGX_OK) {
             goto failed;
         }
     }
@@ -395,20 +383,17 @@ ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
         ngx_chain_update_chains(r->pool, &ctx->free, &ctx->busy, &ctx->out,
                                 (ngx_buf_tag_t) &ngx_http_zstd_filter_module);
 
+        /* After chain update, buffers may have been recycled or reassigned.
+         * Invalidate ctx->out_buf to force fresh buffer allocation/validation
+         * on next compression iteration to prevent
+         * use-after-free of recycled buffers. */
+        ctx->out_buf = NULL;
+
         ctx->last_out = &ctx->out;
         ctx->nomem = 0;
         flush = 0;
 
         if (ctx->done) {
-            rv = ZSTD_freeCStream(ctx->cstream);
-            if (ZSTD_isError(rv)) {
-                ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
-                              "ZSTD_freeCStream() failed: %s",
-                              ZSTD_getErrorName(rv));
-
-                rc = NGX_ERROR;
-            }
-
             return rc;
         }
     }
@@ -416,11 +401,6 @@ ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 failed:
 
     ctx->done = 1;
-    rv = ZSTD_freeCStream(ctx->cstream);
-    if (ZSTD_isError(rv)) {
-        ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
-                      "ZSTD_freeCStream() failed: %s", ZSTD_getErrorName(rv));
-    }
 
     return NGX_ERROR;
 }
@@ -429,88 +409,122 @@ failed:
 static ngx_int_t
 ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
 {
-    size_t        rc, pos_in, pos_out;
-    char         *hint;
-    ngx_chain_t  *cl;
-    ngx_buf_t    *b;
-    unsigned      last_action;
+    size_t            rc, pos_in, pos_out;
+    ngx_uint_t        last;
+    ZSTD_EndDirective directive;
+    ngx_chain_t      *cl;
+    ngx_buf_t        *b;
+    ZSTD_CCtx        *cctx;
 
-    ngx_log_debug8(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                   "zstd compress in: src:%p pos:%ud size: %ud, "
-                   "dst:%p pos:%ud size:%ud flush:%d redo:%d",
-                   ctx->buffer_in.src, ctx->buffer_in.pos, ctx->buffer_in.size,
+    ngx_log_debug6(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "zstd compress in: src:%p pos:%uz size:%uz "
+                   "dst:%p pos:%uz size:%uz",
+                   ctx->buffer_in.src,  ctx->buffer_in.pos,
+                   ctx->buffer_in.size,
                    ctx->buffer_out.dst, ctx->buffer_out.pos,
-                   ctx->buffer_out.size, ctx->flush, ctx->redo);
+                   ctx->buffer_out.size);
 
-    pos_in = ctx->buffer_in.pos;
+    pos_in  = ctx->buffer_in.pos;
     pos_out = ctx->buffer_out.pos;
 
-    switch (ctx->action) {
-
-    case NGX_HTTP_ZSTD_FILTER_FLUSH:
-        hint = "ZSTD_flushStream() ";
-        rc = ZSTD_flushStream(ctx->cstream, &ctx->buffer_out);
-        break;
-
-    case NGX_HTTP_ZSTD_FILTER_END:
-        hint = "ZSTD_endStream() ";
-        rc = ZSTD_endStream(ctx->cstream, &ctx->buffer_out);
-        break;
-
-    default:
-        hint = "ZSTD_compressStream() ";
-        rc = ZSTD_compressStream(ctx->cstream, &ctx->buffer_out,
-                                 &ctx->buffer_in);
-        break;
+    /* Determine the compression directive based on action state */
+    if (ctx->action == NGX_HTTP_ZSTD_FILTER_END) {
+        directive = ZSTD_e_end;
+    } else if (ctx->action == NGX_HTTP_ZSTD_FILTER_FLUSH) {
+        directive = ZSTD_e_flush;
+    } else {
+        directive = ZSTD_e_continue;
     }
+
+    cctx = ctx->cctx;
+    if (cctx == NULL) {
+        ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                      "zstd: request CCtx not initialized");
+        return NGX_ERROR;
+    }
+
+    rc = ZSTD_compressStream2(cctx, &ctx->buffer_out, &ctx->buffer_in, directive);
 
     if (ZSTD_isError(rc)) {
         ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
-                      "%s failed: %s", hint, ZSTD_getErrorName(rc));
-
+                      "zstd: ZSTD_compressStream2() failed: %s",
+                      ZSTD_getErrorName(rc));
         return NGX_ERROR;
     }
 
     ngx_log_debug6(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                   "zstd compress out: src:%p pos:%ud size: %ud, "
-                   "dst:%p pos:%ud size:%ud",
-                   ctx->buffer_in.src, ctx->buffer_in.pos, ctx->buffer_in.size,
+                   "zstd compress out: src:%p pos:%uz size:%uz "
+                   "dst:%p pos:%uz size:%uz",
+                   ctx->buffer_in.src,  ctx->buffer_in.pos,
+                   ctx->buffer_in.size,
                    ctx->buffer_out.dst, ctx->buffer_out.pos,
                    ctx->buffer_out.size);
 
-    ctx->in_buf->pos += ctx->buffer_in.pos - pos_in;
+    ctx->in_buf->pos   += ctx->buffer_in.pos  - pos_in;
     ctx->out_buf->last += ctx->buffer_out.pos - pos_out;
     ctx->redo = 0;
 
-    last_action = ctx->action;
-
+    /* PR #49: State machine logic for action transitions */
     if (rc > 0) {
+        /*
+         * rc > 0: zstd has buffered data. For COMPRESS, transition to FLUSH
+         * to drain libzstd's internal buffers. For FLUSH/END, keep the action.
+         */
         if (ctx->action == NGX_HTTP_ZSTD_FILTER_COMPRESS) {
-            ctx->last_action = ctx->action;
             ctx->action = NGX_HTTP_ZSTD_FILTER_FLUSH;
         }
-
         ctx->redo = 1;
 
     } else if (ctx->last && ctx->action != NGX_HTTP_ZSTD_FILTER_END
-              && ctx->buffer_in.pos >= ctx->buffer_in.size
-              && ctx->in == NULL) {
-        ctx->redo = 1;
-        ctx->last_action = ctx->action;
+               && ctx->buffer_in.pos >= ctx->buffer_in.size
+               && ctx->in == NULL)
+    {
+        /*
+         * PR #49: All input consumed; transition to END only when:
+         * - last flag is set (we know this is the final chunk)
+         * - input buffer fully drained (no more bytes to feed libzstd)
+         * - no more chain links queued (all input streams exhausted)
+         * This prevents premature END transitions that cause 131072-byte
+         * truncation.
+         */
         ctx->action = NGX_HTTP_ZSTD_FILTER_END;
+        ctx->redo   = 1;
 
-        /* pending to call the ZSTD_endStream() */
-
-        return NGX_AGAIN;
+        /*
+         * We have only just switched to END; the call above ran with
+         * ZSTD_e_continue/flush and has NOT yet written the zstd end-of-frame
+         * marker. If it produced no output, force another iteration so
+         * ZSTD_e_end runs. If it did produce output, fall through to emit
+         * those (valid, non-terminal) bytes — but `last` must stay false this
+         * iteration so we do not set last_buf before the end marker exists.
+         */
+        if (ngx_buf_size(ctx->out_buf) == 0) {
+            return NGX_AGAIN;
+        }
 
     } else if (ctx->action != NGX_HTTP_ZSTD_FILTER_END) {
-        ctx->last_action = ctx->action;
-        ctx->action = NGX_HTTP_ZSTD_FILTER_COMPRESS; /* restore */
+        /* Restore to COMPRESS after FLUSH drains (unless transitioning to END) */
+        ctx->action = NGX_HTTP_ZSTD_FILTER_COMPRESS;
     }
 
-    if (ngx_buf_size(ctx->out_buf) == 0
-        && last_action != NGX_HTTP_ZSTD_FILTER_FLUSH)
-    {
+    /*
+     * Terminal frame: the call that just ran used ZSTD_e_end (so `directive`
+     * — captured before any action transition above — is ZSTD_e_end) and
+     * libzstd reports the frame is fully flushed (rc == 0). Keyed on
+     * `directive`, not `ctx->action`, because the COMPRESS→END transition
+     * above mutates ctx->action *after* the compress call; using ctx->action
+     * here would declare the stream terminal one iteration too early and
+     * truncate it (no end-of-frame marker written yet).
+     *
+     * Evaluated before the empty-buffer early return below: a terminal
+     * ZSTD_e_end that produces zero output bytes (everything drained on a
+     * prior iteration) must still emit a zero-length last_buf, otherwise the
+     * request loops forever with NGX_HTTP_GZIP_BUFFERED set and hangs until
+     * timeout.
+     */
+    last = rc == 0 && ctx->last && directive == ZSTD_e_end;
+
+    if (ngx_buf_size(ctx->out_buf) == 0 && !last && !(rc == 0 && ctx->flush)) {
         return NGX_AGAIN;
     }
 
@@ -520,36 +534,28 @@ ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
     }
 
     b = ctx->out_buf;
-    if (ngx_buf_size(b) == 0) {
-        b = ngx_calloc_buf(ctx->request->pool);
-        if (b == NULL) {
-            return NGX_ERROR;
-        }
-    }
 
-    if (rc == 0
-        && (ctx->flush
-            || (ctx->last && ctx->action == NGX_HTTP_ZSTD_FILTER_END))) {
+    if (rc == 0 && (ctx->flush || last)) {
         r->connection->buffered &= ~NGX_HTTP_GZIP_BUFFERED;
 
-        b->flush = ctx->flush;
-        b->last_buf = ctx->last;
+        b->flush = ctx->flush && !ctx->last;
+        b->last_buf = last;
 
-        ctx->done = ctx->last;
+        ctx->done  = b->last_buf;
         ctx->flush = 0;
     }
 
     ctx->bytes_out += ngx_buf_size(b);
 
     cl->next = NULL;
-    cl->buf = b;
+    cl->buf  = b;
 
     *ctx->last_out = cl;
-    ctx->last_out = &cl->next;
+    ctx->last_out  = &cl->next;
 
     ngx_memzero(&ctx->buffer_out, sizeof(ZSTD_outBuffer));
 
-    return ctx->last && rc == 0 ? NGX_OK : NGX_AGAIN;
+    return last ? NGX_OK : NGX_AGAIN;
 }
 
 
@@ -639,246 +645,103 @@ ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
 
     ctx->buffer_out.dst = ctx->out_buf->pos;
     ctx->buffer_out.pos = 0;
+
+    /* Validate buffer pointers to detect corruption before using in ZSTD */
+    if (ctx->out_buf->end < ctx->out_buf->start) {
+        ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                      "corrupted output buffer: end (%p) < start (%p)",
+                      ctx->out_buf->end, ctx->out_buf->start);
+        return NGX_ERROR;
+    }
+
     ctx->buffer_out.size = ctx->out_buf->end - ctx->out_buf->start;
 
     return NGX_OK;
 }
 
 
-static ZSTD_CStream *
-ngx_http_zstd_filter_create_cstream(ngx_http_request_t *r,
+/*
+ * Configure a per-request CCtx on first body data.
+ * The CCtx is allocated outside the request pool but attached to the request
+ * cleanup chain, so overlapping requests in one worker never share libzstd
+ * streaming state.
+ */
+static ngx_int_t
+ngx_http_zstd_filter_init_cctx(ngx_http_request_t *r,
     ngx_http_zstd_ctx_t *ctx)
 {
     size_t                      rc;
-    ZSTD_CStream               *cstream;
-    ZSTD_customMem              cmem;
+    ZSTD_CCtx                  *cctx;
     ngx_http_zstd_loc_conf_t   *zlcf;
 
     zlcf = ngx_http_get_module_loc_conf(r, ngx_http_zstd_filter_module);
 
-    cmem.customAlloc = ngx_http_zstd_filter_alloc;
-    cmem.customFree = ngx_http_zstd_filter_free;
-    cmem.opaque = ctx;
+    if (ctx->cctx == NULL) {
+        ngx_pool_cleanup_t  *cln;
 
-    cstream = ZSTD_createCStream_advanced(cmem);
-    if (cstream == NULL) {
-        ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
-                      "ZSTD_createCStream_advanced() failed");
+        ctx->cctx = ZSTD_createCCtx();
+        if (ctx->cctx == NULL) {
+            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                          "zstd: ZSTD_createCCtx() failed");
+            return NGX_ERROR;
+        }
 
-        return NULL;
+        cln = ngx_pool_cleanup_add(r->pool, 0);
+        if (cln == NULL) {
+            ZSTD_freeCCtx(ctx->cctx);
+            ctx->cctx = NULL;
+            return NGX_ERROR;
+        }
+
+        cln->handler = ngx_http_zstd_cleanup_cctx;
+        cln->data = ctx->cctx;
     }
 
-    /* TODO use the advanced initialize functions */
+    cctx = ctx->cctx;
 
-    if (zlcf->dict) {
-#if ZSTD_VERSION_NUMBER >= 10500
-        rc = ZSTD_CCtx_reset(cstream, ZSTD_reset_session_only);
-        if (ZSTD_isError(rc)) {
-            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
-                          "ZSTD_CCtx_reset() failed: %s",
-                          ZSTD_getErrorName(rc));
-            goto failed;
-        }
-
-        rc = ZSTD_CCtx_refCDict(cstream, zlcf->dict);
-        if (ZSTD_isError(rc)) {
-            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
-                          "ZSTD_CCtx_refCDict() failed: %s",
-                          ZSTD_getErrorName(rc));
-            goto failed;
-        }
-#else
-        rc = ZSTD_initCStream_usingCDict(cstream, zlcf->dict);
-        if (ZSTD_isError(rc)) {
-            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
-                          "ZSTD_initCStream_usingCDict() failed: %s",
-                          ZSTD_getErrorName(rc));
-            goto failed;
-        }
-#endif
-
-    } else {
-        rc = ZSTD_initCStream(cstream, zlcf->level);
-        if (ZSTD_isError(rc)) {
-            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
-                          "ZSTD_initCStream() failed: %s",
-                          ZSTD_getErrorName(rc));
-
-            goto failed;
-        }
-    }
-
-    return cstream;
-
-failed:
-    rc = ZSTD_freeCStream(cstream);
+    /* Full reset: session state + all parameters. */
+    rc = ZSTD_CCtx_reset(cctx, ZSTD_reset_session_and_parameters);
     if (ZSTD_isError(rc)) {
         ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
-                      "ZSTD_freeCStream() failed: %s", ZSTD_getErrorName(rc));
+                      "zstd: ZSTD_CCtx_reset() failed: %s",
+                      ZSTD_getErrorName(rc));
+        return NGX_ERROR;
     }
 
-    return NULL;
-}
-
-
-static ngx_int_t
-ngx_http_zstd_ok(ngx_http_request_t *r)
-{
-    ngx_table_elt_t  *ae;
-
-    if (r != r->main) {
-        return NGX_DECLINED;
+    rc = ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel,
+                                 (int) zlcf->level);
+    if (ZSTD_isError(rc)) {
+        ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                      "zstd: ZSTD_CCtx_setParameter(level=%d) failed: %s",
+                      (int) zlcf->level, ZSTD_getErrorName(rc));
+        return NGX_ERROR;
     }
 
-    ae = r->headers_in.accept_encoding;
-    if (ae == NULL) {
-        return NGX_DECLINED;
-    }
-
-    if (ae->value.len < sizeof("zstd") - 1) {
-        return NGX_DECLINED;
-    }
-
-    if (ngx_memcmp(ae->value.data, "zstd", 4) != 0
-        && ngx_http_zstd_accept_encoding(&ae->value) != NGX_OK)
-    {
-        return NGX_DECLINED;
-    }
-
-    r->gzip_tested = 1;
-    r->gzip_ok = 0;
-
-    return NGX_OK;
-}
-
-
-/*
- * a copy of ngx_http_gzip_accept_encoding, for zstd content encoding
- */
-
-static ngx_int_t
-ngx_http_zstd_accept_encoding(ngx_str_t *ae)
-{
-    u_char  *p, *start, *last;
-
-    start = ae->data;
-    last = start + ae->len;
-
-    for ( ;; ) {
-        p = ngx_strcasestrn(start, "zstd", 4 - 1);
-        if (p == NULL) {
-            return NGX_DECLINED;
+    /* Issue #38: Apply target compressed block size if configured */
+#ifdef ZSTD_c_targetCBlockSize
+    if (zlcf->target_cblock_size > 0) {
+        rc = ZSTD_CCtx_setParameter(cctx, ZSTD_c_targetCBlockSize,
+                                     (int) zlcf->target_cblock_size);
+        if (ZSTD_isError(rc)) {
+            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                          "zstd: ZSTD_CCtx_setParameter(targetCBlockSize=%d) failed: %s",
+                          (int) zlcf->target_cblock_size, ZSTD_getErrorName(rc));
+            return NGX_ERROR;
         }
-
-        if (p == start || (*(p - 1) == ',' || *(p - 1) == ' ')) {
-            break;
-        }
-
-        start = p + 4;
     }
+#endif
 
-    p += 4;
-
-    while (p < last) {
-        switch (*p++) {
-        case ',':
-            return NGX_OK;
-        case ';':
-            goto quantity;
-        case ' ':
-            continue;
-        default:
-            return NGX_DECLINED;
+    if (zlcf->dict) {
+        rc = ZSTD_CCtx_refCDict(cctx, zlcf->dict);
+        if (ZSTD_isError(rc)) {
+            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                          "zstd: ZSTD_CCtx_refCDict() failed: %s",
+                          ZSTD_getErrorName(rc));
+            return NGX_ERROR;
         }
     }
 
     return NGX_OK;
-
-quantity:
-
-    while (p < last) {
-        switch (*p++) {
-        case 'q':
-        case 'Q':
-            goto equal;
-        case ' ':
-            continue;
-        default:
-            return NGX_DECLINED;
-        }
-    }
-
-    return NGX_OK;
-
-equal:
-
-    if (p + 2 > last || *p++ != '=') {
-        return NGX_DECLINED;
-    }
-
-    if (ngx_http_zstd_quantity(p, last) == 0) {
-        return NGX_DECLINED;
-    }
-
-    return NGX_OK;
-}
-
-
-/*
- * a copy of ngx_http_gzip_quantity
- */
-
-static ngx_uint_t
-ngx_http_zstd_quantity(u_char *p, u_char *last)
-{
-    u_char      c;
-    ngx_uint_t  n, q;
-
-    c = *p++;
-
-    if (c != '0' && c != '1') {
-        return 0;
-    }
-
-    q = (c - '0') * 100;
-
-    if (p == last) {
-        return q;
-    }
-
-    c = *p++;
-
-    if (c == ',' || c == ' ') {
-        return q;
-    }
-
-    if (c != '.') {
-        return 0;
-    }
-
-    n = 0;
-
-    while (p < last) {
-        c = *p++;
-
-        if (c == ',' || c == ' ') {
-            break;
-        }
-
-        if (c >= '0' && c <= '9') {
-            q += c - '0';
-            n++;
-            continue;
-        }
-
-        return 0;
-    }
-
-    if (q > 100 || n > 3) {
-        return 0;
-    }
-
-    return q;
 }
 
 
@@ -936,7 +799,7 @@ ngx_http_zstd_create_loc_conf(ngx_conf_t *cf)
     conf->level = NGX_CONF_UNSET;
     conf->min_length = NGX_CONF_UNSET;
     conf->max_length = NGX_CONF_UNSET;
-    conf->bypass = NGX_CONF_UNSET_PTR;
+    conf->target_cblock_size = NGX_CONF_UNSET;
 
     return conf;
 }
@@ -963,8 +826,8 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_value(conf->enable, prev->enable, 0);
     ngx_conf_merge_value(conf->level, prev->level, 3);
     ngx_conf_merge_value(conf->min_length, prev->min_length, 20);
-    ngx_conf_merge_value(conf->max_length, prev->max_length, 0);
-    ngx_conf_merge_ptr_value(conf->bypass, prev->bypass, NULL);
+    ngx_conf_merge_value(conf->max_length, prev->max_length, NGX_CONF_UNSET);
+    ngx_conf_merge_value(conf->target_cblock_size, prev->target_cblock_size, 0);
 
     if (ngx_http_merge_types(cf, &conf->types_keys, &conf->types,
                              &prev->types_keys, &prev->types,
@@ -981,13 +844,17 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
     if (conf->enable && zmcf->dict_file.len > 0) {
 
-        if (conf->level == prev->level) {
+        if (conf->level == prev->level && prev->dict != NULL) {
+            /*
+             * Same compression level and parent already loaded the dict:
+             * reuse it to avoid redundant loading.
+             */
             conf->dict = prev->dict;
 
-        } else {
+        } else if (conf->dict == NULL) {
             /*
-             * compression level is different from the outer block,
-             * so we should create a separate dict object.
+             * Either levels differ or parent was disabled (prev->dict == NULL):
+             * load the dict fresh for this location's compression level.
              */
 
             fd = ngx_open_file(zmcf->dict_file.data, NGX_FILE_RDONLY,
@@ -1011,6 +878,19 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
             }
 
             size = ngx_file_size(&info);
+
+            /* Validate dictionary file size to prevent DoS
+             * via memory exhaustion */
+            if (size > NGX_HTTP_ZSTD_MAX_DICT_SIZE) {
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                   "dictionary file too large: %uz bytes "
+                                   "(limit: %d bytes)",
+                                   size, NGX_HTTP_ZSTD_MAX_DICT_SIZE);
+
+                rc = NGX_CONF_ERROR;
+                goto close;
+            }
+
             buf = ngx_palloc(cf->pool, size);
             if (buf == NULL) {
                 rc = NGX_CONF_ERROR;
@@ -1035,12 +915,35 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
                 goto close;
             }
 
-            conf->dict = ZSTD_createCDict_byReference(buf, size, conf->level);
+            conf->dict = ZSTD_createCDict(buf, size, conf->level);
             if (conf->dict == NULL) {
                 ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                                   "ZSTD_createCDict_byReference() failed");
+                                   "ZSTD_createCDict() failed");
                 rc = NGX_CONF_ERROR;
                 goto close;
+            }
+
+            /* Register cleanup handler to free dictionary when
+             * config is destroyed.
+             * Note: Using ZSTD_createCDict() (copy mode) instead
+             * of _byReference() to avoid use-after-free during
+             * config reloads. Dictionary buffer is copied into
+             * ZSTD's internal memory so config pool cleanup can
+             * safely free the original buf without affecting
+             * in-flight compressions. */
+            {
+                ngx_pool_cleanup_t  *cln;
+
+                cln = ngx_pool_cleanup_add(cf->pool, 0);
+                if (cln == NULL) {
+                    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                       "ngx_pool_cleanup_add() failed");
+                    rc = NGX_CONF_ERROR;
+                    goto close;
+                }
+
+                cln->handler = ngx_http_zstd_cleanup_dict;
+                cln->data = conf->dict;
             }
         }
     }
@@ -1076,6 +979,8 @@ close:
 static ngx_int_t
 ngx_http_zstd_filter_init(ngx_conf_t *cf)
 {
+    (void)cf;
+
     ngx_http_next_header_filter = ngx_http_top_header_filter;
     ngx_http_top_header_filter = ngx_http_zstd_header_filter;
 
@@ -1083,22 +988,6 @@ ngx_http_zstd_filter_init(ngx_conf_t *cf)
     ngx_http_top_body_filter = ngx_http_zstd_body_filter;
 
     return NGX_OK;
-}
-
-
-static void *
-ngx_http_zstd_filter_alloc(void *opaque, size_t size)
-{
-    ngx_http_zstd_ctx_t *ctx = opaque;
-
-    void  *p;
-
-    p = ngx_palloc(ctx->request->pool, size);
-
-    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, ctx->request->connection->log, 0,
-                   "zstd alloc: %p, size: %uz", p, size);
-
-    return p;
 }
 
 
@@ -1126,20 +1015,24 @@ ngx_http_zstd_ratio_variable(ngx_http_request_t *r,
     ngx_uint_t            ratio_int, ratio_frac;
     ngx_http_zstd_ctx_t  *ctx;
 
+    (void) data;
+
     ctx = ngx_http_get_module_ctx(r, ngx_http_zstd_filter_module);
     if (ctx == NULL || !ctx->done || ctx->bytes_out == 0) {
         vv->not_found = 1;
         return NGX_OK;
     }
 
-    vv->data = ngx_pnalloc(r->pool, NGX_INT32_LEN + 3);
+    /* Two ngx_uint_t values (up to NGX_INT_T_LEN digits each) + '.' + '\0' */
+    vv->data = ngx_pnalloc(r->pool, NGX_INT_T_LEN * 2 + 2);
     if (vv->data == NULL) {
         return NGX_ERROR;
     }
 
     ratio_int = (ngx_uint_t) ctx->bytes_in / ctx->bytes_out;
     /* Use uint64_t to prevent integer overflow when multiplying by 1000 */
-    ratio_frac = (ngx_uint_t) ((uint64_t) ctx->bytes_in * 1000 / ctx->bytes_out % 1000);
+    ratio_frac = (ngx_uint_t) ((uint64_t) ctx->bytes_in * 1000
+                 / ctx->bytes_out % 1000);
 
     vv->len = ngx_sprintf(vv->data, "%ui.%03ui", ratio_int, ratio_frac)
               - vv->data;
@@ -1152,16 +1045,24 @@ ngx_http_zstd_ratio_variable(ngx_http_request_t *r,
 
 
 static void
-ngx_http_zstd_filter_free(void *opaque, void *address)
+ngx_http_zstd_cleanup_cctx(void *data)
 {
-#if (NGX_DEBUG)
+    ZSTD_CCtx *cctx = data;
 
-    ngx_http_zstd_ctx_t *ctx = opaque;
+    if (cctx != NULL) {
+        ZSTD_freeCCtx(cctx);
+    }
+}
 
-    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ctx->request->connection->log, 0,
-                   "zstd free: %p", address);
 
-#endif
+static void
+ngx_http_zstd_cleanup_dict(void *data)
+{
+    ZSTD_CDict  *dict = data;
+
+    if (dict != NULL) {
+        ZSTD_freeCDict(dict);
+    }
 }
 
 
@@ -1170,23 +1071,43 @@ ngx_http_zstd_comp_level(ngx_conf_t *cf, void *post, void *data)
 {
     ngx_int_t  *np = data;
 
-    if (*np == 0 || *np < (ngx_int_t) ZSTD_minCLevel()
-        || *np > ZSTD_maxCLevel())
-    {
-        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                           "zstd compress level must between %i "
-                           "and %i excluding 0", (ngx_int_t) ZSTD_minCLevel(),
-                           (ngx_int_t) ZSTD_maxCLevel());
+    (void)post;
 
+    /*
+     * Validate compression level range.
+     * ZSTD supports both positive (1-22) and negative (-131072 to -1) levels.
+     * - Positive levels: higher number = more compression
+     * - Negative levels: faster speed, less compression
+     * - 0: Use ZSTD default compression level (ZSTD_CLEVEL_DEFAULT)
+     *
+     * ZSTD_minCLevel() was introduced in zstd 1.4.0. On older libraries
+     * (zstd < 1.4.0) negative levels are not supported; clamp to 1.
+     */
+#if ZSTD_VERSION_NUMBER >= 10400
+    if (*np < (ngx_int_t) ZSTD_minCLevel() || *np > ZSTD_maxCLevel()) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "zstd compression level must be between %i and %i "
+                           "(0 = default, negative = faster, positive = "
+                           "slower/better)",
+                           (ngx_int_t) ZSTD_minCLevel(), ZSTD_maxCLevel());
         return NGX_CONF_ERROR;
     }
+#else
+    if (*np < 1 || *np > ZSTD_maxCLevel()) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "zstd compression level must be between 1 and %i "
+                           "(zstd < 1.4.0: negative levels not supported)",
+                           ZSTD_maxCLevel());
+        return NGX_CONF_ERROR;
+    }
+#endif
 
     return NGX_CONF_OK;
 }
 
-
 static char *
-ngx_http_zstd_set_num_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+ngx_conf_zstd_set_num_slot_with_negatives(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf)
 {
     char  *p = conf;
 
@@ -1194,10 +1115,11 @@ ngx_http_zstd_set_num_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_str_t        *value;
     ngx_conf_post_t  *post;
 
+
     np = (ngx_int_t *) (p + cmd->offset);
 
     if (*np != NGX_CONF_UNSET) {
-        return "is duplicate";
+        return (char *) "is duplicate";
     }
 
     value = cf->args->elts;
@@ -1206,12 +1128,10 @@ ngx_http_zstd_set_num_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         /* Parse ignoring the leading '-' character */
         *np = ngx_atoi(value[1].data + 1, value[1].len - 1);
 
-        /*
-         * NGX_ERROR is -1 so we need to check for that before making the parsed
-         * result negative
-         */
+        /* NGX_ERROR is -1 so we need to check for that before making the
+         * parsed result negative */
         if (*np == NGX_ERROR) {
-            return "invalid number";
+            return (char *) "invalid number";
         }
 
         *np = -*np;
@@ -1219,7 +1139,7 @@ ngx_http_zstd_set_num_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         *np = ngx_atoi(value[1].data, value[1].len);
 
         if (*np == NGX_ERROR) {
-            return "invalid number";
+            return (char *) "invalid number";
         }
     }
 

--- a/ngx_http_zstd_common.h
+++ b/ngx_http_zstd_common.h
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) Alex Zhang
+ *
+ * Shared helpers used by both the filter module and the static module.
+ * Included as a static inline header to avoid a separate compilation unit
+ * while eliminating the duplication between the two modules.
+ */
+
+#ifndef NGX_HTTP_ZSTD_COMMON_H
+#define NGX_HTTP_ZSTD_COMMON_H
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+
+/*
+ * ngx_http_zstd_accept_encoding()
+ *
+ * Returns NGX_OK  if the Accept-Encoding value contains "zstd" with a
+ * non-zero quality value (q > 0), NGX_DECLINED otherwise.
+ *
+ * Implements RFC 7231 §5.3.4 quality-value parsing:
+ *   qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
+ */
+static ngx_int_t
+ngx_http_zstd_accept_encoding(ngx_str_t *ae)
+{
+    u_char  *p;
+
+    /*
+     * ngx_strcasestrn()'s last argument is the needle length minus one
+     * (it does length+1 internally). "zstd" is 4 chars, so:
+     *   sizeof("zstd") - 2 == 5 - 2 == 3 == strlen("zstd") - 1.
+     * Do not "fix" this to -1; that would over-read the needle.
+     */
+    p = ngx_strcasestrn(ae->data, (char *) "zstd", sizeof("zstd") - 2);
+    if (p == NULL) {
+        return NGX_DECLINED;
+    }
+
+    if (p == ae->data || (*(p - 1) == ',' || *(p - 1) == ' ')) {
+
+        p += sizeof("zstd") - 1;
+
+        if (p == ae->data + ae->len || *p == ',' || *p == ' ' || *p == ';') {
+            /* Found "zstd" token; now check quality value if present */
+            if (*p == ';') {
+                p++;
+                /* Skip whitespace */
+                while (p < ae->data + ae->len && (*p == ' ' || *p == '\t')) {
+                    p++;
+                }
+
+                /* Look for q= parameter (RFC 7231) */
+                if (p + 1 < ae->data + ae->len
+                    && ngx_tolower(p[0]) == 'q' && p[1] == '=')
+                {
+                    p += 2;
+                    /* Skip whitespace after = */
+                    while (p < ae->data + ae->len
+                           && (*p == ' ' || *p == '\t'))
+                    {
+                        p++;
+                    }
+
+                    /*
+                     * Parse quality value per RFC 7231 §5.3.1:
+                     *   qvalue = ( "0" [ "." 0*3DIGIT ] )
+                     *          / ( "1" [ "." 0*3("0") ] )
+                     * Only "0" and "1" are valid leading digits.
+                     * Values outside [0,1] or malformed decimals are rejected.
+                     */
+                    if (p < ae->data + ae->len) {
+                        if (*p == '0') {
+                            p++;
+
+                            /* q=0 with no decimal → not acceptable */
+                            if (p == ae->data + ae->len
+                                || *p == ',' || *p == ' ' || *p == ';')
+                            {
+                                return NGX_DECLINED;
+                            }
+
+                            /* Must be followed by '.' for a valid decimal */
+                            if (*p != '.') {
+                                return NGX_DECLINED;
+                            }
+                            p++;
+
+                            /* Require at least one digit after the dot */
+                            if (p == ae->data + ae->len
+                                || *p < '0' || *p > '9')
+                            {
+                                return NGX_DECLINED;
+                            }
+
+                            /* All-zero fractional part → not acceptable */
+                            while (p < ae->data + ae->len
+                                   && *p >= '0' && *p <= '9')
+                            {
+                                if (*p != '0') {
+                                    return NGX_OK;
+                                }
+                                p++;
+                            }
+
+                            return NGX_DECLINED;
+
+                        } else if (*p == '1') {
+                            p++;
+
+                            /* q=1 with optional ".0*" suffix → accept */
+                            if (p < ae->data + ae->len && *p == '.') {
+                                p++;
+                                while (p < ae->data + ae->len
+                                       && *p >= '0' && *p <= '9')
+                                {
+                                    if (*p != '0') {
+                                        /* q=1.x where x>0 is invalid per RFC */
+                                        return NGX_DECLINED;
+                                    }
+                                    p++;
+                                }
+                            }
+
+                            return NGX_OK;
+
+                        } else {
+                            /* Leading digit other than 0 or 1: out of [0,1] */
+                            return NGX_DECLINED;
+                        }
+                    }
+                }
+            }
+
+            /* No quality value specified → accept */
+            return NGX_OK;
+        }
+    }
+
+    return NGX_DECLINED;
+}
+
+
+/*
+ * ngx_http_zstd_ok()
+ *
+ * Returns NGX_OK if the request is a main request whose client advertises
+ * acceptable zstd support (Accept-Encoding contains "zstd" with q > 0).
+ * Sets r->gzip_tested / r->gzip_ok as side effects for Vary handling.
+ */
+static ngx_int_t
+ngx_http_zstd_ok(ngx_http_request_t *r)
+{
+    ngx_table_elt_t  *ae;
+
+    if (r != r->main) {
+        return NGX_DECLINED;
+    }
+
+    ae = r->headers_in.accept_encoding;
+    if (ae == NULL) {
+        return NGX_DECLINED;
+    }
+
+    if (ae->value.len < sizeof("zstd") - 1) {
+        return NGX_DECLINED;
+    }
+
+    if (ngx_http_zstd_accept_encoding(&ae->value) != NGX_OK) {
+        return NGX_DECLINED;
+    }
+
+    r->gzip_tested = 1;
+    r->gzip_ok = 0;
+
+    return NGX_OK;
+}
+
+
+#endif /* NGX_HTTP_ZSTD_COMMON_H */

--- a/static/config
+++ b/static/config
@@ -13,7 +13,7 @@ if [ -n "$ZSTD_INC" -o -n "$ZSTD_LIB" ]; then
     # we try the static shared library firstly
     ngx_zstd_opt_I="-I$ZSTD_INC -DZSTD_STATIC_LINKING_ONLY"
     ngx_zstd_opt_L="$ZSTD_LIB/libzstd.a"
-    SAVED_CC_TAST_FLAGS=$CC_TEST_FLAGS
+    SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
     CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
     SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
     NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
@@ -21,15 +21,15 @@ if [ -n "$ZSTD_INC" -o -n "$ZSTD_LIB" ]; then
     . auto/feature
 
     # restore
-    CC_TEST_FLAGS=$SAVED_CC_TAST_FLAGS
+    CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
     NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
 
     if [ $ngx_found = no ]; then
         # then try the dynamic shared library
         ngx_feature="ZStandard dynamic library in $ZSTD_INC and $ZSTD_LIB"
-        ngx_zstd_opt_L="-L$ZSTD_LIB -lzstd -Wl,-rpath, $ZSTD_LIB"
+        ngx_zstd_opt_L="-L$ZSTD_LIB -lzstd -Wl,-rpath,$ZSTD_LIB"
 
-        SAVED_CC_TAST_FLAGS=$CC_TEST_FLAGS
+        SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
         CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
         SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
         NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
@@ -37,7 +37,7 @@ if [ -n "$ZSTD_INC" -o -n "$ZSTD_LIB" ]; then
         . auto/feature
 
         # restore
-        CC_TEST_FLAGS=$SAVED_CC_TAST_FLAGS
+        CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
         NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
 
         if [ $ngx_found = no ]; then
@@ -55,7 +55,7 @@ else
     ngx_zstd_opt_I=
     ngx_zstd_opt_L="-lzstd"
 
-    SAVED_CC_TAST_FLAGS=$CC_TEST_FLAGS
+    SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
     CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
     SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
     NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
@@ -63,38 +63,48 @@ else
     . auto/feature
 
     # restore
-    CC_TEST_FLAGS=$SAVED_CC_TAST_FLAGS
+    CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
     NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
 
     if [ $ngx_found = no ]; then
+        # Dynamic auto-discovery failed. Try pkg-config (portable across
+        # Linux, FreeBSD, OpenBSD, Gentoo, Rocky/RHEL) before giving up.
+        # Note: -l:libzstd.a is GNU ld only and not used here.
+        ngx_pkgconf=
+        if command -v pkgconf > /dev/null 2>&1; then
+            ngx_pkgconf=pkgconf
+        elif command -v pkg-config > /dev/null 2>&1; then
+            ngx_pkgconf=pkg-config
+        fi
 
-        ngx_feature="ZStandard static library"
-        ngx_zstd_opt_I="-DZSTD_STATIC_LINKING_ONLY"
-        ngx_zstd_opt_L="-l:libzstd.a"
-        SAVED_CC_TAST_FLAGS=$CC_TEST_FLAGS
-        CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
-        SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
-        NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
+        if [ -n "$ngx_pkgconf" ] && $ngx_pkgconf --exists libzstd 2>/dev/null; then
+            ngx_feature="ZStandard library via pkg-config"
+            ngx_zstd_opt_I="$($ngx_pkgconf --cflags libzstd)"
+            ngx_zstd_opt_L="$($ngx_pkgconf --libs libzstd)"
 
-        . auto/feature
+            SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
+            CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
+            SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
+            NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
+
+            . auto/feature
+
+            # restore
+            CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
+            NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
+        fi
 
         if [ $ngx_found = no ]; then
             cat << END
-            $0: error: ngx_http_zstd_filter_module requires the ZStandard library.
+            $0: error: ngx_http_zstd_static_module requires the ZStandard library.
+            Install libzstd-dev (Debian/Ubuntu), zstd-devel (RHEL/Rocky),
+            dev-libs/zstd (Gentoo), or security/zstd (FreeBSD/OpenBSD ports),
+            or set ZSTD_INC and ZSTD_LIB to the library location.
 END
             exit 1
         fi
-
-        # restore
-        CC_TEST_FLAGS=$SAVED_CC_TAST_FLAGS
-        NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
-
-        cat << END
-        $0: warning: ngx_http_zstd_filter_module uses advanced ZStandard APIs (which are still considered experimental) while you are trying to link the dynamic shared library.
-END
     fi
 
-    # TODO we need more tries for the different OS port.
 fi
 
 NGX_LD_OPT="$ngx_zstd_opt_L $NGX_LD_OPT"
@@ -105,26 +115,9 @@ HTTP_ZSTD_SRCS="$ngx_addon_dir/ngx_http_zstd_static_module.c"
 ngx_addon_name=ngx_http_zstd_static_module
 ngx_module_type=HTTP
 ngx_module_name=ngx_http_zstd_static_module
-ngx_module_incs=
+ngx_module_incs="$ngx_zstd_opt_I"
 ngx_module_srcs=$HTTP_ZSTD_SRCS
-ngx_module_order="$ngx_module_name \
-                  ngx_http_brotli_static_module \
-                  ngx_http_gzip_static_module"
+ngx_module_order="ngx_http_brotli_static_module \
+                  $ngx_module_name"
 
 . auto/module
-
-if [ "$ngx_module_link" != DYNAMIC ]; then
-    # ngx_module_order doesn't work with static modules,
-    # so we must re-order here.
-    if echo $HTTP_MODULES | grep ngx_http_brotli_static_module >/dev/null; then
-        next=ngx_http_brotli_static_module
-    elif echo $HTTP_MODULES | grep ngx_http_gzip_static_module >/dev/null; then
-        next=ngx_http_gzip_static_module
-    else
-        next=ngx_http_static_module
-    fi
-
-    HTTP_MODULES=`echo $HTTP_MODULES \
-                  | sed "s/$ngx_module_name//" \
-                  | sed "s/$next/$next $ngx_module_name/"`
-fi

--- a/static/ngx_http_zstd_static_module.c
+++ b/static/ngx_http_zstd_static_module.c
@@ -8,6 +8,8 @@
 #include <ngx_core.h>
 #include <ngx_http.h>
 
+#include "../ngx_http_zstd_common.h"
+
 
 #define NGX_HTTP_ZSTD_STATIC_OFF        0
 #define NGX_HTTP_ZSTD_STATIC_ON         1
@@ -19,23 +21,10 @@ typedef struct {
 } ngx_http_zstd_static_conf_t;
 
 
-static ngx_int_t ngx_http_zstd_static_handler(ngx_http_request_t *r);
-
-static ngx_int_t ngx_http_zstd_ok(ngx_http_request_t *r);
-static ngx_int_t ngx_http_zstd_accept_encoding(ngx_str_t *ae);
-static ngx_uint_t ngx_http_zstd_quantity(u_char *p, u_char *last);
-
-static void *ngx_http_zstd_static_create_conf(ngx_conf_t *cf);
-static char *ngx_http_zstd_static_merge_conf(ngx_conf_t *cf, void *parent,
-    void *child);
-static ngx_int_t ngx_http_zstd_static_init(ngx_conf_t *cf);
-
-
 static ngx_conf_enum_t  ngx_http_zstd_static[] = {
     { ngx_string("off"), NGX_HTTP_ZSTD_STATIC_OFF },
     { ngx_string("on"), NGX_HTTP_ZSTD_STATIC_ON },
     { ngx_string("always"), NGX_HTTP_ZSTD_STATIC_ALWAYS },
-    { ngx_null_string, 0 }
 };
 
 
@@ -48,37 +37,44 @@ static ngx_command_t  ngx_http_zstd_static_commands[] = {
       offsetof(ngx_http_zstd_static_conf_t, enable),
       &ngx_http_zstd_static },
 
-      ngx_null_command
+    ngx_null_command
 };
 
 
+static ngx_int_t ngx_http_zstd_static_handler(ngx_http_request_t *r);
+static void * ngx_http_zstd_static_create_loc_conf(ngx_conf_t *cf);
+static char * ngx_http_zstd_static_merge_loc_conf(ngx_conf_t *cf, void *parent,
+    void *child);
+static ngx_int_t ngx_http_zstd_static_init(ngx_conf_t *cf);
+
+
 static ngx_http_module_t  ngx_http_zstd_static_module_ctx = {
-    NULL,                                  /* preconfiguration */
-    ngx_http_zstd_static_init,             /* postconfiguration */
+    NULL,                                     /* preconfiguration */
+    ngx_http_zstd_static_init,                /* postconfiguration */
 
-    NULL,                                  /* create main configuration */
-    NULL,                                  /* init main configuration */
+    NULL,                                     /* create main configuration */
+    NULL,                                     /* init main configuration */
 
-    NULL,                                  /* create server configuration */
-    NULL,                                  /* merge server configuration */
+    NULL,                                     /* create server configuration */
+    NULL,                                     /* merge server configuration */
 
-    ngx_http_zstd_static_create_conf,      /* create location configuration */
-    ngx_http_zstd_static_merge_conf        /* merge location configuration */
+    ngx_http_zstd_static_create_loc_conf,  /* create location configuration */
+    ngx_http_zstd_static_merge_loc_conf,      /* merge location configuration */
 };
 
 
 ngx_module_t  ngx_http_zstd_static_module = {
     NGX_MODULE_V1,
-    &ngx_http_zstd_static_module_ctx,      /* module context */
-    ngx_http_zstd_static_commands,         /* module directives */
-    NGX_HTTP_MODULE,                       /* module type */
-    NULL,                                  /* init master */
-    NULL,                                  /* init module */
-    NULL,                                  /* init process */
-    NULL,                                  /* init thread */
-    NULL,                                  /* exit thread */
-    NULL,                                  /* exit process */
-    NULL,                                  /* exit master */
+    &ngx_http_zstd_static_module_ctx,       /* module context */
+    ngx_http_zstd_static_commands,          /* module directives */
+    NGX_HTTP_MODULE,                        /* module type */
+    NULL,                                   /* init master */
+    NULL,                                   /* init module */
+    NULL,                                   /* init process */
+    NULL,                                   /* init thread */
+    NULL,                                   /* exit thread */
+    NULL,                                   /* exit process */
+    NULL,                                   /* exit master */
     NGX_MODULE_V1_PADDING
 };
 
@@ -87,14 +83,14 @@ static ngx_int_t
 ngx_http_zstd_static_handler(ngx_http_request_t *r)
 {
     u_char                       *p;
-    size_t                        root;
-    ngx_str_t                     path;
     ngx_int_t                     rc;
     ngx_uint_t                    level;
-    ngx_log_t                    *log;
+    size_t                        root;
+    ngx_str_t                     path;
     ngx_buf_t                    *b;
-    ngx_chain_t                   out;
+    ngx_log_t                    *log;
     ngx_table_elt_t              *h;
+    ngx_chain_t                   out;
     ngx_open_file_info_t          of;
     ngx_http_core_loc_conf_t     *clcf;
     ngx_http_zstd_static_conf_t  *zscf;
@@ -103,7 +99,9 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
         return NGX_DECLINED;
     }
 
-    if (r->uri.data[r->uri.len - 1] == '/') {
+    /* Validate URI length before accessing last byte to prevent underflow.
+     * While nginx guarantees non-empty URI, add defensive check for safety. */
+    if (r->uri.len == 0 || r->uri.data[r->uri.len - 1] == '/') {
         return NGX_DECLINED;
     }
 
@@ -117,7 +115,6 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
         rc = ngx_http_zstd_ok(r);
 
     } else {
-        /* always */
         rc = NGX_OK;
     }
 
@@ -137,7 +134,6 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
     *p++ = '.';
     *p++ = 'z';
     *p++ = 's';
-    *p++ = 't';
     *p++ = 't';
     *p = '\0';
 
@@ -223,12 +219,11 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
     r->root_tested = !r->error_page;
 
     rc = ngx_http_discard_request_body(r);
-
     if (rc != NGX_OK) {
         return rc;
     }
 
-    log->action = "sending response to client";
+    log->action = (char *) "sending response to client";
 
     r->headers_out.status = NGX_HTTP_OK;
     r->headers_out.content_length_n = of.size;
@@ -252,14 +247,15 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
     }
 
     h->hash = 1;
-    h->next = NULL;
     ngx_str_set(&h->key, "Content-Encoding");
     ngx_str_set(&h->value, "zstd");
     r->headers_out.content_encoding = h;
 
-    r->allow_ranges = 1;
-
-    /* we need to allocate all before the header would be sent */
+    /* Byte ranges are meaningless on a compressed body: offsets in the
+     * .zst file do not correspond to positions in the original content.
+     * RFC 9110 §14.2 — clear Accept-Ranges so clients do not request
+     * ranges that would yield undecipherable fragments. */
+    ngx_http_clear_accept_ranges(r);
 
     b = ngx_calloc_buf(r->pool);
     if (b == NULL) {
@@ -283,7 +279,6 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
     b->in_file = b->file_last ? 1 : 0;
     b->last_buf = (r == r->main) ? 1 : 0;
     b->last_in_chain = 1;
-    b->sync = (b->last_buf || b->in_file) ? 0 : 1;
 
     b->file->fd = of.fd;
     b->file->name = path;
@@ -297,173 +292,12 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
 }
 
 
-static ngx_int_t
-ngx_http_zstd_ok(ngx_http_request_t *r)
-{
-    ngx_table_elt_t  *ae;
-
-    if (r != r->main) {
-        return NGX_DECLINED;
-    }
-
-    ae = r->headers_in.accept_encoding;
-    if (ae == NULL) {
-        return NGX_DECLINED;
-    }
-
-    if (ae->value.len < sizeof("zstd") - 1) {
-        return NGX_DECLINED;
-    }
-
-    if (ngx_memcmp(ae->value.data, "zstd", 4) != 0
-        && ngx_http_zstd_accept_encoding(&ae->value) != NGX_OK)
-    {
-        return NGX_DECLINED;
-    }
-
-    r->gzip_tested = 1;
-    r->gzip_ok = 0;
-
-    return NGX_OK;
-}
-
-
-/*
- * a copy of ngx_http_gzip_accept_encoding, for zstd content encoding
- */
-
-static ngx_int_t
-ngx_http_zstd_accept_encoding(ngx_str_t *ae)
-{
-    u_char  *p, *start, *last;
-
-    start = ae->data;
-    last = start + ae->len;
-
-    for ( ;; ) {
-        p = ngx_strcasestrn(start, "zstd", 4 - 1);
-        if (p == NULL) {
-            return NGX_DECLINED;
-        }
-
-        if (p == start || (*(p - 1) == ',' || *(p - 1) == ' ')) {
-            break;
-        }
-
-        start = p + 4;
-    }
-
-    p += 4;
-
-    while (p < last) {
-        switch (*p++) {
-        case ',':
-            return NGX_OK;
-        case ';':
-            goto quantity;
-        case ' ':
-            continue;
-        default:
-            return NGX_DECLINED;
-        }
-    }
-
-    return NGX_OK;
-
-quantity:
-
-    while (p < last) {
-        switch (*p++) {
-        case 'q':
-        case 'Q':
-            goto equal;
-        case ' ':
-            continue;
-        default:
-            return NGX_DECLINED;
-        }
-    }
-
-    return NGX_OK;
-
-equal:
-
-    if (p + 2 > last || *p++ != '=') {
-        return NGX_DECLINED;
-    }
-
-    if (ngx_http_zstd_quantity(p, last) == 0) {
-        return NGX_DECLINED;
-    }
-
-    return NGX_OK;
-}
-
-
-/*
- * a copy of ngx_http_gzip_quantity
- */
-
-static ngx_uint_t
-ngx_http_zstd_quantity(u_char *p, u_char *last)
-{
-    u_char      c;
-    ngx_uint_t  n, q;
-
-    c = *p++;
-
-    if (c != '0' && c != '1') {
-        return 0;
-    }
-
-    q = (c - '0') * 100;
-
-    if (p == last) {
-        return q;
-    }
-
-    c = *p++;
-
-    if (c == ',' || c == ' ') {
-        return q;
-    }
-
-    if (c != '.') {
-        return 0;
-    }
-
-    n = 0;
-
-    while (p < last) {
-        c = *p++;
-
-        if (c == ',' || c == ' ') {
-            break;
-        }
-
-        if (c >= '0' && c <= '9') {
-            q += c - '0';
-            n++;
-            continue;
-        }
-
-        return 0;
-    }
-
-    if (q > 100 || n > 3) {
-        return 0;
-    }
-
-    return q;
-}
-
-
 static void *
-ngx_http_zstd_static_create_conf(ngx_conf_t *cf)
+ngx_http_zstd_static_create_loc_conf(ngx_conf_t *cf)
 {
     ngx_http_zstd_static_conf_t  *conf;
 
-    conf = ngx_palloc(cf->pool, sizeof(ngx_http_zstd_static_conf_t));
+    conf = ngx_pcalloc(cf->pool, sizeof(ngx_http_zstd_static_conf_t));
     if (conf == NULL) {
         return NULL;
     }
@@ -475,7 +309,7 @@ ngx_http_zstd_static_create_conf(ngx_conf_t *cf)
 
 
 static char *
-ngx_http_zstd_static_merge_conf(ngx_conf_t *cf, void *parent, void *child)
+ngx_http_zstd_static_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 {
     ngx_http_zstd_static_conf_t *prev = parent;
     ngx_http_zstd_static_conf_t *conf = child;


### PR DESCRIPTION
## Summary
This PR regroups the remaining runtime and config work that did not replay cleanly as one-commit cherry-picks after resetting `master` to upstream.

## Why
Older fork commits collided heavily with upstream parser/runtime rewrites, so preserving the original commit boundaries would have produced conflict-driven noise instead of reviewable changes.

## Included files
- `.clang-format`
- `filter/config`
- `filter/ngx_http_zstd_filter_module.c`
- `ngx_http_zstd_common.h`
- `static/config`
- `static/ngx_http_zstd_static_module.c`

## Review notes
- Base branch is `split/21-699a055-fix-set-ngx-addon-dir-to-subdirectory-befo`
- This PR is the prerequisite for the README and CI/testing regrouped PRs
