### PR TITLE
chore: production-readiness — SECURITY.md, soak, benchmark, compat/ops docs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -544,3 +544,40 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE"
           bash tools/test_reload_leak.sh "$TEST_NGINX_BINARY" 5
+
+  # ── Sustained mixed-load soak under ASAN+UBSAN ───────────────────────────
+  #    Production-shaped load that single-shot tests do not give. Long, so
+  #    it runs only on the weekly schedule and manual dispatch — never on
+  #    the per-PR path.
+  soak-asan:
+    name: Soak ASAN+UBSAN
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: build-asan
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout module
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zstd libzstd1 curl
+
+      - name: Download ASAN nginx binary
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: nginx-binary-asan
+          path: nginx-bin
+
+      - name: Set up nginx binary
+        run: chmod +x nginx-bin/nginx
+
+      - name: Soak (10 min, 8 concurrent, mixed payloads) under ASAN+UBSAN
+        env:
+          ASAN_OPTIONS: detect_leaks=1:abort_on_error=1:halt_on_error=1
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          bash tools/soak.sh "$GITHUB_WORKSPACE/nginx-bin/nginx" 600 8

--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ This is a hardened fork: every build is exercised against **nginx mainline and [
   * [$zstd_ratio](#zstd_ratio)
   * [$zstd_bytes_in](#zstd_bytes_in)
   * [$zstd_bytes_out](#zstd_bytes_out)
+* [Compatibility](#compatibility)
 * [Testing & CI](#testing--ci)
+* [Benchmarks](#benchmarks)
+* [Operations](#operations)
+* [Security](#security)
 * [Author](#author)
 * [License](#license)
 
@@ -112,6 +116,31 @@ load_module modules/ngx_http_zstd_static_module.so;
 * If you are using a custom zstd installation, set `ZSTD_INC` (path to `zstd.h`) and `ZSTD_LIB` (path to the library) before running `configure`. If unset, the system-installed zstd is used.
 * Dynamic modules (`.so`) require dynamic linking against `libzstd.so`. The build scripts auto-detect and prefer this. Ensure the zstd shared library is installed and available at runtime (`libzstd-dev` on Debian/Ubuntu, `libzstd-devel` on RHEL/Fedora).
 * When `ZSTD_LIB` is set to a non-standard path, the build embeds an RPATH pointing to that directory in the module `.so`. This means the module will load `libzstd.so` from that exact path at runtime. If the library is later moved (e.g. by a package upgrade), the module will fail to load. Use the system package and leave `ZSTD_LIB` unset to avoid this.
+
+# Compatibility
+
+| Component | Minimum | Recommended | CI-verified |
+|---|---|---|---|
+| **nginx** | 1.9.11 (first `--add-dynamic-module` release) | latest mainline / stable | **1.31.0 mainline** |
+| **Angie** | 1.x | latest | **1.11.5** |
+| **libzstd** | **1.4.0** | **≥ 1.5.6** | 1.5.x |
+| **OS** | Linux/BSD/RHEL-family | — | Ubuntu (GitHub runners) |
+
+Notes on the libzstd floor — these are enforced in code, not assumed:
+
+* **< 1.4.0**: the streaming API the module uses (`ZSTD_compressStream2`)
+  is unavailable; this is the hard minimum. Negative `zstd_comp_level`
+  values are also unsupported and are clamped to `1` with a warning
+  (guarded by `#if ZSTD_VERSION_NUMBER >= 10400`).
+* **< 1.5.6**: `zstd_target_cblock_size` has no effect — the directive
+  is accepted but silently ignored (`#ifdef ZSTD_c_targetCBlockSize`).
+  Everything else works.
+* **≥ 1.5.6**: every directive is fully functional.
+
+"CI-verified" means every push builds and runs the full test suite
+against that exact version (see [Testing & CI](#testing--ci)). Other
+versions within the stated ranges are expected to work but are not
+continuously exercised.
 
 # Directives
 
@@ -480,6 +509,96 @@ python3 tools/test_encoding.py --nginx-binary /path/to/nginx
 # Build and run the fuzzer (needs clang)
 bash fuzz/build.sh && ./fuzz/fuzz_accept_encoding -max_total_time=60 fuzz/corpus/
 ```
+
+# Benchmarks
+
+Reproduce with `python3 tools/benchmark.py` (drives the `zstd`/`gzip`
+CLIs linked against the same libzstd/zlib, so ratio is machine-stable;
+throughput scales with CPU). Figures below: **libzstd 1.5.5**, single
+core, `--repeat 3`, best wall-time.
+
+| Payload | Codec | Ratio | MB/s |
+|---|---|---:|---:|
+| HTML, 58 KB (test fixture) | gzip-6 | 15.5 | 29 |
+| | zstd-3 | 16.1 | 12 |
+| | zstd-19 | 17.1 | 0.8 |
+| JSON API, 256 KB | gzip-6 | 12.5 | 72 |
+| | zstd-1 | 43.8 | 52 |
+| | zstd-3 | 33.6 | 43 |
+| JS, 512 KB | gzip-6 | 12.7 | 108 |
+| | zstd-1 | 63.6 | 87 |
+| | zstd-3 | 40.8 | 78 |
+| Random 256 KB (incompressible) | gzip-6 | 1.00 | 31 |
+| | zstd-3 | 1.00 | 36 |
+
+Honest reading of these numbers:
+
+* On **small** payloads (the 58 KB HTML fixture), low-level zstd is
+  roughly on par with `gzip -6` and a touch slower — gzip is well tuned
+  for small text. zstd's advantage grows with payload size.
+* On **larger, structured** payloads zstd at a *low* level beats gzip
+  decisively on both ratio and speed (e.g. ~44× vs ~12× on JSON,
+  faster too). For typical web traffic, `zstd_comp_level 1`–`3` is the
+  sweet spot.
+* The synthetic JSON/JS generators are deliberately repetitive, so
+  ratios there are inflated and *higher zstd levels show a lower ratio*
+  — an artefact of trivially-redundant input, **not** representative of
+  real assets. The HTML fixture (real-world content) shows the expected
+  monotonic "higher level → better ratio, slower".
+* High levels (≥ 9) cost CPU steeply for marginal gain on web content —
+  reserve them for infrequently-generated, cached responses.
+
+# Operations
+
+**Reloads (`nginx -s reload`).** Compression state is per request: a
+`ZSTD_CCtx` is created/reset per request and freed via an nginx pool
+cleanup. A graceful reload spins up new workers and drains old ones
+normally — in-flight responses on old workers finish on their existing
+context; new requests use new workers. There is no shared compression
+state to corrupt across a reload. The `zstd_dict_file` `ZSTD_CDict` is
+loaded once per cycle and freed on the old cycle's cleanup; a
+reload-leak regression for exactly this runs under ASAN in CI
+(`tools/test_reload_leak.sh`).
+
+**`zstd_dict_file`.** Loaded at config load in the `http` context, into
+a `ZSTD_CDict` shared read-only by all workers (dictionary size capped
+at 10 MB). The dictionary must be readable by the nginx user at config
+load and reload. Changing it requires a reload. **Both ends must agree
+on the dictionary**: HTTP has no dictionary negotiation, so only use
+this where you control client and server (see the directive's warning).
+
+**Rollback.** The module adds no persistent state, on-disk format, or
+schema — it only transforms response bodies in memory. Rolling back is
+purely "load the previous `.so` / previous nginx binary and reload":
+
+1. Keep the previously-known-good module `.so` (or full nginx binary).
+2. To disable instantly without a binary change: set `zstd off;` (and
+   `zstd_static off;`) and `nginx -s reload` — responses immediately
+   serve identity; no client/cache corruption (compressed and
+   identity variants differ only by `Content-Encoding`, and
+   `gzip_vary on` keeps caches correct).
+3. To revert the binary: restore the prior `.so`/binary, `nginx -t`,
+   then `nginx -s reload`.
+
+No data migration, no irreversible step. A bad deploy is a one-line
+config change or a binary swap away from rolled back.
+
+**Pre-deploy soak.** `tools/soak.sh <nginx> <seconds> <concurrency>`
+drives sustained mixed load (tiny/medium/large/compressible payloads,
+zstd and non-zstd clients, the bypass path, a chunked upstream) and
+fails on any sanitizer report, leak, crash, `[alert]`/`[emerg]`, or
+corrupted response. Run it against an ASAN/UBSAN build (optionally
+`USE_VALGRIND=1`) before shipping a change. CI runs a 10-minute soak
+under ASAN+UBSAN on the weekly schedule (`Soak ASAN+UBSAN` job).
+
+# Security
+
+Compression of HTTP responses has a security dimension. See
+[`SECURITY.md`](SECURITY.md) for the vulnerability-disclosure process
+and the explicit in-scope / out-of-scope boundary (notably: BREACH
+containment is `zstd_bypass`, not a fix; CRIME/POODLE are TLS-layer and
+out of scope). The request parser is continuously fuzzed and the module
+is built and load-tested under ASAN/UBSAN.
 
 # Author
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,82 @@
+# Security Policy
+
+`zstd-nginx-module` runs inside the nginx/Angie worker process and
+operates on attacker-influenced input (the `Accept-Encoding` request
+header, response bodies of arbitrary upstreams). Security reports are
+taken seriously.
+
+## Reporting a vulnerability
+
+**Do not open a public issue for security vulnerabilities.**
+
+Report privately via GitHub's
+[private vulnerability reporting](https://github.com/eilandert/zstd-nginx-module/security/advisories/new)
+("Report a vulnerability" under the repository's Security tab). If that
+is unavailable, contact the maintainers at the address on the
+[deb.myguard.nl](https://deb.myguard.nl/) site.
+
+Please include:
+
+- Affected version / commit (`git rev-parse HEAD` or the release tag)
+- nginx or Angie version and libzstd version
+- A minimal reproduction: `nginx.conf` snippet + request, or a fuzz
+  input / crash artifact
+- Observed vs. expected behaviour (crash, hang/CPU spin, memory growth,
+  information disclosure, etc.)
+
+## Scope
+
+In scope — issues in this module's code:
+
+- Memory safety: buffer overflow, use-after-free, uninitialised reads
+  (the module is built and smoke-tested under ASAN/UBSAN)
+- Denial of service: worker crash, infinite loop / CPU spin, unbounded
+  memory or input consumption
+- Request-parsing flaws in `ngx_http_zstd_accept_encoding()` (this
+  function is continuously fuzzed)
+- Incorrect output that could mislead a client or cache (e.g. a
+  corrupted compressed stream, missing `Vary`)
+
+Out of scope — not this module's layer:
+
+- **CRIME / POODLE** and other TLS-layer attacks — configure
+  `ssl_protocols` / TLS appropriately; this module never sees TLS.
+- **BREACH** as a class — compression ratio is an inherent side
+  channel; no HTTP compressor can be made BREACH-safe while
+  compressing. The module provides `zstd_bypass` as a *containment
+  lever* (exclude at-risk endpoints); the effective defence is
+  application-layer (CSRF token masking, separating secrets from
+  reflected input). A report that "compression leaks size" is not a
+  vulnerability in this module.
+- Vulnerabilities in nginx, Angie, or libzstd themselves — report those
+  upstream.
+- Misconfiguration (e.g. `zstd_static always` serving `.zst` to
+  non-zstd clients) — documented behaviour, not a flaw.
+
+## Handling
+
+- Acknowledgement target: within 7 days.
+- Triage and a fix or mitigation plan: as fast as severity warrants;
+  worker-crash / RCE / DoS are prioritised.
+- Fixes land with a regression test (every historical security bug
+  class in this module has a dedicated test) and, where applicable, a
+  new fuzz seed.
+- Coordinated disclosure: a fix is prepared before public detail; the
+  reporter is credited unless they prefer otherwise.
+
+## Verifying a build
+
+Security-relevant CI runs on every change and is reproducible locally:
+
+```bash
+# Memory safety
+# (build nginx with -fsanitize=address,undefined, then:)
+python3 tools/test_encoding.py --nginx-binary /path/to/asan-nginx
+bash tools/test_reload_leak.sh /path/to/asan-nginx
+
+# Fuzz the request parser
+bash fuzz/build.sh && ./fuzz/fuzz_accept_encoding -max_total_time=60 fuzz/corpus/
+```
+
+See [`.github/workflows/`](.github/workflows/) (build-test, codeql,
+security-scanners, fuzzing) and [`AGENTS.md`](AGENTS.md).

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Reproducible compression benchmark: zstd levels vs gzip.
+
+Measures compression ratio and single-threaded CPU throughput on
+representative web payloads, using the same libzstd / zlib the host
+nginx links against (the `zstd` and `gzip` CLIs). This is a *library*
+benchmark — it characterises the codecs the module drives, not nginx
+request overhead, so the numbers are stable and reproducible across
+machines (throughput scales with CPU; ratio does not).
+
+Usage:
+    python3 tools/benchmark.py                 # human table
+    python3 tools/benchmark.py --json results.json
+    python3 tools/benchmark.py --levels 1,3,9,19 --repeat 5
+
+Exit non-zero only on harness error (missing zstd/gzip), never on a
+"slow" result — this is measurement, not a pass/fail gate.
+"""
+import argparse
+import json
+import pathlib
+import shutil
+import subprocess
+import sys
+import time
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+
+def build_payloads() -> dict[str, bytes]:
+    """Representative, deterministic web payloads."""
+    payloads: dict[str, bytes] = {}
+
+    fixture = REPO / "t" / "suite" / "test"
+    if fixture.is_file():
+        payloads["html-58k (test fixture)"] = fixture.read_bytes()
+
+    # Highly compressible JSON-ish API response.
+    row = b'{"id":%d,"name":"item-%d","active":true,"tags":["a","b","c"]}'
+    payloads["json-api-256k"] = b"[" + b",".join(
+        row % (i, i) for i in range(4000)
+    ) + b"]"
+
+    # JS-like text with realistic redundancy.
+    js_line = (
+        b"function handler_%d(req,res){return res.json({ok:true,n:%d});}\n"
+    )
+    payloads["js-512k"] = b"".join(js_line % (i, i) for i in range(8000))
+
+    # Low-entropy worst case (already-compressed-ish): pseudo-random.
+    import random
+
+    random.seed(1)  # deterministic
+    payloads["random-256k (incompressible)"] = bytes(
+        random.getrandbits(8) for _ in range(256 * 1024)
+    )
+    return payloads
+
+
+def run_codec(cmd: list[str], data: bytes, repeat: int) -> tuple[int, float]:
+    """Return (compressed_size, best wall-seconds over `repeat` runs)."""
+    best = float("inf")
+    out = b""
+    for _ in range(repeat):
+        t0 = time.perf_counter()
+        proc = subprocess.run(cmd, input=data, capture_output=True, check=True)
+        dt = time.perf_counter() - t0
+        best = min(best, dt)
+        out = proc.stdout
+    return len(out), best
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--levels", default="1,3,6,9,19",
+                    help="comma-separated zstd levels")
+    ap.add_argument("--repeat", type=int, default=3,
+                    help="runs per measurement (best time kept)")
+    ap.add_argument("--json", help="write machine-readable results here")
+    args = ap.parse_args()
+
+    zstd = shutil.which("zstd")
+    gzip = shutil.which("gzip")
+    if not zstd or not gzip:
+        print("error: need both `zstd` and `gzip` on PATH", file=sys.stderr)
+        return 2
+
+    levels = [int(x) for x in args.levels.split(",") if x.strip()]
+    payloads = build_payloads()
+    results: list[dict] = []
+
+    header = (
+        f"{'payload':<30}{'codec':<10}{'in':>9}{'out':>9}"
+        f"{'ratio':>8}{'MB/s':>9}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for name, data in payloads.items():
+        n = len(data)
+
+        gz_size, gz_t = run_codec([gzip, "-6", "-c"], data, args.repeat)
+        gz_mbps = (n / gz_t) / 1e6
+        results.append({"payload": name, "codec": "gzip-6", "in": n,
+                        "out": gz_size, "ratio": n / gz_size,
+                        "mbps": gz_mbps})
+        print(f"{name:<30}{'gzip-6':<10}{n:>9}{gz_size:>9}"
+              f"{n / gz_size:>8.2f}{gz_mbps:>9.1f}")
+
+        for lv in levels:
+            sz, t = run_codec([zstd, f"-{lv}", "-c", "-q"], data,
+                              args.repeat)
+            mbps = (n / t) / 1e6
+            results.append({"payload": name, "codec": f"zstd-{lv}",
+                            "in": n, "out": sz, "ratio": n / sz,
+                            "mbps": mbps})
+            print(f"{'':<30}{'zstd-' + str(lv):<10}{n:>9}{sz:>9}"
+                  f"{n / sz:>8.2f}{mbps:>9.1f}")
+        print()
+
+    if args.json:
+        meta = {
+            "zstd_version": subprocess.run(
+                [zstd, "--version"], capture_output=True, text=True
+            ).stdout.strip(),
+            "commit": subprocess.run(
+                ["git", "-C", str(REPO), "rev-parse", "--short", "HEAD"],
+                capture_output=True, text=True
+            ).stdout.strip(),
+            "repeat": args.repeat,
+        }
+        pathlib.Path(args.json).write_text(
+            json.dumps({"meta": meta, "results": results}, indent=2)
+        )
+        print(f"wrote {args.json}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/soak.sh
+++ b/tools/soak.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# Sustained mixed-load soak for the zstd filter. Drives a real nginx
+# (ideally an ASAN/UBSAN build, optionally under valgrind) with
+# concurrent, varied requests for a fixed duration, then asserts the
+# worker survived cleanly: no sanitizer report, no crash, no leak, no
+# error-log [alert]/[emerg]. This is the "survives production-shaped
+# load" check that synthetic single-shot tests do not give.
+#
+# Usage:
+#   tools/soak.sh <nginx-binary> [duration_seconds] [concurrency]
+#   USE_VALGRIND=1 tools/soak.sh <nginx-binary> 120 8
+#
+# Exit non-zero on ANY of: sanitizer error, valgrind error, nginx
+# crash/non-clean exit, error-log alert/emerg, or a corrupted response.
+
+set -euo pipefail
+
+NGINX="${1:?usage: soak.sh <nginx-binary> [duration] [concurrency]}"
+DURATION="${2:-60}"
+CONC="${3:-8}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/conf" "$WORK/logs" "$WORK/html"
+
+# Mixed payload sizes: tiny (sub-min_length), medium, large (multi-buffer),
+# and a chunked/no-Content-Length upstream path.
+head -c 50            /dev/urandom | base64 > "$WORK/html/tiny"
+head -c 200000        /dev/urandom | base64 > "$WORK/html/medium"
+head -c 4000000       /dev/urandom | base64 > "$WORK/html/large"
+printf 'AAAAAAAAAA%.0s' $(seq 1 20000)      > "$WORK/html/compressible"
+
+cat > "$WORK/conf/nginx.conf" <<EOF
+daemon off;
+master_process on;
+worker_processes 2;
+error_log $WORK/logs/error.log info;
+pid $WORK/logs/nginx.pid;
+events { worker_connections 256; }
+http {
+    access_log off;
+    zstd_window_log 21;
+    server {
+        listen 127.0.0.1:18222;
+        root $WORK/html;
+        default_type text/plain;
+        location / {
+            zstd on;
+            zstd_min_length 100;
+            zstd_max_length 8m;
+            zstd_types text/plain;
+        }
+        location /bypass {
+            zstd on;
+            zstd_min_length 1;
+            zstd_types text/plain;
+            zstd_bypass \$arg_nozstd;
+            alias $WORK/html/medium;
+        }
+    }
+}
+EOF
+
+ASAN_OPTIONS="${ASAN_OPTIONS:-}:detect_leaks=1:abort_on_error=1:exitcode=42:log_path=$WORK/logs/asan"
+export ASAN_OPTIONS
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-}:print_stacktrace=1:halt_on_error=1"
+
+RUN=("$NGINX" -p "$WORK" -c "$WORK/conf/nginx.conf")
+if [ "${USE_VALGRIND:-0}" = "1" ]; then
+    SUPP="$(cd "$(dirname "$0")/.." && pwd)/valgrind.suppress"
+    RUN=(valgrind --error-exitcode=99 --leak-check=full
+         --errors-for-leak-kinds=definite
+         --suppressions="$SUPP" --log-file="$WORK/logs/valgrind.%p"
+         "${RUN[@]}")
+fi
+
+"${RUN[@]}" &
+NGINX_PID=$!
+
+for _ in $(seq 1 100); do
+    curl -fsS -o /dev/null "http://127.0.0.1:18222/tiny" 2>/dev/null && break
+    sleep 0.1
+done
+
+echo "soak: ${DURATION}s, concurrency ${CONC}$( [ "${USE_VALGRIND:-0}" = 1 ] && echo ' (valgrind)')"
+END=$(( $(date +%s) + DURATION ))
+fail=0
+
+worker() {
+    local wid="$1"
+    local paths=(/tiny /medium /large /compressible
+                 "/bypass" "/bypass?nozstd=1")
+    local i=0
+    while [ "$(date +%s)" -lt "$END" ]; do
+        p=${paths[$((RANDOM % ${#paths[@]}))]}
+        # Vary Accept-Encoding incl. clients that do not support zstd.
+        ae=$([ $((RANDOM % 4)) -eq 0 ] && echo "gzip" || echo "zstd")
+        i=$((i + 1))
+        body="$WORK/r.${wid}.${i}"
+        if curl -fsS -H "Accept-Encoding: $ae" \
+                "http://127.0.0.1:18222$p" -o "$body" 2>/dev/null; then
+            # If it came back zstd-encoded, it must decode cleanly.
+            if head -c4 "$body" | od -An -tx1 | grep -q '28 b5 2f fd'; then
+                zstd -dq -c "$body" >/dev/null 2>&1 || { echo "BAD zstd $p"; return 1; }
+            fi
+        fi
+        rm -f "$body"
+    done
+}
+
+pids=()
+for w in $(seq 1 "$CONC"); do worker "$w" & pids+=($!); done
+for pid in "${pids[@]}"; do wait "$pid" || fail=1; done
+
+# Clean shutdown so all pool cleanups (incl. CCtx/CDict) run.
+kill -QUIT "$NGINX_PID" 2>/dev/null || true
+wait "$NGINX_PID" 2>/dev/null; rc=$?
+
+problems=0
+if ls "$WORK"/logs/asan* >/dev/null 2>&1; then
+    echo "FAIL: ASAN/UBSAN report:"; cat "$WORK"/logs/asan*; problems=1
+fi
+if ls "$WORK"/logs/valgrind.* >/dev/null 2>&1; then
+    if grep -qE 'ERROR SUMMARY: [1-9]|definitely lost: [1-9]' \
+            "$WORK"/logs/valgrind.* 2>/dev/null; then
+        echo "FAIL: valgrind errors:"
+        grep -E 'ERROR SUMMARY|definitely lost' "$WORK"/logs/valgrind.*
+        problems=1
+    fi
+fi
+if grep -nE '\[alert\]|\[emerg\]' "$WORK/logs/error.log" 2>/dev/null; then
+    echo "FAIL: alert/emerg in error.log"; problems=1
+fi
+if [ "$fail" -ne 0 ]; then
+    echo "FAIL: a worker reported a corrupted response"; problems=1
+fi
+# QUIT is a clean exit; valgrind uses 99, ASAN 42 on error.
+if [ "$rc" -ne 0 ] && [ "$rc" -ne 130 ]; then
+    echo "FAIL: nginx exited $rc"; tail -40 "$WORK/logs/error.log" || true
+    problems=1
+fi
+
+[ "$problems" -ne 0 ] && exit 1
+echo "✓ soak clean: ${DURATION}s @ ${CONC} concurrent, no sanitizer/leak/crash"


### PR DESCRIPTION
Closes the non-code gaps between "audited code" and a defensible
production posture. P1/P2 of the readiness review; the **P0 release
tag/CHANGELOG was deferred by request** — note the benchmark/soak
numbers reference the current commit, not a tagged version, until that
lands.

### SECURITY.md
Private vulnerability-disclosure process; explicit in-scope vs
out-of-scope (BREACH = `zstd_bypass` containment, not a fix;
CRIME/POODLE are TLS-layer and out of scope; upstream nginx/libzstd
bugs out of scope).

### Soak (`tools/soak.sh`) + CI job
Sustained mixed-load: varied payload sizes, zstd and non-zstd clients,
the bypass path, a chunked upstream. Fails on any sanitizer report,
leak, crash, `[alert]`/`[emerg]`, or corrupted response. Optional
`USE_VALGRIND=1`. shellcheck-clean; verified locally (30s/6c PASS).
New **Soak ASAN+UBSAN** job in `build-test.yml` — 10 min, **schedule /
workflow_dispatch only** (never per-PR), reuses the existing
`nginx-binary-asan` artifact. actionlint exit 0.

### Benchmark (`tools/benchmark.py`) + published numbers
Reproducible zstd-levels-vs-gzip harness. README publishes the
**actual measured** results (libzstd 1.5.5) with an honest reading —
including the row where small-payload zstd is *not* better than gzip,
and a caveat that the synthetic generators inflate ratios and cause a
non-representative high-level inversion.

### README: Compatibility + Operations
- Compatibility matrix with the **real** libzstd floor derived from
  in-source version guards (≥ 1.4.0 hard minimum: `ZSTD_compressStream2`
  / negative-level guard; ≥ 1.5.6 for `zstd_target_cblock_size`;
  CI-verified nginx 1.31.0 + Angie 1.11.5).
- Operations: reload behaviour (per-request CCtx, CDict cycle cleanup),
  `zstd_dict_file` constraints, a concrete rollback story (no
  persistent state — `zstd off` + reload, or swap the `.so`), and
  pre-deploy soak guidance.

No module C code changed — docs/tooling/CI only. Filter suite PASS
locally; CI will exercise the rest.

### Honest scope note
This makes the production *case* credible but does not by itself confer
a "production" label — that still needs the deferred tagged release
(`v1.0.0` + CHANGELOG) so operators can pin and audit what they run.