### PR TITLE
refactor: split header-filter eligibility guard into early returns

### DIFF
--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -252,23 +252,62 @@ ngx_http_zstd_header_filter(ngx_http_request_t *r)
 
     zlcf = ngx_http_get_module_loc_conf(r, ngx_http_zstd_filter_module);
 
-    if (!zlcf->enable
-        || (r->headers_out.status < NGX_HTTP_OK         /* < 200 */
-            || r->headers_out.status == NGX_HTTP_NO_CONTENT  /* 204: no body */
-            || r->headers_out.status == 205              /* 205: no body */
-            || (r->headers_out.status > 299
-                && r->headers_out.status != NGX_HTTP_FORBIDDEN
-                && r->headers_out.status != NGX_HTTP_NOT_FOUND))
-       || (r->headers_out.content_encoding
-           && r->headers_out.content_encoding->value.len)
-       || (r->headers_out.content_length_n != -1
-           && r->headers_out.content_length_n < zlcf->min_length)
-       || (zlcf->max_length != NGX_CONF_UNSET
-           && r->headers_out.content_length_n != -1
-           && r->headers_out.content_length_n > zlcf->max_length)
-       || ngx_http_test_content_type(r, &zlcf->types) == NULL
-       || r->header_only)
+    /*
+     * Eligibility gate. This is the original single 9-term disjunction
+     * split into one early return per reason: behaviour is identical
+     * (|| short-circuits and every term led to the same next-filter
+     * return), but each rejection cause is now individually visible and
+     * greppable. Order is preserved so short-circuit semantics — e.g.
+     * not dereferencing content_encoding before the cheaper checks — are
+     * unchanged.
+     */
+
+    /* zstd disabled for this location */
+    if (!zlcf->enable) {
+        return ngx_http_next_header_filter(r);
+    }
+
+    /* status not eligible: < 200, bodyless 204/205, or any > 299
+     * except 403/404 (which carry compressible error bodies) */
+    if (r->headers_out.status < NGX_HTTP_OK
+        || r->headers_out.status == NGX_HTTP_NO_CONTENT
+        || r->headers_out.status == 205
+        || (r->headers_out.status > 299
+            && r->headers_out.status != NGX_HTTP_FORBIDDEN
+            && r->headers_out.status != NGX_HTTP_NOT_FOUND))
     {
+        return ngx_http_next_header_filter(r);
+    }
+
+    /* already encoded (e.g. upstream gzip/br) — do not double-compress */
+    if (r->headers_out.content_encoding
+        && r->headers_out.content_encoding->value.len)
+    {
+        return ngx_http_next_header_filter(r);
+    }
+
+    /* known body smaller than zstd_min_length — not worth a frame */
+    if (r->headers_out.content_length_n != -1
+        && r->headers_out.content_length_n < zlcf->min_length)
+    {
+        return ngx_http_next_header_filter(r);
+    }
+
+    /* known body larger than zstd_max_length cap */
+    if (zlcf->max_length != NGX_CONF_UNSET
+        && r->headers_out.content_length_n != -1
+        && r->headers_out.content_length_n > zlcf->max_length)
+    {
+        return ngx_http_next_header_filter(r);
+    }
+
+    /* content type not in zstd_types */
+    if (ngx_http_test_content_type(r, &zlcf->types) == NULL) {
+        return ngx_http_next_header_filter(r);
+    }
+
+    /* header-only response: no body to compress */
+    if (r->header_only) {
         return ngx_http_next_header_filter(r);
     }
 


### PR DESCRIPTION
**Stack (merge bottom-up):**
1. **#PR1 (this)** — `refactor/split-header-guard` → `master` (C1)
2. #PR2 — `refactor/setparam-helper` → this branch (D1)
3. #PR3 — `harden/intmax-config-bound` → PR2 (H1)

> Stacked per `AGENTS.md`. Merge bottom-up; base PR squash-merged **without deleting its branch** until the next is retargeted (hardened procedure from the #21→#22 incident).

---

Outcome of a dedup/complexity/hardening re-audit. This is the **complexity-reduction** item (C1).

The header filter rejected ineligible responses with a single 9-term boolean disjunction. Split into one early-return guard per reason, each commented.

**Behaviour is provably identical:** `||` short-circuits and every term returned the same `ngx_http_next_header_filter(r)` call, so the split form `if(T1)ret; if(T2)ret; …` has the same truth table and the same evaluation order — notably `content_encoding` is still only dereferenced after the cheaper status checks. No functional change; readability only.

### Verification
- Builds clean against nginx 1.31.0, `-Werror -Wall`.
- Runtime check: eligible response still emits `Content-Encoding: zstd`; a sub-`zstd_min_length` body and a body whose type is not in `zstd_types` are both still served identity (the split guard rejects on exactly the same conditions).

### Audit note
This PR is C1 of three. D1 (dedup the repeated `ZSTD_CCtx_setParameter`+log block) and H1 (`INT_MAX` config-load bound) follow as stacked PRs. D2/C2/H2 from the audit were deliberately **not** actioned — merging them would add complexity or risk for no real gain.