### PR TITLE
perf: default zstd_buffers to 4x32k; document stacked-PR workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,38 @@ python3 -c "import glob,yaml;[yaml.safe_load(open(f)) for f in glob.glob('.githu
   `master`, they will collide on test numbering + the plan constant.
   Flag this in the PR body; whichever merges later gets a trivial
   renumber rebase. Don't hide the conflict.
+
+### Stacked PRs (one PR per issue/change)
+
+When a single piece of work decomposes into several independent
+changes, ship them as a **stack** — one PR per logical change, each
+based on the previous PR's branch rather than all on `master`. This
+keeps every PR small and individually reviewable while preserving the
+real dependency order, instead of one sprawling diff or several PRs
+that secretly conflict.
+
+Rules:
+
+- **One PR per issue/change.** Each branch contains exactly one
+  logical change and its docs (README reference **and** TOC) — never
+  bundle an unrelated fix because it was convenient.
+- **Base each PR on the one below it**, not on `master`. The base
+  branch of PR _n_ is the head branch of PR _n−1_. Set it explicitly:
+  `gh pr create --base <lower-branch>`.
+- **Order by dependency, lowest-risk first.** Pure refactors and
+  hot-path cleanups go at the bottom of the stack; new directives and
+  default changes on top. A reviewer reading bottom-up sees each diff
+  in isolation.
+- **State the stack in every PR body.** List the full stack with links
+  and mark this PR's position, e.g. `Stack: #12 ← #13 (this) ← #14`,
+  and note "merge bottom-up".
+- **Merge strictly bottom-up.** Squash-merge the base PR first; GitHub
+  retargets the next PR onto `master` automatically. Re-check CI on
+  the newly retargeted PR before merging it. Never merge a higher PR
+  before its base — that pulls the lower change's diff in with it.
+- **A rejected lower PR collapses the stack.** If the base PR needs
+  rework, rebase the rest of the stack onto its updated branch before
+  continuing; don't let higher PRs drift onto stale bases.
 - Update `README.md` (reference **and** TOC) in the same PR as any
   user-visible directive/variable change. Keep `.github/CI_SETUP.md`
   truthful if you change CI structure.

--- a/README.md
+++ b/README.md
@@ -272,10 +272,12 @@ zstd_types
 ### zstd_buffers
 
 **Syntax:** `zstd_buffers number size;`
-**Default:** `zstd_buffers 32 4k;` (on 4 KB pages) or `zstd_buffers 16 8k;` (on 8 KB pages)
+**Default:** `zstd_buffers 4 32k;`
 **Context:** `http, server, location`
 
-Configures the number and size of output buffers used during compression. The total buffer space is `number × size`. The defaults give a fixed 128 KB of buffer space regardless of platform page size, which is appropriate for most workloads.
+Configures the number and size of output buffers used during compression. The total buffer space is `number × size`, which the default keeps at ~128 KB.
+
+The default was changed from many page-sized buffers (`32 4k`) to a few large ones (`4 32k`). zstd's natural output unit is roughly 128 KB; draining each compress call into a 4 KB buffer forced many extra compression round-trips and output-chain allocations per response. Larger buffers let each compress call flush a much bigger slice, reducing per-response CPU and allocation overhead at the same total memory. Configurations that set `zstd_buffers` explicitly are unaffected.
 
 Increasing these values allows larger chunks to be accumulated before writing, potentially improving throughput at the cost of higher per-request memory usage.
 

--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -998,8 +998,17 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     }
 
     ngx_conf_merge_ptr_value(conf->dict, prev->dict, NULL);
-    ngx_conf_merge_bufs_value(conf->bufs, prev->bufs,
-                              (128 * 1024) / ngx_pagesize, ngx_pagesize);
+    /*
+     * Default to a few large buffers rather than many page-sized ones.
+     * zstd's natural output unit is ZSTD_CStreamOutSize() (~128 KB);
+     * draining each ZSTD_compressStream2() call into a 4 KB buffer forced
+     * many extra compress round-trips and ngx_alloc_chain_link() calls per
+     * response. 4 x 32 KB keeps total filter memory at the previous
+     * ~128 KB while letting each compress call flush a far larger slice,
+     * cutting inner-loop iterations and chain churn. Operators who tuned
+     * zstd_buffers explicitly are unaffected (merge keeps their value).
+     */
+    ngx_conf_merge_bufs_value(conf->bufs, prev->bufs, 4, 32 * 1024);
 
     zmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_zstd_filter_module);
 


### PR DESCRIPTION
**Stack (merge bottom-up):**
1. #21 — `perf/hoist-locconf` → `master`
2. #22 — `feat/zstd-long` → `perf/hoist-locconf`
3. **#PR3 (this)** — `perf/larger-default-buffers` → `feat/zstd-long`

> Based on #22 (which is based on #21). **Merge last.** GitHub retargets this to `master` once #22 lands.

---

### Buffer default change

`zstd_buffers` defaulted to `(128*1024)/pagesize` page-sized buffers (`32 4k` on a 4 KB page). zstd's natural output unit is roughly `ZSTD_CStreamOutSize()` (~128 KB), so draining each `ZSTD_compressStream2()` call into a 4 KB buffer forced many extra compress round-trips and `ngx_alloc_chain_link()` allocations per response.

Default to **`4 32k`** instead: identical ~128 KB total filter memory, far fewer inner-loop iterations and less output-chain churn. Configs that set `zstd_buffers` explicitly are unaffected (the merge keeps their value).

### Docs: stacked-PR workflow

Adds a **Stacked PRs** subsection to `AGENTS.md` → "PR conventions": one PR per logical change, each based on the PR below it, ordered lowest-risk-first, merged strictly bottom-up. This stack (#21 → #22 → this) is the worked example of that policy.

README: `zstd_buffers` default + rationale.

### Verification
- Built clean against nginx 1.31.0 (`-Werror -Wall`).
- Runtime smoke test (combined with the stack): valid zstd frame, `zstd -d` round-trips byte-for-byte.