### PR TITLE
fix: hardening improvements and test enhancements

### DIFF
--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -31,6 +31,7 @@ typedef struct {
     ssize_t                      target_cblock_size;  /* Issue #38: ZSTD_c_targetCBlockSize */
     ngx_int_t                    window_log;          /* ZSTD_c_windowLog: bounds per-request memory */
     ngx_flag_t                   long_mode;           /* ZSTD_c_enableLongDistanceMatching */
+    ssize_t                      max_cctx_memory;     /* config-load assert: per-request CCtx memory budget */
 
     ngx_array_t                 *bypass;              /* ngx_http_complex_value_t: per-request bypass */
 
@@ -220,6 +221,13 @@ static ngx_command_t  ngx_http_zstd_filter_commands[] = {
       ngx_conf_set_flag_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_zstd_loc_conf_t, long_mode),
+      NULL },
+
+    { ngx_string("zstd_max_cctx_memory"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_size_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_zstd_loc_conf_t, max_cctx_memory),
       NULL },
 
     { ngx_string("zstd_bypass"),
@@ -579,7 +587,9 @@ failed:
 static ngx_int_t
 ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
 {
-    size_t            rc, pos_in, pos_out;
+    size_t            zrc, pos_in, pos_out;  /* zrc: ZSTD_compressStream2
+                                              * bytes-remaining hint, not an
+                                              * NGX_* code */
     ngx_uint_t        last;
     ZSTD_EndDirective directive;
     ngx_chain_t      *cl;
@@ -627,12 +637,13 @@ ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
         return NGX_ERROR;
     }
 
-    rc = ZSTD_compressStream2(cctx, &ctx->buffer_out, &ctx->buffer_in, directive);
+    zrc = ZSTD_compressStream2(cctx, &ctx->buffer_out, &ctx->buffer_in,
+                               directive);
 
-    if (ZSTD_isError(rc)) {
+    if (ZSTD_isError(zrc)) {
         ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
                       "zstd: ZSTD_compressStream2() failed: %s",
-                      ZSTD_getErrorName(rc));
+                      ZSTD_getErrorName(zrc));
         return NGX_ERROR;
     }
 
@@ -649,7 +660,7 @@ ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
     ctx->redo = 0;
 
     /* PR #49: State machine logic for action transitions */
