### PR TITLE
obs: permanent structured emit-decision debug logging

### DIFF
--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -670,7 +670,26 @@ ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
      */
     last = rc == 0 && ctx->last && directive == ZSTD_e_end;
 
+    /*
+     * Structured emit-decision trace. Permanent: compiled out of
+     * release builds via NGX_DEBUG (zero runtime cost when off),
+     * visible with `error_log ... debug`. This is the single most
+     * useful probe for the module's recurring truncation /
+     * zero-size-buffer / terminal-frame bug class — it records exactly
+     * what the emit guard saw (output size, libzstd return, terminal
+     * and flush state, action) so future diagnosis is one
+     * `error_log debug` away instead of a patch/rebuild cycle. Behaviour
+     * is unchanged; this only observes.
+     */
+    ngx_log_debug6(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "zstd emit?: outsz:%uz rc0:%d last:%d ctx_last:%d "
+                   "ctx_flush:%d action:%d",
+                   (size_t) ngx_buf_size(ctx->out_buf), rc == 0, last,
+                   ctx->last, ctx->flush, (ngx_uint_t) ctx->action);
+
     if (ngx_buf_size(ctx->out_buf) == 0 && !last && !(rc == 0 && ctx->flush)) {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "zstd emit: suppressed empty non-terminal buffer");
         return NGX_AGAIN;
     }
 


### PR DESCRIPTION
## What

Adds two gated `ngx_log_debug` calls at the output emit-decision point in `ngx_http_zstd_filter_compress`:

```
zstd emit?: outsz:N rc0:N last:N ctx_last:N ctx_flush:N action:N
zstd emit: suppressed empty non-terminal buffer
```

`NGX_DEBUG`-gated (the `ngx_log_debug*` macros expand to nothing in release builds) → **zero runtime cost when off**, visible with `error_log ... debug`. **No behaviour change** — it only observes the existing guard.

## Why

This module has a recurring truncation / zero-size-buffer / terminal-frame bug class (`a209f96`, `2af5889`, PR#23/#49, the in-progress bug B). Every prior diagnosis required temporarily patching debug lines in and rebuilding — repeatedly, this session included. This makes the single most diagnostic probe **permanent**: exactly what state the emit guard saw and why it suppressed/forwarded a buffer. During bug-B investigation it immediately exposed the forced-flush-under-`proxy_buffering off` mechanism with no patch/rebuild loop.

## Scope

Observability only. This is **not** the bug-B fix (that is unsolved and tracked separately in `BUG-B-PLAN.md` / `BUG-B-RUNBOOK.md`). Shipping this independently so the diagnostic exists in tree for the ongoing investigation and future regressions.

## Verification

- Builds clean under the project `-Werror -Wall` flags (nginx 1.31.0).
- No logic/guard change (diff is purely the two `ngx_log_debug` blocks).