### PR TITLE
perf: default zstd_buffers size to ZSTD_CStreamOutSize()

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,12 +272,14 @@ zstd_types
 ### zstd_buffers
 
 **Syntax:** `zstd_buffers number size;`
-**Default:** `zstd_buffers 4 32k;`
+**Default:** `zstd_buffers 2 <ZSTD_CStreamOutSize()>;` (the size is libzstd's recommended streaming output unit, ~128 KB)
 **Context:** `http, server, location`
 
-Configures the number and size of output buffers used during compression. The total buffer space is `number × size`, which the default keeps at ~128 KB.
+Configures the number and size of output buffers used during compression. The total buffer space is `number × size`.
 
-The default was changed from many page-sized buffers (`32 4k`) to a few large ones (`4 32k`). zstd's natural output unit is roughly 128 KB; draining each compress call into a 4 KB buffer forced many extra compression round-trips and output-chain allocations per response. Larger buffers let each compress call flush a much bigger slice, reducing per-response CPU and allocation overhead at the same total memory. Configurations that set `zstd_buffers` explicitly are unaffected.
+The default buffer **size** is `ZSTD_CStreamOutSize()` — the value libzstd documents as the minimum at which `ZSTD_compressStream2()` can flush a complete internal block in a single call. With any smaller buffer, zstd is forced to fragment a block across calls, costing extra compression round-trips and output-chain allocations per response. Earlier versions used a heuristic (`32 4k`, then `4 32k`) that approximated this; the module now asks libzstd for the exact value so it stays correct if the library changes it.
+
+The default **count** is `2`: one buffer being filled by the compressor while the other is in flight down the output chain. This sets the per-request filter-memory floor at roughly `2 × ZSTD_CStreamOutSize()` (~256 KB), up from the previous ~128 KB — the deliberate cost of never forcing zstd to flush mid-block. If that trade is wrong for your workload (many concurrent connections, memory-constrained), set `zstd_buffers` explicitly to a smaller value; configurations that set it are unaffected by this default.
 
 Increasing these values allows larger chunks to be accumulated before writing, potentially improving throughput at the cost of higher per-request memory usage.
 

--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -999,16 +999,29 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_ptr_value(conf->dict, prev->dict, NULL);
     /*
-     * Default to a few large buffers rather than many page-sized ones.
-     * zstd's natural output unit is ZSTD_CStreamOutSize() (~128 KB);
-     * draining each ZSTD_compressStream2() call into a 4 KB buffer forced
-     * many extra compress round-trips and ngx_alloc_chain_link() calls per
-     * response. 4 x 32 KB keeps total filter memory at the previous
-     * ~128 KB while letting each compress call flush a far larger slice,
-     * cutting inner-loop iterations and chain churn. Operators who tuned
-     * zstd_buffers explicitly are unaffected (merge keeps their value).
+     * Default the output buffer size to ZSTD_CStreamOutSize() — the
+     * encoder's own recommended output granularity (~128 KB). It is the
+     * documented minimum at which ZSTD_compressStream2() can flush a full
+     * internal block in a single call; with any smaller buffer zstd is
+     * forced to fragment a block across calls, costing extra
+     * compress round-trips and ngx_alloc_chain_link() churn per response.
+     * The previous 4 x 32 KB heuristic approximated this; using the API's
+     * value is the principled form and tracks libzstd if it ever changes.
+     *
+     * Two such buffers: one being filled by the compressor while the
+     * other is in flight down the output chain. This raises the
+     * per-request filter-memory floor to ~2 x ZSTD_CStreamOutSize()
+     * (~256 KB) from the prior ~128 KB — the deliberate cost of never
+     * forcing zstd to mid-block flush. Operators who set zstd_buffers
+     * explicitly are unaffected (the merge keeps their value), and can
+     * tune it down if the memory trade is wrong for their workload.
+     *
+     * ZSTD_CStreamOutSize() is a constant-returning libzstd call (no
+     * allocation, no per-call cost); it is evaluated once here at config
+     * merge, not per request.
      */
-    ngx_conf_merge_bufs_value(conf->bufs, prev->bufs, 4, 32 * 1024);
+    ngx_conf_merge_bufs_value(conf->bufs, prev->bufs,
+                              2, ZSTD_CStreamOutSize());
 
     zmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_zstd_filter_module);
 


### PR DESCRIPTION
**Stack (merge bottom-up):**
1. #25 — `perf/ratio-single-divide` → `master`
2. **#PR2 (this)** — `perf/buffers-cstreamoutsize` → `perf/ratio-single-divide`

> Based on #25. **Do not merge before #25.** When #25 is squash-merged, it is merged **without deleting its branch**; this PR is then retargeted to `master` via REST API and CI re-triggered by rebase before merging (the documented stacked-PR procedure in `AGENTS.md`, hardened after the #21→#22 auto-close incident).

---

The output-buffer **size** default was a heuristic (`32 4k` → `4 32k`) approximating zstd's streaming output unit. Ask libzstd for the exact value: `ZSTD_CStreamOutSize()` is documented as the minimum buffer at which `ZSTD_compressStream2()` can flush a complete internal block in one call. Below it, zstd fragments a block across calls — extra compress round-trips and `ngx_alloc_chain_link()` churn per response. Using the API value is the principled form and tracks libzstd if the unit ever changes.

**Memory trade-off (called out explicitly):** count defaults to `2` (one buffer filling while the other drains the output chain), so the per-request filter-memory floor rises to ~`2 × ZSTD_CStreamOutSize()` (~256 KB) from the prior ~128 KB. This is the deliberate cost of never forcing a mid-block flush. Operators who set `zstd_buffers` explicitly are unaffected and can tune memory down; documented in the README.

`ZSTD_CStreamOutSize()` is a constant-returning libzstd call, evaluated **once at config merge**, not per request.

### Verification
- Built clean against nginx 1.31.0, `-Werror -Wall`.
- Runtime smoke test: 3 MB body (forces multi-buffer compress cycles) with the new default → `Content-Encoding: zstd`, `zstd -d | cmp` byte-for-byte identical, no zstd errors.

README: `zstd_buffers` default + memory trade-off documented.