### PR TITLE
fix: body filter checks last_buf before flush (gzip/brotli order)

### DIFF
--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -836,11 +836,24 @@ ngx_http_zstd_filter_add_data(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
     ctx->in_buf = ctx->in->buf;
     ctx->in = ctx->in->next;
 
-    if (ctx->in_buf->flush) {
-        ctx->flush = 1;
-
-    } else if (ctx->in_buf->last_buf) {
+    /*
+     * Test last_buf FIRST, then flush — matching the order used by the
+     * nginx gzip and brotli body filters
+     * (ngx_http_gzip_filter_module.c / brotli filter). An upstream
+     * terminal chain link can legitimately carry BOTH last_buf=1 and
+     * flush=1 (e.g. proxy_buffering off + the upstream finalising its
+     * stream): with the reverse order ctx->flush wins, ctx->last is
+     * never set, the END-action transition below never fires, and the
+     * stream is sent without its terminal zstd frame — the connection
+     * hangs or the decoder sees a truncated frame. End-of-stream
+     * implies a flush at the writer layer, so prioritising last_buf
+     * loses nothing.
+     */
+    if (ctx->in_buf->last_buf) {
         ctx->last = 1;
+
+    } else if (ctx->in_buf->flush) {
+        ctx->flush = 1;
     }
 
     ctx->buffer_in.src = ctx->in_buf->pos;


### PR DESCRIPTION
## Summary

\`ngx_http_zstd_filter_add_data()\` tested \`ctx->in_buf->flush\` **before** \`ctx->in_buf->last_buf\`. nginx's gzip and brotli body filters do it the other way round — see [\`ngx_http_gzip_filter_module.c\`](https://github.com/nginx/nginx/blob/master/src/http/modules/ngx_http_gzip_filter_module.c) and \`modules/nginx/http-brotli/.../ngx_http_brotli_filter_module.c:509\`. They have a reason: an upstream terminal chain link can carry **both** bits (e.g. \`proxy_buffering off\` with an upstream that finalises mid-flush).

With flush-first, \`ctx->flush\` wins, \`ctx->last\` is never set, the END-action transition in \`ngx_http_zstd_filter_compress()\` never fires, and the response goes out **without** a terminal zstd frame — connection hangs or decoder sees a truncated stream.

This swaps the order to match the nginx idiom: last_buf-first. End-of-stream implies a flush at the writer layer, so the flush-only case loses nothing.

## Bug class

Latent — not reproducible with current upstreams via plain configs (none of the existing tests inject both bits simultaneously), but exactly the kind of state-machine corner that the recurring Bug-B history lives in. Hardening change that aligns with the established nginx body-filter pattern.

## Test plan

- [ ] CI: \`build-test.yml\` matrix (Perl + Python decode-and-diff under \`proxy_buffering off\`)
- [ ] CI: \`tests-asan\` (ASAN+UBSAN smoke + matrix)
- [ ] CI: \`test_proxy_unbuffered_truncation.py\` — the test class closest to the conditions that came near triggering this
- [ ] CI: \`test_compression_matrix.py\` — 504 cells across buffer/chunked/static × sizes × AE

No new Perl test: \`tcp_reply\` cannot inject both bits on the same buffer, and the existing decode-and-diff matrix already covers the practical paths. The comment in the source pins the rationale.