### PR TITLE
perf: compute $zstd_ratio with a single division

### DIFF
--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -1217,10 +1217,19 @@ ngx_http_zstd_ratio_variable(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-    ratio_int = (ngx_uint_t) ctx->bytes_in / ctx->bytes_out;
-    /* Use uint64_t to prevent integer overflow when multiplying by 1000 */
-    ratio_frac = (ngx_uint_t) ((uint64_t) ctx->bytes_in * 1000
-                 / ctx->bytes_out % 1000);
+    /*
+     * Compute the scaled ratio once and derive both the integer and the
+     * three-decimal fractional part from it, instead of dividing
+     * bytes_in by bytes_out twice. uint64_t scaling is required anyway to
+     * avoid overflow in the *1000 step, so the single division carries no
+     * extra precondition over the previous two.
+     */
+    {
+        uint64_t  scaled = (uint64_t) ctx->bytes_in * 1000 / ctx->bytes_out;
+
+        ratio_int  = (ngx_uint_t) (scaled / 1000);
+        ratio_frac = (ngx_uint_t) (scaled % 1000);
+    }
 
     vv->len = ngx_sprintf(vv->data, "%ui.%03ui", ratio_int, ratio_frac)
               - vv->data;


### PR DESCRIPTION
**Stack (merge bottom-up):**
1. **#PR1 (this)** — `perf/ratio-single-divide` → `master`
2. #PR2 — `perf/buffers-cstreamoutsize` → this branch

> Per the stacked-PR workflow documented in `AGENTS.md`. Merge bottom-up; the base PR is squash-merged **without deleting its branch** until PR2 is retargeted (lesson from the #21→#22 auto-close).

---

`ngx_http_zstd_ratio_variable()` divided `bytes_in / bytes_out` **twice** — once for the integer part, again inside the `*1000/.../%1000` fractional computation. Compute the uint64_t-scaled ratio once and derive both parts from it.

- The `(uint64_t) bytes_in * 1000` scaling was already required to avoid overflow, so the single division carries **no new precondition**.
- Output is byte-for-byte identical (`%ui.%03ui` formatting unchanged).
- Log-path only (fires when `$zstd_ratio` is logged) — this is a micro-cleanup, not a hot-path win. Bundled into the stack for tidiness, scoped as its own PR per the one-change-per-PR rule.

### Verification
- Built clean against nginx 1.31.0, `-Werror -Wall`.

### Audit note
A separate candidate — removing the post-`chain_update` `ctx->out_buf = NULL` to skip "redundant" buffer re-validation — was investigated and **rejected**: `compress()` zeroes `ctx->buffer_out` after every emit, so `get_buf()`'s early-return guard is bypassed regardless of whether `out_buf` is NULL. Nulling it saves zero validations while removing a use-after-free guard on recycled buffers. No-op optimization; not pursued.