### PR TITLE
feat: zstd_bypass — per-request compression opt-out (BREACH containment lever)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This is a hardened fork: every build is exercised against **nginx mainline and [
     * [zstd_buffers](#zstd_buffers)
     * [zstd_target_cblock_size](#zstd_target_cblock_size)
     * [zstd_window_log](#zstd_window_log)
+    * [zstd_bypass](#zstd_bypass)
     * [zstd_dict_file](#zstd_dict_file)
   * [ngx_http_zstd_static_module](#ngx_http_zstd_static_module)
     * [zstd_static](#zstd_static)
@@ -304,6 +305,55 @@ http {
     zstd_window_log   21;   # cap the window at 2 MB per request
 }
 ```
+
+---
+
+### zstd_bypass
+
+**Syntax:** `zstd_bypass string ...;`
+**Default:** `—`
+**Context:** `http, server, location`
+
+Disables on-the-fly compression for the current request when at least
+one of the given string parameters evaluates to a non-empty value that
+is not `"0"`. Each parameter is typically a variable (often driven by a
+`map`), so the decision is made per request rather than statically.
+
+```nginx
+map $request_uri $no_zstd {
+    default              0;
+    ~^/wp-admin/         1;   # authenticated admin: reflects input + nonces
+    ~^/wp-json/          1;   # REST: responses mix tokens with user data
+}
+
+server {
+    zstd on;
+    zstd_bypass $no_zstd;            # skip those paths
+    zstd_bypass $http_x_no_compression;  # honour a client opt-out header
+}
+```
+
+> **Security note — BREACH:** `zstd_bypass` is the intended lever for
+> mitigating [BREACH](https://en.wikipedia.org/wiki/BREACH)-style
+> attacks, which exploit the *size* of a compressed HTTP body that
+> contains **both** a secret (CSRF token, session data) **and**
+> attacker-influenced reflected input. Use it to serve identity on the
+> specific endpoints where that combination occurs.
+>
+> Be honest about what this does and does not do: **no HTTP compressor
+> can be made BREACH-safe while still compressing** — the attack is
+> inherent to compression ratio as a side channel. `zstd_bypass` only
+> lets you *exclude* the at-risk responses. The effective, primary
+> BREACH defenses live in the application: per-request CSRF token
+> masking, separating secrets from reflected input, and
+> referer/origin checks. Treat `zstd_bypass` as a containment tool, not
+> a fix. (CRIME and POODLE are unrelated TLS-layer attacks and are not
+> addressed — or addressable — here; configure `ssl_protocols`
+> appropriately instead.)
+
+> **Note:** length-padding "anti-BREACH" schemes are intentionally
+> **not** provided: small pads are defeated statistically and large
+> ones waste bandwidth, giving false confidence.
 
 ---
 

--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -29,6 +29,8 @@ typedef struct {
     ssize_t                      target_cblock_size;  /* Issue #38: ZSTD_c_targetCBlockSize */
     ngx_int_t                    window_log;          /* ZSTD_c_windowLog: bounds per-request memory */
 
+    ngx_array_t                 *bypass;              /* ngx_http_complex_value_t: per-request bypass */
+
     ngx_hash_t                   types;
 
     ngx_bufs_t                   bufs;
@@ -184,6 +186,13 @@ static ngx_command_t  ngx_http_zstd_filter_commands[] = {
       offsetof(ngx_http_zstd_loc_conf_t, window_log),
       NULL },
 
+    { ngx_string("zstd_bypass"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_1MORE,
+      ngx_http_set_predicate_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_zstd_loc_conf_t, bypass),
+      NULL },
+
     { ngx_string("zstd_dict_file"),
       NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_str_slot,
@@ -252,6 +261,23 @@ ngx_http_zstd_header_filter(ngx_http_request_t *r)
        || ngx_http_test_content_type(r, &zlcf->types) == NULL
        || r->header_only)
     {
+        return ngx_http_next_header_filter(r);
+    }
+
+    /*
+     * Per-request bypass. If any zstd_bypass predicate variable resolves
+     * to a non-empty value other than "0", skip compression for this
+     * request. This is the operator lever for serving identity on
+     * endpoints that must not be compressed — e.g. responses that mix a
+     * secret (CSRF token, session data) with attacker-influenced
+     * reflected input (a BREACH-style exposure), or already-compressed
+     * dynamic payloads — without splitting the location.
+     */
+    if (zlcf->bypass != NULL
+        && ngx_http_test_predicates(r, zlcf->bypass) != NGX_OK)
+    {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "zstd: bypassed by zstd_bypass predicate");
         return ngx_http_next_header_filter(r);
     }
 
@@ -833,6 +859,7 @@ ngx_http_zstd_create_loc_conf(ngx_conf_t *cf)
     conf->max_length = NGX_CONF_UNSET;
     conf->target_cblock_size = NGX_CONF_UNSET;
     conf->window_log = NGX_CONF_UNSET;
+    conf->bypass = NGX_CONF_UNSET_PTR;
 
     return conf;
 }
@@ -862,6 +889,7 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_value(conf->max_length, prev->max_length, NGX_CONF_UNSET);
     ngx_conf_merge_value(conf->target_cblock_size, prev->target_cblock_size, 0);
     ngx_conf_merge_value(conf->window_log, prev->window_log, 0);
+    ngx_conf_merge_ptr_value(conf->bypass, prev->bypass, NULL);
 
     if (ngx_http_merge_types(cf, &conf->types_keys, &conf->types,
                              &prev->types_keys, &prev->types,

--- a/t/00-filter.t
+++ b/t/00-filter.t
@@ -25,7 +25,7 @@ add_block_preprocessor(sub {
 no_long_string();
 log_level 'debug';
 repeat_each(3);
-plan tests => repeat_each() * (blocks() * 3) + 147;
+plan tests => repeat_each() * (blocks() * 3) + 153;
 run_tests();
 
 
@@ -947,6 +947,71 @@ GET /filter
 --- more_headers
 Accept-Encoding: zstd
 --- response_headers
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 40: zstd_bypass skips compression when the predicate is truthy
+# A request header maps to a bypass variable; when it is set to a
+# non-empty value other than "0", the response must be served identity
+# even though the client supports zstd and the type/size qualify.
+--- http_config
+    map $http_x_no_zstd $zstd_off {
+        default 0;
+        "1"     1;
+    }
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        zstd_bypass $zstd_off;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test;
+    }
+    location /test {
+        root $TEST_NGINX_PERL_PATH/suite/;
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+X-No-Zstd: 1
+--- response_headers
+Content-Length: 59738
+!Content-Encoding
+--- no_error_log
+[error]
+
+
+
+=== TEST 41: zstd_bypass value "0" does NOT bypass (still compresses)
+# Same config, but the bypass variable resolves to "0", which per
+# ngx_http_test_predicates is falsy — compression must still happen.
+# Pins the "0"/empty == not-bypassed contract.
+--- http_config
+    map $http_x_no_zstd $zstd_off {
+        default 0;
+        "1"     1;
+    }
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        zstd_bypass $zstd_off;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test;
+    }
+    location /test {
+        root $TEST_NGINX_PERL_PATH/suite/;
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+!Content-Length
 Content-Encoding: zstd
 --- no_error_log
 [error]


### PR DESCRIPTION
## What

Adds `zstd_bypass string ...;` (http/server/location). When any
parameter resolves to a non-empty value other than `"0"`, compression
is skipped for that request.

Implemented with nginx's **canonical predicate primitives** —
`ngx_http_set_predicate_slot` + `ngx_http_test_predicates`, the exact
machinery `proxy_cache_bypass` uses — not a hand-rolled evaluator.

## Why

The one legitimate per-request attack-surface lever:

- **BREACH containment**: serve identity on endpoints that mix a secret
  (CSRF token / session) with attacker-reflected input, without
  splitting the location.
- Client opt-out, or skipping already-compressed dynamic payloads.

## Tests

- `t/00-filter.t` **TEST 39**: predicate truthy → response identity.
- **TEST 40**: predicate `"0"` → still compressed (pins the falsy
  contract). Filter suite **PASS** locally (513 tests).

## Docs

README gets the directive reference and an **honest** security section:
`zstd_bypass` is a *containment lever, not a fix* — no compressor is
BREACH-safe; real defense is app-layer (CSRF masking, secret/input
separation). Length-padding deliberately not provided (false
confidence). CRIME/POODLE explicitly noted as out of scope (TLS layer).

Tier 1 hardening (issue #3 of the production-readiness review).

> ⚠️ Merge note: branched from `master` after #14 merged, so it
> includes `zstd_window_log`; new tests are 39/40. #15 (input cap)
> still carries its own `TEST 38` and will need a renumber rebase
> against merged master regardless of merge order here.