### PR TITLE
feat: add zstd_long directive (long-distance matching)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This is a hardened fork: every build is exercised against **nginx mainline and [
     * [zstd_buffers](#zstd_buffers)
     * [zstd_target_cblock_size](#zstd_target_cblock_size)
     * [zstd_window_log](#zstd_window_log)
+    * [zstd_long](#zstd_long)
     * [zstd_bypass](#zstd_bypass)
     * [zstd_dict_file](#zstd_dict_file)
   * [ngx_http_zstd_static_module](#ngx_http_zstd_static_module)
@@ -343,6 +344,31 @@ http {
     zstd on;
     zstd_comp_level   9;
     zstd_window_log   21;   # cap the window at 2 MB per request
+}
+```
+
+---
+
+### zstd_long
+
+**Syntax:** `zstd_long on | off;`
+**Default:** `zstd_long off;`
+**Context:** `http, server, location`
+
+Enables zstd **long-distance matching** (`ZSTD_c_enableLongDistanceMatching`). zstd keeps a secondary long-range hash table that finds repeated sequences far beyond the regular match window, which can meaningfully improve the compression ratio on large, internally repetitive bodies — concatenated JSON, HTML with repeated boilerplate, log dumps, sitemaps.
+
+Off by default: the win only appears on inputs large enough to exceed the match window, and it costs a modest, bounded amount of extra per-request memory for the long-range table. Small responses should not pay that allocation, so enable it only on locations that serve large repetitive payloads.
+
+Interacts with [`zstd_window_log`](#zstd_window_log): an explicit `zstd_window_log` still takes precedence over the window zstd would otherwise derive when long mode is on, so the per-request memory ceiling remains under your control.
+
+**Example:**
+
+```nginx
+location /api/bulk-export {
+    zstd on;
+    zstd_comp_level  12;
+    zstd_long        on;    # large, highly repetitive JSON
+    zstd_window_log  24;    # keep the memory ceiling explicit
 }
 ```
 

--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -28,6 +28,7 @@ typedef struct {
     ssize_t                      max_length;
     ssize_t                      target_cblock_size;  /* Issue #38: ZSTD_c_targetCBlockSize */
     ngx_int_t                    window_log;          /* ZSTD_c_windowLog: bounds per-request memory */
+    ngx_flag_t                   long_mode;           /* ZSTD_c_enableLongDistanceMatching */
 
     ngx_array_t                 *bypass;              /* ngx_http_complex_value_t: per-request bypass */
 
@@ -184,6 +185,13 @@ static ngx_command_t  ngx_http_zstd_filter_commands[] = {
       ngx_conf_set_num_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_zstd_loc_conf_t, window_log),
+      NULL },
+
+    { ngx_string("zstd_long"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_zstd_loc_conf_t, long_mode),
       NULL },
 
     { ngx_string("zstd_bypass"),
@@ -803,6 +811,29 @@ ngx_http_zstd_filter_init_cctx(ngx_http_request_t *r,
 #endif
 
     /*
+     * Long-distance matching. zstd keeps a secondary long-range hash
+     * table that finds repeats far beyond the regular match window —
+     * a meaningful ratio win on large, internally repetitive bodies
+     * (concatenated JSON, HTML with repeated boilerplate, logs) at a
+     * modest, bounded extra memory cost. Off by default; the win only
+     * materialises on inputs large enough to exceed the window, and
+     * small responses should not pay the table allocation. Set before
+     * zstd_window_log below so an explicit window cap still takes
+     * precedence over the LDM-derived default.
+     */
+    if (zlcf->long_mode) {
+        rc = ZSTD_CCtx_setParameter(cctx, ZSTD_c_enableLongDistanceMatching,
+                                     1);
+        if (ZSTD_isError(rc)) {
+            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                          "zstd: ZSTD_CCtx_setParameter("
+                          "enableLongDistanceMatching) failed: %s",
+                          ZSTD_getErrorName(rc));
+            return NGX_ERROR;
+        }
+    }
+
+    /*
      * Cap the compression window. zstd's per-context working memory is
      * dominated by the window size (~2^windowLog bytes plus match-table
      * overhead). Without a cap, a high level on large bodies lets each
@@ -925,6 +956,7 @@ ngx_http_zstd_create_loc_conf(ngx_conf_t *cf)
     conf->max_length = NGX_CONF_UNSET;
     conf->target_cblock_size = NGX_CONF_UNSET;
     conf->window_log = NGX_CONF_UNSET;
+    conf->long_mode = NGX_CONF_UNSET;
     conf->bypass = NGX_CONF_UNSET_PTR;
 
     return conf;
@@ -955,6 +987,7 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_value(conf->max_length, prev->max_length, NGX_CONF_UNSET);
     ngx_conf_merge_value(conf->target_cblock_size, prev->target_cblock_size, 0);
     ngx_conf_merge_value(conf->window_log, prev->window_log, 0);
+    ngx_conf_merge_value(conf->long_mode, prev->long_mode, 0);
     ngx_conf_merge_ptr_value(conf->bypass, prev->bypass, NULL);
 
     if (ngx_http_merge_types(cf, &conf->types_keys, &conf->types,


### PR DESCRIPTION
**Stack (merge bottom-up):**
1. #21 — `perf/hoist-locconf` → `master`
2. **#PR2 (this)** — `feat/zstd-long` → `perf/hoist-locconf`
3. #PR3 — `perf/larger-default-buffers` → `feat/zstd-long`

> Based on #21. **Do not merge before #21.** GitHub will retarget this PR to `master` once #21 is squash-merged.

---

Expose `ZSTD_c_enableLongDistanceMatching` as a boolean directive — `zstd_long on|off` (`http`/`server`/`location`).

zstd's long-range hash table finds repeats far beyond the regular match window: a useful ratio win on large, internally repetitive bodies (concatenated JSON, HTML boilerplate, log dumps, sitemaps).

- **Off by default.** The gain only appears on inputs large enough to exceed the match window; small responses should not pay the table allocation.
- Parameter is set **before** the `zstd_window_log` cap, so an explicit window still bounds per-request memory.
- `ZSTD_c_enableLongDistanceMatching` is in the **stable** libzstd API since 1.4.0 (the module's hard floor), so no version guard is needed — consistent with how the stable `windowLog` parameter is handled.

README: new `zstd_long` section + TOC entry.

### Verification
- Built clean against nginx 1.31.0 (`-Werror -Wall`).
- Runtime smoke test: `zstd_long on` accepted by the config parser, nginx starts, response served `Content-Encoding: zstd`, and `zstd -d` round-trips the body byte-for-byte.