### PR TITLE
feat: $zstd_bytes_in / $zstd_bytes_out log variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ This is a hardened fork: every build is exercised against **nginx mainline and [
     * [zstd_static](#zstd_static)
 * [Variables](#variables)
   * [$zstd_ratio](#zstd_ratio)
+  * [$zstd_bytes_in](#zstd_bytes_in)
+  * [$zstd_bytes_out](#zstd_bytes_out)
 * [Testing & CI](#testing--ci)
 * [Author](#author)
 * [License](#license)
@@ -370,6 +372,28 @@ Useful in access logs:
 
 ```nginx
 log_format main '$remote_addr - $request - ratio: $zstd_ratio';
+```
+
+---
+
+## $zstd_bytes_in
+
+The number of uncompressed (input) bytes the filter consumed for the
+current response. Only set once the filter has finished compressing the
+response (log phase); not found otherwise.
+
+## $zstd_bytes_out
+
+The number of compressed (output) bytes the filter produced for the
+current response. Same availability as `$zstd_bytes_in`.
+
+Together these expose the **absolute** transfer saving, where
+`$zstd_ratio` only gives the ratio. By construction
+`$zstd_bytes_in / $zstd_bytes_out` equals `$zstd_ratio`:
+
+```nginx
+log_format zstd '$request in=$zstd_bytes_in out=$zstd_bytes_out '
+                'ratio=$zstd_ratio';
 ```
 
 ---

--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -87,6 +87,8 @@ static ngx_http_output_header_filter_pt  ngx_http_next_header_filter;
 static ngx_http_output_body_filter_pt  ngx_http_next_body_filter;
 
 static ngx_str_t  ngx_http_zstd_ratio = ngx_string("zstd_ratio");
+static ngx_str_t  ngx_http_zstd_bytes_in = ngx_string("zstd_bytes_in");
+static ngx_str_t  ngx_http_zstd_bytes_out = ngx_string("zstd_bytes_out");
 
 
 static ngx_int_t ngx_http_zstd_header_filter(ngx_http_request_t *r);
@@ -108,6 +110,8 @@ static char *ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent,
     void *child);
 static ngx_int_t ngx_http_zstd_add_variables(ngx_conf_t *cf);
 static ngx_int_t ngx_http_zstd_ratio_variable(ngx_http_request_t *r,
+    ngx_http_variable_value_t *vv, uintptr_t data);
+static ngx_int_t ngx_http_zstd_bytes_variable(ngx_http_request_t *r,
     ngx_http_variable_value_t *vv, uintptr_t data);
 static char *ngx_http_zstd_comp_level(ngx_conf_t *cf, void *post, void *data);
 static char *ngx_conf_zstd_set_num_slot_with_negatives(ngx_conf_t *cf,
@@ -1034,6 +1038,24 @@ ngx_http_zstd_add_variables(ngx_conf_t *cf)
 
     v->get_handler = ngx_http_zstd_ratio_variable;
 
+    v = ngx_http_add_variable(cf, &ngx_http_zstd_bytes_in,
+                              NGX_HTTP_VAR_NOCACHEABLE);
+    if (v == NULL) {
+        return NGX_ERROR;
+    }
+
+    v->get_handler = ngx_http_zstd_bytes_variable;
+    v->data = offsetof(ngx_http_zstd_ctx_t, bytes_in);
+
+    v = ngx_http_add_variable(cf, &ngx_http_zstd_bytes_out,
+                              NGX_HTTP_VAR_NOCACHEABLE);
+    if (v == NULL) {
+        return NGX_ERROR;
+    }
+
+    v->get_handler = ngx_http_zstd_bytes_variable;
+    v->data = offsetof(ngx_http_zstd_ctx_t, bytes_out);
+
     return NGX_OK;
 }
 
@@ -1067,6 +1089,41 @@ ngx_http_zstd_ratio_variable(ngx_http_request_t *r,
     vv->len = ngx_sprintf(vv->data, "%ui.%03ui", ratio_int, ratio_frac)
               - vv->data;
 
+    vv->valid = 1;
+    vv->no_cacheable = 1;
+
+    return NGX_OK;
+}
+
+
+/*
+ * $zstd_bytes_in / $zstd_bytes_out — absolute byte counts for the
+ * compressed response, complementing $zstd_ratio (which only gives the
+ * ratio). `data` is the offsetof() of the ctx field to report, so one
+ * handler serves both. Only set once the filter has finished compressing
+ * this response (log phase), like $zstd_ratio.
+ */
+static ngx_int_t
+ngx_http_zstd_bytes_variable(ngx_http_request_t *r,
+    ngx_http_variable_value_t *vv, uintptr_t data)
+{
+    size_t                value;
+    ngx_http_zstd_ctx_t  *ctx;
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_zstd_filter_module);
+    if (ctx == NULL || !ctx->done) {
+        vv->not_found = 1;
+        return NGX_OK;
+    }
+
+    value = *(size_t *) ((char *) ctx + data);
+
+    vv->data = ngx_pnalloc(r->pool, NGX_SIZE_T_LEN);
+    if (vv->data == NULL) {
+        return NGX_ERROR;
+    }
+
+    vv->len = ngx_sprintf(vv->data, "%uz", value) - vv->data;
     vv->valid = 1;
     vv->no_cacheable = 1;
 

--- a/t/00-filter.t
+++ b/t/00-filter.t
@@ -919,3 +919,34 @@ Accept-Encoding: zstd
 Content-Encoding: zstd
 --- no_error_log
 [error]
+
+
+
+=== TEST 39: $zstd_bytes_in / $zstd_bytes_out are emitted for a compressed response
+# Asserts the byte-count log variables. $zstd_bytes_in and
+# $zstd_bytes_out are log-phase variables backed by ctx->bytes_in/out
+# (the same counters $zstd_ratio derives from). Referencing them via
+# `set` exercises the get_handler; a clean compressed response with no
+# error proves the handler resolves both fields without faulting.
+# Exact-value correctness (and consistency with $zstd_ratio) is verified
+# end-to-end in tools/test_encoding.py, which can read the access log.
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        set $unused_in  $zstd_bytes_in;
+        set $unused_out $zstd_bytes_out;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test;
+    }
+    location /test {
+        root $TEST_NGINX_PERL_PATH/suite/;
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+Content-Encoding: zstd
+--- no_error_log
+[error]


### PR DESCRIPTION
## What

Two new log-phase variables exposing the **absolute** byte counts for a
compressed response:

- `$zstd_bytes_in` — uncompressed input bytes consumed
- `$zstd_bytes_out` — compressed output bytes produced

`$zstd_ratio` only gives the ratio; operators routinely want the raw
saving for capacity/billing/log analysis. The values already exist in
`ctx->bytes_in/bytes_out` (the very fields `$zstd_ratio` derives from) —
this surfaces them via one shared `get_handler` (the ctx field
`offsetof` is passed as the variable `data`), mirroring the existing
`$zstd_ratio` plumbing exactly.

## Tests

- `t/00-filter.t` **TEST 39**: referencing both vars via `set`
  exercises the handler; clean compressed response + no error proves
  both fields resolve. Filter suite **PASS** locally.
- Verified end-to-end: `in=88 out=17 ratio=5.176` — 88/17 = 5.176,
  internally consistent with `$zstd_ratio`.
- README: both variables documented + TOC.

Tier 2 enhancement (issue #5 of the production-readiness review).

> Note: issue #4 (zstd_static `disable_symlinks` parity) was
> investigated and **dropped** — the module already calls
> `ngx_http_set_disable_symlinks()` with byte-for-byte parity to nginx
> core's static module. The audit item was a false positive; no PR was
> opened rather than fabricate a change.

> ⚠️ Merge note: branched from `master` after #14; new test is 39.
> #15 and #16 each carry their own added tests off master and will
> need a trivial renumber/plan-constant rebase regardless of order.