-    if (rc > 0) {
+    if (zrc > 0) {
         /*
          * rc > 0: zstd has buffered data. For COMPRESS, transition to FLUSH
          * to drain libzstd's internal buffers. For FLUSH/END, keep the action.
@@ -706,7 +717,7 @@ ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
      * request loops forever with NGX_HTTP_GZIP_BUFFERED set and hangs until
      * timeout.
      */
-    last = rc == 0 && ctx->last && directive == ZSTD_e_end;
+    last = zrc == 0 && ctx->last && directive == ZSTD_e_end;
 
     /*
      * Structured emit-decision trace. Permanent: compiled out of
@@ -722,7 +733,7 @@ ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
     ngx_log_debug6(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "zstd emit?: outsz:%uz rc0:%d last:%d ctx_last:%d "
                    "ctx_flush:%d action:%d",
-                   (size_t) ngx_buf_size(ctx->out_buf), rc == 0, last,
+                   (size_t) ngx_buf_size(ctx->out_buf), zrc == 0, last,
                    ctx->last, ctx->flush, (ngx_uint_t) ctx->action);
 
     /*
@@ -759,7 +770,7 @@ ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
      * falls through to be emitted with last_buf set below.
      */
     if (ngx_buf_size(ctx->out_buf) == 0 && !last) {
-        if (rc == 0 && ctx->flush) {
+        if (zrc == 0 && ctx->flush) {
             r->connection->buffered &= ~NGX_HTTP_GZIP_BUFFERED;
             ctx->flush = 0;
             ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
@@ -780,7 +791,7 @@ ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
 
     b = ctx->out_buf;
 
-    if (rc == 0 && (ctx->flush || last)) {
+    if (zrc == 0 && (ctx->flush || last)) {
         r->connection->buffered &= ~NGX_HTTP_GZIP_BUFFERED;
 
         b->flush = ctx->flush && !ctx->last;
@@ -1171,6 +1182,7 @@ ngx_http_zstd_create_loc_conf(ngx_conf_t *cf)
     conf->target_cblock_size = NGX_CONF_UNSET;
     conf->window_log = NGX_CONF_UNSET;
     conf->long_mode = NGX_CONF_UNSET;
+    conf->max_cctx_memory = NGX_CONF_UNSET;
     conf->bypass = NGX_CONF_UNSET_PTR;
 
     return conf;
@@ -1191,7 +1203,7 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_file_info_t             info;
     ngx_http_zstd_main_conf_t  *zmcf;
 
-    rc = NGX_OK;
+    rc = NGX_CONF_OK;
     buf = NULL;
     fd = NGX_INVALID_FILE;
 
@@ -1202,6 +1214,7 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_value(conf->target_cblock_size, prev->target_cblock_size, 0);
     ngx_conf_merge_value(conf->window_log, prev->window_log, 0);
     ngx_conf_merge_value(conf->long_mode, prev->long_mode, 0);
+    ngx_conf_merge_value(conf->max_cctx_memory, prev->max_cctx_memory, 0);
     ngx_conf_merge_ptr_value(conf->bypass, prev->bypass, NULL);
 
     if (ngx_http_merge_types(cf, &conf->types_keys, &conf->types,
@@ -1304,8 +1317,8 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
                 goto close;
 
             } else if ((size_t) n != size) {
-                ngx_conf_log_error(NGX_LOG_EMERG, cf, ngx_errno,
-                                   ngx_read_fd_n "\"%V incomplete\"",
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                   ngx_read_fd_n " \"%V\" incomplete read",
                                    &zmcf->dict_file);
 
                 rc = NGX_CONF_ERROR;
@@ -1355,7 +1368,131 @@ close:
         rc = NGX_CONF_ERROR;
     }
 
-    if (rc == NGX_OK && conf->enable) {
+    /*
+     * Per-request CCtx memory budget (config-load assertion).
+     *
+     * zstd's streaming compressor working set is dominated by the
+     * compression-level *strategy* tables (chain/hash/search), not by
+     * the window alone — see the README. Lowering windowLog therefore
+     * does NOT meaningfully bound memory for high levels (level 22 at
+     * windowLog 20 still allocates ~640 MB). The honest, precise lever
+     * is to validate the configured parameters against the operator's
+     * budget at config load using libzstd's own estimator, and refuse
+     * to start if they exceed it. The directive does not silently tune
+     * anything — a too-tight budget is a hard error so operators see
+     * the misconfiguration up front instead of discovering it as a
+     * worker-RSS surprise under concurrency.
+     *
+     * The estimator API lives in libzstd's experimental section
+     * (ZSTDLIB_STATIC_API), so the check is compiled in only when the
+     * module is built with -DZSTD_STATIC_LINKING_ONLY against
+     * libzstd >= 1.4.0 (the project's production and CI builds enable
+     * this). Without it, the directive is unsupported and rejected with
+     * an actionable error rather than silently no-op'd.
+     */
+    if (rc == NGX_CONF_OK && conf->enable
+        && conf->max_cctx_memory != NGX_CONF_UNSET
+        && conf->max_cctx_memory > 0)
+    {
+#if defined(ZSTD_STATIC_LINKING_ONLY) && ZSTD_VERSION_NUMBER >= 10400
+        ZSTD_CCtx_params  *cp;
+        size_t             est;
+        size_t             srv;
+
+        cp = ZSTD_createCCtxParams();
+        if (cp == NULL) {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "ZSTD_createCCtxParams() failed");
+            return NGX_CONF_ERROR;
+        }
+
+        srv = ZSTD_CCtxParams_init(cp, (int) conf->level);
+        if (ZSTD_isError(srv)) {
+            ZSTD_freeCCtxParams(cp);
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "ZSTD_CCtxParams_init(level=%i) failed: %s",
+                               conf->level, ZSTD_getErrorName(srv));
+            return NGX_CONF_ERROR;
+        }
+
+        if (conf->window_log > 0) {
+            srv = ZSTD_CCtxParams_setParameter(cp, ZSTD_c_windowLog,
+                                               (int) conf->window_log);
+            if (ZSTD_isError(srv)) {
+                ZSTD_freeCCtxParams(cp);
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                   "ZSTD_CCtxParams_setParameter("
+                                   "windowLog=%i) failed: %s",
+                                   conf->window_log,
+                                   ZSTD_getErrorName(srv));
+                return NGX_CONF_ERROR;
+            }
+        }
+
+        if (conf->long_mode) {
+            srv = ZSTD_CCtxParams_setParameter(
+                      cp, ZSTD_c_enableLongDistanceMatching, 1);
+            if (ZSTD_isError(srv)) {
+                ZSTD_freeCCtxParams(cp);
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                   "ZSTD_CCtxParams_setParameter("
+                                   "enableLongDistanceMatching) failed: %s",
+                                   ZSTD_getErrorName(srv));
+                return NGX_CONF_ERROR;
+            }
+        }
+
+#ifdef ZSTD_c_targetCBlockSize
+        if (conf->target_cblock_size > 0) {
+            srv = ZSTD_CCtxParams_setParameter(
+                      cp, ZSTD_c_targetCBlockSize,
+                      (int) conf->target_cblock_size);
+            if (ZSTD_isError(srv)) {
+                ZSTD_freeCCtxParams(cp);
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                   "ZSTD_CCtxParams_setParameter("
+                                   "targetCBlockSize=%z) failed: %s",
+                                   conf->target_cblock_size,
+                                   ZSTD_getErrorName(srv));
+                return NGX_CONF_ERROR;
+            }
+        }
+#endif
+
+        est = ZSTD_estimateCStreamSize_usingCCtxParams(cp);
+        ZSTD_freeCCtxParams(cp);
+
+        if (ZSTD_isError(est)) {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "ZSTD_estimateCStreamSize_usingCCtxParams() "
+                               "failed: %s", ZSTD_getErrorName(est));
+            return NGX_CONF_ERROR;
+        }
+
+        if (est > (size_t) conf->max_cctx_memory) {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "the configured zstd parameters need ~%uz "
+                               "bytes of per-request compressor memory, "
+                               "which exceeds \"zstd_max_cctx_memory\" %z; "
+                               "lower \"zstd_comp_level\" (currently %i), "
+                               "lower \"zstd_window_log\", disable "
+                               "\"zstd_long\", or raise the budget",
+                               est, conf->max_cctx_memory, conf->level);
+            return NGX_CONF_ERROR;
+        }
+#else
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "\"zstd_max_cctx_memory\" requires the module "
+                           "to be built with -DZSTD_STATIC_LINKING_ONLY "
+                           "against libzstd >= 1.4.0 (memory-estimation "
+                           "API); rebuild accordingly, or use "
+                           "\"zstd_window_log\" for a coarse window-based "
+                           "bound");
+        return NGX_CONF_ERROR;
+#endif
+    }
+
+    if (rc == NGX_CONF_OK && conf->enable) {
         ngx_http_core_loc_conf_t  *clcf;
 
         clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
@@ -1603,10 +1740,46 @@ static char *
 ngx_http_zstd_check_num_int_max(ngx_conf_t *cf, void *post, void *data)
 {
     ngx_int_t  *np = data;
+    char       *rc;
 
     (void) post;
 
-    return ngx_http_zstd_int_max_bound(cf, *np, "zstd_window_log");
+    rc = ngx_http_zstd_int_max_bound(cf, *np, "zstd_window_log");
+    if (rc != NGX_CONF_OK) {
+        return rc;
+    }
+
+    /*
+     * 0 means "unset" (keep zstd's level-derived default). Any other
+     * value is passed straight to ZSTD_c_windowLog, which only accepts
+     * [ZSTD_WINDOWLOG_MIN, ZSTD_WINDOWLOG_MAX]. Those macros live behind
+     * ZSTD_STATIC_LINKING_ONLY (experimental section of zstd.h) and are
+     * not visible on the module's normal dynamic-link build, so the
+     * stable, long-documented constants are inlined here: MIN is 10 and
+     * MAX is 30 on 32-bit / 31 on 64-bit size_t. libzstd would otherwise
+     * reject an out-of-range value per-request (a 500 on every response
+     * for this location); catching it at config load turns that into a
+     * clear startup error instead.
+     */
+#define NGX_HTTP_ZSTD_WINDOWLOG_MIN  10
+#define NGX_HTTP_ZSTD_WINDOWLOG_MAX  (sizeof(size_t) == 4 ? 30 : 31)
+
+    if (*np != 0
+        && (*np < NGX_HTTP_ZSTD_WINDOWLOG_MIN
+            || *np > (ngx_int_t) NGX_HTTP_ZSTD_WINDOWLOG_MAX))
+    {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "\"zstd_window_log\" must be 0 (default) or "
+                           "between %d and %d",
+                           NGX_HTTP_ZSTD_WINDOWLOG_MIN,
+                           (int) NGX_HTTP_ZSTD_WINDOWLOG_MAX);
+        return NGX_CONF_ERROR;
+    }
+
+#undef NGX_HTTP_ZSTD_WINDOWLOG_MIN
+#undef NGX_HTTP_ZSTD_WINDOWLOG_MAX
+
+    return NGX_CONF_OK;
 }
 
 

--- a/static/ngx_http_zstd_static_module.c
+++ b/static/ngx_http_zstd_static_module.c
@@ -8,6 +8,13 @@
 #include <ngx_core.h>
 #include <ngx_http.h>
 
+#include <zstd.h>     /* ZSTD_MAGICNUMBER, ZSTD_MAGIC_SKIPPABLE_* — stable since 0.8.0 */
+#include <stdint.h>   /* uint32_t for the magic-number compare */
+
+#if !(NGX_WIN32)
+#include <unistd.h>   /* pread(2) for the magic-number probe */
+#endif
+
 #include "../ngx_http_zstd_common.h"
 
 
@@ -216,6 +223,73 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
 
         return NGX_HTTP_NOT_FOUND;
     }
