### PR TITLE
docs(AGENTS): correct the upstream remote reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,6 @@ Rules:
   user-visible directive/variable change. Keep `.github/CI_SETUP.md`
   truthful if you change CI structure.
 - `gh` may resolve the wrong repo here (multiple remotes — `origin` =
-  `eilandert/zstd-nginx-module`, `upstream` = the HanadaLee fork). Pass
+  `eilandert/zstd-nginx-module`, `upstream` = `tokers/zstd-nginx-module`). Pass
   `--repo eilandert/zstd-nginx-module` or rely on the configured
   default.


### PR DESCRIPTION
Documentation only — one-line factual correction. Standalone PR.

The `AGENTS.md` "PR conventions" note described the `upstream` remote as *"the HanadaLee fork"*. Verified with `git remote -v`:

```
upstream  https://github.com/tokers/zstd-nginx-module.git
```

`upstream` points at **`tokers/zstd-nginx-module`** (the original project this repo forked from), not a HanadaLee fork. Corrected so the "gh resolves the wrong repo" warning names the real remote.

No code or behaviour change.