### PR TITLE
feat: zstd_window_log — bound per-request compression memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This is a hardened fork: every build is exercised against **nginx mainline and [
     * [zstd_types](#zstd_types)
     * [zstd_buffers](#zstd_buffers)
     * [zstd_target_cblock_size](#zstd_target_cblock_size)
+    * [zstd_window_log](#zstd_window_log)
     * [zstd_dict_file](#zstd_dict_file)
   * [ngx_http_zstd_static_module](#ngx_http_zstd_static_module)
     * [zstd_static](#zstd_static)
@@ -266,6 +267,41 @@ http {
 | `16384` (16 KB) | Very aggressive incremental parsing; reduces ratio notably |
 | `65536` (64 KB) | Moderate; CSS/JS in head typically available faster |
 | `262144` (256 KB) | Conservative; minimal ratio impact |
+
+---
+
+### zstd_window_log
+
+**Syntax:** `zstd_window_log exponent;`
+**Default:** `—` (disabled; zstd uses its level-derived default)
+**Context:** `http, server, location`
+
+Caps the zstd compression **window** at `2^exponent` bytes. zstd's
+per-request working memory is dominated by the window size (roughly the
+window plus match-table overhead), so without a cap a high compression
+level on large response bodies lets each concurrent request inflate the
+worker's resident memory unpredictably. Bounding `window_log` gives a
+hard, predictable per-request memory ceiling.
+
+Typical values are `20`–`24` (1–16 MB). Lower values reduce memory and
+the compression ratio on inputs larger than the window; on responses
+smaller than the window there is no ratio impact. Unset (or `0`) keeps
+zstd's default window for the configured level.
+
+> **Note:** This bounds compressor memory, not the amount of response
+> body buffered by nginx (that is governed by `zstd_buffers`). For a hard
+> limit on how much input is ever fed to the compressor regardless of
+> `Content-Length`, see also `zstd_max_length`.
+
+**Example:**
+
+```nginx
+http {
+    zstd on;
+    zstd_comp_level   9;
+    zstd_window_log   21;   # cap the window at 2 MB per request
+}
+```
 
 ---
 

--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -27,6 +27,7 @@ typedef struct {
     ssize_t                      min_length;
     ssize_t                      max_length;
     ssize_t                      target_cblock_size;  /* Issue #38: ZSTD_c_targetCBlockSize */
+    ngx_int_t                    window_log;          /* ZSTD_c_windowLog: bounds per-request memory */
 
     ngx_hash_t                   types;
 
@@ -170,6 +171,13 @@ static ngx_command_t  ngx_http_zstd_filter_commands[] = {
       ngx_conf_set_size_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_zstd_loc_conf_t, target_cblock_size),
+      NULL },
+
+    { ngx_string("zstd_window_log"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_num_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_zstd_loc_conf_t, window_log),
       NULL },
 
     { ngx_string("zstd_dict_file"),
@@ -731,6 +739,26 @@ ngx_http_zstd_filter_init_cctx(ngx_http_request_t *r,
     }
 #endif
 
+    /*
+     * Cap the compression window. zstd's per-context working memory is
+     * dominated by the window size (~2^windowLog bytes plus match-table
+     * overhead). Without a cap, a high level on large bodies lets each
+     * concurrent request inflate worker RSS unpredictably. Bounding
+     * windowLog gives operators a hard, predictable per-request memory
+     * ceiling at a small ratio cost on inputs larger than the window.
+     * Unset (0) keeps zstd's level-derived default.
+     */
+    if (zlcf->window_log > 0) {
+        rc = ZSTD_CCtx_setParameter(cctx, ZSTD_c_windowLog,
+                                     (int) zlcf->window_log);
+        if (ZSTD_isError(rc)) {
+            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                          "zstd: ZSTD_CCtx_setParameter(windowLog=%d) failed: %s",
+                          (int) zlcf->window_log, ZSTD_getErrorName(rc));
+            return NGX_ERROR;
+        }
+    }
+
     if (zlcf->dict) {
         rc = ZSTD_CCtx_refCDict(cctx, zlcf->dict);
         if (ZSTD_isError(rc)) {
@@ -800,6 +828,7 @@ ngx_http_zstd_create_loc_conf(ngx_conf_t *cf)
     conf->min_length = NGX_CONF_UNSET;
     conf->max_length = NGX_CONF_UNSET;
     conf->target_cblock_size = NGX_CONF_UNSET;
+    conf->window_log = NGX_CONF_UNSET;
 
     return conf;
 }
@@ -828,6 +857,7 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_value(conf->min_length, prev->min_length, 20);
     ngx_conf_merge_value(conf->max_length, prev->max_length, NGX_CONF_UNSET);
     ngx_conf_merge_value(conf->target_cblock_size, prev->target_cblock_size, 0);
+    ngx_conf_merge_value(conf->window_log, prev->window_log, 0);
 
     if (ngx_http_merge_types(cf, &conf->types_keys, &conf->types,
                              &prev->types_keys, &prev->types,

--- a/t/00-filter.t
+++ b/t/00-filter.t
@@ -891,3 +891,31 @@ Accept-Encoding: zstd
 !Content-Encoding
 --- no_error_log
 [error]
+
+
+
+=== TEST 38: zstd_window_log caps the window and still produces valid output
+# Regression for the zstd_window_log memory-bounding directive. With a
+# 15-bit (32 KB) window and a body well over 32 KB, zstd must still emit
+# a well-formed stream: the directive bounds per-request memory, it must
+# not corrupt the response. Served from the on-disk test fixture (~58 KB)
+# so the capped window is genuinely exercised.
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_window_log 15;
+        zstd_types text/plain;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test;
+    }
+    location /test {
+        root $TEST_NGINX_PERL_PATH/suite/;
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+Content-Encoding: zstd
+--- no_error_log
+[error]


### PR DESCRIPTION
## Problem

The module sets compression level and (optionally) target cblock size,
but never bounds the zstd **window**. zstd's per-context working memory
is dominated by the window (~2^windowLog bytes plus match-table
overhead). On a public endpoint, a high level on large response bodies
lets each concurrent request inflate worker RSS unpredictably — a
resource-exhaustion exposure with no operator control.

## Change

Add `zstd_window_log <exponent>;` (http/server/location) → sets
`ZSTD_c_windowLog`, giving a hard, predictable per-request memory
ceiling. Unset/`0` keeps zstd's level-derived default. Plumbing mirrors
the existing `zstd_target_cblock_size` exactly (conf field, command,
create/merge, setParameter with `ZSTD_isError` guard + graceful
fallback).

## Tests

- `t/00-filter.t` **TEST 38**: a capped 15-bit (32 KB) window on the
  ~58 KB on-disk fixture must still produce a well-formed, decodable
  zstd stream (the cap bounds memory, must not corrupt output).
- Filter suite **PASS** locally against nginx 1.31.0.
- README directive reference + TOC updated.

Tier 1 hardening (issue #1 of the production-readiness review).