+
+#if (NGX_HAVE_PREAD)
+    /*
+     * Magic-number sanity check on the .zst file.
+     *
+     * Without this, a truncated, half-downloaded, mistakenly-renamed
+     * (e.g. `cp foo.txt foo.zst`), or otherwise non-zstd file would be
+     * served with `Content-Encoding: zstd` and the client would get an
+     * undecodable body — a confusing outage class that nginx's built-in
+     * gzip_static also doesn't defend against. The probe is cheap (one
+     * pread(2) of 4 bytes at offset 0; pread is offset-explicit so it
+     * never moves the open_file_cache's shared fd position — using
+     * plain read(2) would do exactly that and corrupt subsequent
+     * requests serving the same cached fd). On mismatch we decline, so
+     * nginx falls back to serving the uncompressed original (or
+     * returns 404 if it is absent), and the operator sees a clear
+     * error log line.
+     *
+     * Both a regular zstd frame (ZSTD_MAGICNUMBER) and a skippable
+     * frame (ZSTD_MAGIC_SKIPPABLE_START..+0xF) are accepted, since
+     * either is a valid leading frame in a zstd stream.
+     *
+     * Gated by NGX_HAVE_PREAD: on platforms where nginx's configure
+     * could not find pread(2) we silently skip the probe rather than
+     * fall back to a read+lseek pair that would mutate the shared fd
+     * offset. Every modern POSIX target has it; this guard is
+     * essentially a build-time tripwire.
+     */
+    if (of.size < 4) {
+        ngx_log_error(NGX_LOG_ERR, log, 0,
+                      "zstd static: \"%s\" too small to be a zstd frame "
+                      "(%O bytes)", path.data, of.size);
+        return NGX_DECLINED;
+    }
+
+    {
+        u_char    magic[4];
+        ssize_t   n;
+        uint32_t  mw;
+
+        n = pread(of.fd, magic, sizeof(magic), 0);
+        if (n != (ssize_t) sizeof(magic)) {
+            ngx_log_error(NGX_LOG_CRIT, log, ngx_errno,
+                          "zstd static: pread(\"%s\", 4 bytes) "
+                          "returned %z", path.data, n);
+            return NGX_DECLINED;
+        }
+
+        mw = ((uint32_t) magic[0])
+           | ((uint32_t) magic[1] << 8)
+           | ((uint32_t) magic[2] << 16)
+           | ((uint32_t) magic[3] << 24);
+
+        if (mw != ZSTD_MAGICNUMBER
+            && (mw & ZSTD_MAGIC_SKIPPABLE_MASK)
+               != ZSTD_MAGIC_SKIPPABLE_START)
+        {
+            ngx_log_error(NGX_LOG_ERR, log, 0,
+                          "zstd static: \"%s\" is not a zstd frame "
+                          "(leading bytes 0x%02xd%02xd%02xd%02xd)",
+                          path.data,
+                          (ngx_uint_t) magic[0], (ngx_uint_t) magic[1],
+                          (ngx_uint_t) magic[2], (ngx_uint_t) magic[3]);
+            return NGX_DECLINED;
+        }
+    }
+#endif /* NGX_HAVE_PREAD */
 
 #endif
 

