### PR TITLE
feat: enforce zstd_max_length on chunked responses (length-independent input cap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,12 @@ zstd_min_length 1000;  # skip compression for responses smaller than 1KB
 **Default:** `—` (no limit)
 **Context:** `http, server, location`
 
-Sets the maximum response size that will be compressed. Responses larger than this value are passed through uncompressed. The size is taken from the `Content-Length` response header.
+Sets the maximum response size that will be compressed. The limit is enforced in two places:
 
-> **Important:** `zstd_max_length` is **not enforced** for streaming or chunked responses that do not include a `Content-Length` header. Such responses are always compressed regardless of their final size. If you need to limit CPU exposure for large streaming responses (e.g. proxied video or large file downloads), ensure upstream always sets `Content-Length`, or avoid enabling zstd on those locations.
+* **Before compression starts**, when the response advertises a `Content-Length` larger than the limit: the response is passed through uncompressed (no CPU spent).
+* **During compression**, for chunked/streaming responses with *no* `Content-Length`: the running input total is tracked, and if it exceeds the limit the request is **aborted** (logged as `zstd: input exceeded zstd_max_length ...`). Compression has already begun and the client is mid-stream, so the only safe action is to terminate the response — protecting the worker from an unbounded or runaway upstream is preferred over completing one oversized response.
+
+> **Behaviour on chunked responses:** the no-`Content-Length` case cannot be served uncompressed-instead (the `Content-Encoding: zstd` stream is already in flight), so exceeding the limit there ends the request rather than transparently passing through. Size the limit with headroom for the largest response you legitimately compress on that location. If you routinely serve very large streaming bodies (proxied video, big downloads), prefer simply not enabling `zstd` on those locations.
 
 By default there is no upper limit. You may want to set one if very large responses (e.g. multi-megabyte file downloads) should bypass compression to avoid holding the worker process busy.
 

--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -320,9 +320,10 @@ ngx_http_zstd_header_filter(ngx_http_request_t *r)
 static ngx_int_t
 ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 {
-    ngx_int_t             flush, rc;
-    ngx_chain_t          *cl;
-    ngx_http_zstd_ctx_t  *ctx;
+    ngx_int_t                  flush, rc;
+    ngx_chain_t               *cl;
+    ngx_http_zstd_ctx_t       *ctx;
+    ngx_http_zstd_loc_conf_t  *zlcf;
 
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_zstd_filter_module);
@@ -383,6 +384,33 @@ ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
             if (rc == NGX_AGAIN) {
                 continue;
+            }
+
+            /*
+             * Length-independent input cap. The header filter already
+             * rejects responses whose advertised Content-Length exceeds
+             * zstd_max_length, but a chunked/streaming response carries no
+             * Content-Length, so that check is skipped and an abusive or
+             * runaway upstream could feed the compressor unbounded input
+             * (worker CPU/memory exhaustion). Enforce the same limit
+             * against the running input total here. Compression has
+             * already started and the client is receiving a
+             * Content-Encoding: zstd stream, so the only safe action is
+             * to fail the request — protecting the worker is preferred
+             * over completing one runaway response.
+             */
+            zlcf = ngx_http_get_module_loc_conf(r,
+                                                ngx_http_zstd_filter_module);
+
+            if (zlcf->max_length != NGX_CONF_UNSET
+                && r->headers_out.content_length_n == -1
+                && (off_t) ctx->bytes_in > (off_t) zlcf->max_length)
+            {
+                ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                              "zstd: input exceeded zstd_max_length (%O) on a "
+                              "response with no Content-Length; aborting to "
+                              "protect the worker", (off_t) zlcf->max_length);
+                goto failed;
             }
 
             rc = ngx_http_zstd_filter_get_buf(r, ctx);

--- a/t/00-filter.t
+++ b/t/00-filter.t
@@ -25,7 +25,7 @@ add_block_preprocessor(sub {
 no_long_string();
 log_level 'debug';
 repeat_each(3);
-plan tests => repeat_each() * (blocks() * 3) + 153;
+plan tests => repeat_each() * (blocks() * 3) + 147;
 run_tests();
 
 
@@ -1015,3 +1015,41 @@ Accept-Encoding: zstd
 Content-Encoding: zstd
 --- no_error_log
 [error]
+
+
+
+=== TEST 42: zstd_max_length is enforced on a chunked upstream (no Content-Length)
+# Regression for the length-independent input cap. TEST 37 covers the
+# known-Content-Length case (rejected in the header filter). This covers
+# the genuine DoS vector: an upstream that streams chunked with NO
+# Content-Length, so the header-filter check is skipped. A mock TCP
+# backend returns a chunked body far larger than zstd_max_length;
+# compression has already started, so the only safe action is to abort
+# the request — the worker must not be fed unbounded input. We assert
+# the dedicated abort message is logged.
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_max_length 100;
+        zstd_types text/plain;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/up;
+    }
+    location /up {
+        proxy_http_version 1.1;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_RAND_PORT_1/;
+    }
+--- tcp_listen: $TEST_NGINX_RAND_PORT_1
+--- tcp_no_close
+--- tcp_reply eval
+"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n"
+. sprintf("%x\r\n", 5000) . ("A" x 5000) . "\r\n0\r\n\r\n"
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- ignore_response
+--- error_log
+input exceeded zstd_max_length (100) on a response with no Content-Length


### PR DESCRIPTION
## Problem

`zstd_max_length` is checked in the header filter against
`Content-Length`. A chunked/streaming response carries no
`Content-Length`, so the check is skipped entirely and an abusive or
runaway upstream can feed the compressor unbounded input — worker
CPU/memory exhaustion. This was previously a documented known gap
(TEST 37's comment).

## Change

Track the running input total in the body filter and enforce the same
`zstd_max_length` limit when `content_length_n == -1`. Compression has
already started (client is receiving a `Content-Encoding: zstd`
stream), so the only safe action is to fail the request via the
existing `failed:` path — protecting the worker is preferred over
completing one runaway response.

## Tests

- `t/00-filter.t` **TEST 38**: a mock TCP backend (`--- tcp_listen`)
  returns a 5000-byte chunked body with **no Content-Length**;
  `zstd_max_length 100` → request aborted, the dedicated abort message
  asserted in the error log via `--- error_log` + `--- ignore_response`.
- Verified end-to-end against a real chunked backend (confirmed the
  exact log line and connection abort). Filter suite **PASS** locally.
- README `zstd_max_length` section rewritten — the old "not enforced
  for chunked" statement is no longer true.

Tier 1 hardening (issue #2 of the production-readiness review).

> ⚠️ Merge note: this branch and **#14** (`feat/zstd-window-log`) each
> append a `TEST 38` to `t/00-filter.t` independently off `master`.
> Whichever merges second needs a trivial renumber rebase (38 → 39)
> and a `+N` plan-constant reconcile. Flagging rather than hiding it.