### PR TITLE
chore(config): drop dead version-detect block; harden static filter reorder

### DIFF
--- a/filter/config
+++ b/filter/config
@@ -113,17 +113,10 @@ NGX_LD_OPT="$ngx_zstd_opt_L $NGX_LD_OPT"
 # The module compiles against older zstd (< 1.4.0) using fallback code
 # paths, but ZSTD_CCtx_reset() (1.5.0+) is used when available for
 # better performance. Versions below 1.4.0 are missing ZSTD_minCLevel().
-ngx_zstd_version=$(cat << 'ZVER_EOF'
-#include <stdio.h>
-#include <zstd.h>
-int main(void) { printf("%d\n", ZSTD_VERSION_NUMBER); return 0; }
-ZVER_EOF
-)
-ngx_zstd_ver=$(echo "$ngx_zstd_version" | \
-    $CC $ngx_zstd_opt_I -x c - -o /dev/null -E 2>/dev/null | \
-    grep ZSTD_VERSION_NUMBER | awk '{print $NF}' | head -1)
-
-# Simpler: extract directly from the header via the preprocessor
+#
+# Extract ZSTD_VERSION_NUMBER directly from the header via the
+# preprocessor: feed "#include <zstd.h>" + the macro name through the
+# compiler's -E and read the expanded value off the last line.
 ngx_zstd_ver=$(echo "#include <zstd.h>
 ZSTD_VERSION_NUMBER" | \
     $CC $ngx_zstd_opt_I -x c -E - 2>/dev/null | \
@@ -188,8 +181,14 @@ if [ "$ngx_module_link" != DYNAMIC ]; then
         next=ngx_http_range_header_filter_module
     fi
 
-    HTTP_FILTER_MODULES=`echo $HTTP_FILTER_MODULES \
-                         | sed "s/$ngx_module_name//" \
-                         | sed "s/$next/$next $ngx_module_name/"`
+    # Reorder as whitespace-delimited tokens, not raw substrings: a
+    # blanket "s/$name//" would also corrupt any module whose name
+    # contains $ngx_module_name (or $next) as a substring. Pad the list
+    # with surrounding spaces so every entry has space delimiters on
+    # both sides, then match " token " exactly.
+    HTTP_FILTER_MODULES=`echo " $HTTP_FILTER_MODULES " \
+                         | sed "s/ $ngx_module_name / /" \
+                         | sed "s/ $next / $next $ngx_module_name /" \
+                         | sed "s/^ *//;s/ *\$//"`
 fi
 


### PR DESCRIPTION
Outcome of a full module re-audit (security, performance, code quality, input validation, error output). The audit found **no critical/high issues** — the major hazards (per-request CCtx isolation, BREACH containment via zstd_bypass, input caps, dict-size limit, weak ETag, Vary, Accept-Encoding parser bounds, static path construction) are all already correctly handled. Two concrete `filter/config` improvements were warranted:

### Q1 — remove dead code
`filter/config` computed `ngx_zstd_ver` twice: an initial heredoc + `$CC -E` attempt, then immediately **overwrote** it with a simpler preprocessor extraction. The first block was never read — pure dead code. Removed; the working extraction is kept and commented.

### S1 — harden the static-link filter reorder
The non-DYNAMIC branch reordered filters with blanket substring seds (`s/$ngx_module_name//`, `s/$next/.../`). If any module name ever contained another's as a substring, this would corrupt the filter chain. Reworked to whitespace-delimited token matching (pad list with spaces, match `" token "`, trim). Not currently exploitable (module names are unique with no substring overlap) — defensive hardening.

**No behaviour change** for current module names.

### Verification
- **Dynamic build** (nginx 1.31.0, `--add-dynamic-module`): exercises the version-detect block — clean, 2 `.so` produced, no spurious version warning (libzstd 1.5.5).
- **Static build** (`--with-http_gzip_static_module --add-module`): exercises the reorder sed — compiles clean, links, and generated `objs/ngx_modules.c` places `ngx_http_zstd_filter_module` immediately after `ngx_http_gzip_filter_module` (correct: later registration = earlier in the output chain).

Full audit summary (S2–S4, Q2, V1–V2, E1 — all verified clean / informational, no change needed) is in the session notes; this PR carries only the two items that warranted code changes.