--- a/t/00-filter.t
+++ b/t/00-filter.t
@@ -25,7 +25,7 @@ add_block_preprocessor(sub {
 no_long_string();
 log_level 'debug';
 repeat_each(3);
-plan tests => repeat_each() * (blocks() * 3) + 153;
+plan tests => repeat_each() * (blocks() * 3) + 147;
 run_tests();
 
 
@@ -1168,3 +1168,50 @@ my $unit = "ABCDEFGHIJ0123456789zstd-multibuffer-regression-payload-";
 my $body = $unit x 5000;
 require Digest::MD5;
 length($body) . ":" . Digest::MD5::md5_hex($body)
+
+
+
+=== TEST 45: zstd_max_cctx_memory rejects parameters that exceed the budget
+# Per-request CCtx memory hardening: a budget of 1 KB with level 19 is
+# wildly insufficient (level 19 needs ~80–90 MB), so nginx must refuse
+# to start. The same test also exercises the no-STATIC_LINKING_ONLY
+# build path: that build cannot honour the directive and rejects it
+# unconditionally with a different but equally clear message. Either
+# way, must_die.
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_comp_level 19;
+        zstd_max_cctx_memory 1k;
+        zstd_types text/plain;
+        return 200 "x";
+    }
+--- request
+GET /filter
+--- must_die
+
+
+
+=== TEST 46: Accept-Encoding "notzstd, zstd" still negotiates zstd
+# Regression for the multi-occurrence parser fix. The first "zstd"
+# substring lives inside the unrelated token "notzstd", which the
+# delimiter check correctly rejects; the parser must then walk on to
+# the next list element, find the standalone "zstd" token, and accept
+# the encoding. Pre-fix this returned identity because only the first
+# occurrence was examined.
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        return 200 "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: notzstd, zstd
+--- response_headers
+Content-Encoding: zstd
+--- no_error_log
+[error]

--- a/t/01-static.t
+++ b/t/01-static.t
@@ -138,7 +138,7 @@ Content-Encoding: zstd
 
 
 
-=== TEST 6: zstd_static always (without accept-encoding header)
+=== TEST 7: zstd_static always (without accept-encoding header)
 --- config
     location /test {
         zstd_static always;
@@ -155,7 +155,7 @@ Content-Encoding: zstd
 
 
 
-=== TEST 7: zstd_static always (without zstd component in accept-encoding header)
+=== TEST 8: zstd_static always (without zstd component in accept-encoding header)
 --- config
     location /test {
         zstd_static always;
@@ -174,7 +174,7 @@ Content-Encoding: zstd
 
 
 
-=== TEST 8: zstd_static always (file does not exist)
+=== TEST 9: zstd_static always (file does not exist)
 --- config
     location /test2 {
         zstd_static always;
@@ -188,7 +188,7 @@ Accept-Encoding: gzip, br
 
 
 
-=== TEST 9: zstd_static on (file does not exist)
+=== TEST 10: zstd_static on (file does not exist)
 --- config
     location /test2 {
         zstd_static on;
@@ -202,7 +202,7 @@ Accept-Encoding: gzip, br
 
 
 
-=== TEST 10: zstd_static off (file does not exist)
+=== TEST 11: zstd_static off (file does not exist)
 --- config
     location /test2 {
         zstd_static off;
@@ -216,7 +216,7 @@ Accept-Encoding: gzip, br
 
 
 
-=== TEST 11: zstd_static on with quality value q=0 (reject)
+=== TEST 12: zstd_static on with quality value q=0 (reject)
 --- config
     location /test {
         zstd_static on;
@@ -235,7 +235,7 @@ ETag: "5be17d33-e95a"
 
 
 
-=== TEST 12: zstd_static on with quality value q=0.5 (accept lower)
+=== TEST 13: zstd_static on with quality value q=0.5 (accept lower)
 --- config
     location /test {
         zstd_static on;
@@ -254,7 +254,7 @@ Content-Encoding: zstd
 
 
 
-=== TEST 13: zstd_static always with q=0 (still serve zst)
+=== TEST 14: zstd_static always with q=0 (still serve zst)
 --- config
     location /test {
         zstd_static always;
@@ -273,7 +273,7 @@ Content-Encoding: zstd
 
 
 
-=== TEST 14: zstd_static on with gzip_vary and gzip support
+=== TEST 15: zstd_static on with gzip_vary and gzip support
 --- config
     location /test {
         zstd_static on;
@@ -293,7 +293,7 @@ Content-Encoding: zstd
 
 
 
-=== TEST 15: zstd_static on with gzip_vary but no zstd support
+=== TEST 16: zstd_static on with gzip_vary but no zstd support
 --- config
     location /test {
         zstd_static on;
@@ -313,7 +313,7 @@ ETag: "5be17d33-e95a"
 
 
 
-=== TEST 16: zstd_static on - HEAD request
+=== TEST 17: zstd_static on - HEAD request
 --- config
     location /test {
         zstd_static on;
@@ -332,7 +332,7 @@ Content-Encoding: zstd
 
 
 
-=== TEST 17: zstd_static on - POST request (not GET/HEAD)
+=== TEST 18: zstd_static on - POST request (not GET/HEAD)
 --- config
     location /test {
         zstd_static on;
@@ -348,7 +348,7 @@ Accept-Encoding: zstd
 
 
 
-=== TEST 18: zstd_dict_file loads and serves correctly (filter path)
+=== TEST 19: zstd_dict_file loads and serves correctly (filter path)
 # Regression for the untested zstd_dict_file feature, which had three
 # distinct historical bug fixes with NO test: 0fb40d9 (CDict leak on
 # cleanup), 50f27a8 (version-specific init error handling), f735a5d
@@ -387,7 +387,7 @@ Content-Encoding: zstd
 
 
 
-=== TEST 19: zstd_static handles a long URI without buffer overflow
+=== TEST 20: zstd_static handles a long URI without buffer overflow
 # Regression for 9789448 "buffer overflow when appending .zst extension".
 # A long request path stresses the .zst path-build reservation made via
 # ngx_http_map_uri_to_path(sizeof(".zst")). Missing file -> clean 404,
@@ -433,3 +433,32 @@ Content-Encoding: zstd
 # (HTTP/1.1) and the matrix under ASAN; the h2-specific framing path
 # would be redundant effort without adding coverage for a new code
 # path. Left for future work when/if CI adds TLS test infrastructure.
+
+
+
+=== TEST 21: zstd_static rejects a file whose contents are not a zstd frame
+# Defence-in-depth: a .zst whose first 4 bytes are not the zstd magic
+# (truncated download, mistakenly renamed text, `cp foo.txt foo.zst`)
+# must NOT be served with Content-Encoding: zstd — the client would
+# receive an undecodable body. The handler pread()s the leading 4
+# bytes, checks them against ZSTD_MAGICNUMBER / ZSTD_MAGIC_SKIPPABLE_*,
+# and declines on mismatch. The fixture below contains plain ASCII
+# ("HELO ...") with no zstd magic; no uncompressed fallback file is
+# placed alongside it, so the request falls through to a clean 404.
+--- config
+    location /bogus_zst {
+        zstd_static on;
+        root html;
+    }
+--- user_files
+>>> bogus.zst
+HELO this is not a zstd frame
+--- request
+GET /bogus_zst/bogus
+--- more_headers
+Accept-Encoding: zstd
+--- error_code: 404
+--- response_headers
+!Content-Encoding
+--- error_log
+is not a zstd frame


### PR DESCRIPTION
## Summary

**Filter module:**
- Add zstd_max_cctx_memory directive to limit per-request CCtx allocation
- Implement config-load assertion using ZSTD_estimateCStreamSize_usingCCtxParams()
- Add windowLog bounds checking (10-31) at config load with clear error messages
- Rename all size_t rc to zrc in ngx_http_zstd_filter_compress() to avoid confusion
- Fix log format for dictionary read incomplete case with proper errno handling
- Correct merge_loc_conf to return NGX_CONF_OK instead of NGX_OK

**Static module:**
- Add magic-number validation for .zst files using pread(2)
- Prevents serving truncated, corrupted, or non-zstd files with wrong encoding header
- Gated by NGX_HAVE_PREAD and !NGX_WIN32 for portability

**Tests:**
- Add TEST 45 (filter): zstd_max_cctx_memory rejection of oversized params
- Add TEST 46 (filter): Multi-occurrence Accept-Encoding parsing regression test
- Add TEST 21 (static): Magic-number validation rejects non-zstd files
- Fix duplicate TEST 6 numbering in static tests via awk renumbering

## Test plan
- Filter tests 1-46 pass (all existing + 2 new)
- Static tests 1-21 pass (all existing + 1 new, numbering fixed)
- Memory budgeting enforced at config load (level 19 with 1k budget rejected)
- Magic-number check prevents serving non-zstd files with zstd encoding header
- All log messages and error codes verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)