### PR TITLE
perf: pledge exact source size to zstd on known Content-Length

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,14 @@ Sets the zstd compression level. Accepted values depend on the installed zstd li
 
 For most web-serving workloads, levels `1`–`3` are recommended. Avoid high levels (> 9) in production unless responses are generated infrequently and cached.
 
+> **Performance note:** when a response has a known exact
+> `Content-Length` (the common proxied/static case), the module passes
+> that size to zstd up front (`ZSTD_CCtx_setPledgedSrcSize`). zstd then
+> sizes its internals to the input and writes a more compact frame
+> header, giving a small speed/ratio improvement at no cost. This is
+> automatic, per request, and requires no configuration. Chunked /
+> unknown-length responses are unaffected (they stream as before).
+
 ---
 
 ### zstd_min_length

--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -827,6 +827,39 @@ ngx_http_zstd_filter_init_cctx(ngx_http_request_t *r,
         }
     }
 
+    /*
+     * When the response body length is known exactly (a declared
+     * Content-Length, i.e. the common proxied / static case), tell zstd
+     * up front. With the pledged size the encoder can size its internals
+     * to the input and write a more compact frame header (an exact
+     * content-size field instead of the streaming-unknown encoding),
+     * improving both speed and ratio slightly at no cost.
+     *
+     * This stays strictly per-request: it is set on this request's own
+     * CCtx after the reset above and before the first compress call,
+     * exactly as ZSTD_CCtx_setPledgedSrcSize() requires. It does NOT
+     * reintroduce a shared/worker-lifetime context — the per-request
+     * context model from 774b4a5 is a deliberate correctness guarantee
+     * and is preserved.
+     *
+     * content_length_n is the body length at this (post-other-filters)
+     * point, which is exactly what is fed to the compressor for a
+     * non-chunked response. The pledge is only an optimisation hint, so
+     * a failure to set it is logged and ignored rather than failing the
+     * request; a genuine size mismatch would still be caught by
+     * ZSTD_compressStream2() and handled on the existing failed: path.
+     */
+    if (r->headers_out.content_length_n != -1) {
+        rc = ZSTD_CCtx_setPledgedSrcSize(
+                 cctx, (unsigned long long) r->headers_out.content_length_n);
+        if (ZSTD_isError(rc)) {
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "zstd: ZSTD_CCtx_setPledgedSrcSize(%O) ignored: %s",
+                           r->headers_out.content_length_n,
+                           ZSTD_getErrorName(rc));
+        }
+    }
+
     return NGX_OK;
 }
 

--- a/t/00-filter.t
+++ b/t/00-filter.t
@@ -25,7 +25,7 @@ add_block_preprocessor(sub {
 no_long_string();
 log_level 'debug';
 repeat_each(3);
-plan tests => repeat_each() * (blocks() * 3) + 147;
+plan tests => repeat_each() * (blocks() * 3) + 150;
 run_tests();
 
 
@@ -1053,3 +1053,42 @@ Accept-Encoding: zstd
 --- ignore_response
 --- error_log
 input exceeded zstd_max_length (100) on a response with no Content-Length
+
+
+
+=== TEST 43: known Content-Length response round-trips (pledged-src-size)
+# Regression for the ZSTD_CCtx_setPledgedSrcSize optimisation. A
+# proxied response with an exact Content-Length takes the pledged-size
+# path in init_cctx; an off-by-anything pledge would make
+# ZSTD_compressStream2 error or corrupt the stream. Assert the response
+# is zstd-encoded, chunked (filter strips the length), and crucially
+# decompresses back to the exact original bytes.
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/src;
+    }
+    location /src {
+        default_type text/plain;
+        return 200 "pledged-src-size round-trip body, long enough to compress and exercise the known-Content-Length path end to end\n";
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+!Content-Length
+Content-Encoding: zstd
+--- response_body_filters eval
+sub {
+    my $zstd = $_[0];
+    open(my $fh, "|-", "zstd -dq -c >/tmp/zstd_t43.out 2>/dev/null") or return "ERR";
+    print $fh $zstd; close($fh);
+    open(my $r, "<", "/tmp/zstd_t43.out") or return "ERR";
+    local $/; my $d = <$r>; close($r); unlink "/tmp/zstd_t43.out";
+    return $d;
+}
+--- response_body
+pledged-src-size round-trip body, long enough to compress and exercise the known-Content-Length path end to end


### PR DESCRIPTION
## What

When the response has an exact declared `Content-Length` (common
proxied/static case), `init_cctx` now calls
`ZSTD_CCtx_setPledgedSrcSize()`. zstd sizes its internals to the input
and emits a compact exact-content-size frame header instead of the
streaming-unknown encoding — a small, free speed/ratio win. Automatic,
per request, zero config. Chunked/unknown-length responses unchanged.

## Why this and NOT a pooled context

The earlier discussion floated a worker-lifetime pooled CCtx. That is
**the design `774b4a5` deliberately deleted** (a `static
ngx_http_zstd_worker_t` reused across requests → cross-request state
leakage). Reverting it for "performance" would reintroduce a known bug
class the suite/ASAN/reload-leak job exist to guard. This change keeps
the per-request CCtx model intact; the pledge is set on the request's
own context, after reset, before first compress — exactly as the API
requires.

## Concurrency / safety (asked explicitly)

nginx request handling is **multi-process, single-threaded per
worker** — N worker processes give multicore utilisation; a response
is handled entirely on one worker's one thread. `ctx->cctx` is
per-request in `r->pool`. The shared `CDict` is immutable (zstd
contract, set before worker fork). No data races possible; no locking
needed or added. This change does not alter any of that.

## Safety of the pledge itself

It is a hint: a failed `set` is logged at debug and ignored, not
fatal. A genuine size mismatch is still caught by
`ZSTD_compressStream2` and handled on the existing `failed:` path.

## Verification

- **TEST 43**: a known-Content-Length response is zstd-encoded,
  chunked, and **decompresses byte-for-byte back to the original**
  (the test pipes the body through `zstd -d` and compares — proves the
  pledged size is *exact*, not just that some stream came out).
- Full filter suite **PASS (537)**; e2e decompression-integrity +
  terminal-frame regressions **PASS**; strict `-Werror` build clean;
  manual round-trip verified (6000 B in → 6000 B out, content intact).

Honest note: the *magnitude* of the win is workload-dependent and
small relative to `zstd_comp_level` choice; this is a free correctness-
preserving refinement, not a headline speedup. The real performance
lever remains configuration (level / min_length / types), as the
README documents.