### PR TITLE
chore(config): declare ngx_http_zstd_common.h as a build dependency

### DIFF
--- a/filter/config
+++ b/filter/config
@@ -143,11 +143,18 @@ fi
 
 HTTP_ZSTD_SRCS="$ngx_addon_dir/ngx_http_zstd_filter_module.c"
 
+# Shared inline header included by this .c file. Declare it as a build
+# dependency so an incremental build (nginx's auto/sources / make .d
+# generation) rebuilds the object whenever the header changes; without
+# this, edits to ngx_http_zstd_common.h leave stale .o files behind.
+HTTP_ZSTD_DEPS="$ngx_addon_dir/../ngx_http_zstd_common.h"
+
 ngx_addon_name=ngx_http_zstd_filter_module
 ngx_module_type=HTTP_FILTER
 ngx_module_name=ngx_http_zstd_filter_module
 ngx_module_incs="$ngx_zstd_opt_I"
 ngx_module_srcs=$HTTP_ZSTD_SRCS
+ngx_module_deps=$HTTP_ZSTD_DEPS
 ngx_module_libs=$NGX_LD_OPT
 ngx_module_order="$ngx_module_name \
                   ngx_pagespeed \

--- a/static/config
+++ b/static/config
@@ -112,11 +112,18 @@ NGX_LD_OPT="$ngx_zstd_opt_L $NGX_LD_OPT"
 # build the ngx_http_zstd_static_module
 HTTP_ZSTD_SRCS="$ngx_addon_dir/ngx_http_zstd_static_module.c"
 
+# Shared inline header included by this .c file. Declare it as a build
+# dependency so an incremental build rebuilds the object whenever the
+# header changes; without this, edits to ngx_http_zstd_common.h leave
+# stale .o files behind.
+HTTP_ZSTD_DEPS="$ngx_addon_dir/../ngx_http_zstd_common.h"
+
 ngx_addon_name=ngx_http_zstd_static_module
 ngx_module_type=HTTP
 ngx_module_name=ngx_http_zstd_static_module
 ngx_module_incs="$ngx_zstd_opt_I"
 ngx_module_srcs=$HTTP_ZSTD_SRCS
+ngx_module_deps=$HTTP_ZSTD_DEPS
 ngx_module_order="ngx_http_brotli_static_module \
                   $ngx_module_name"
 


### PR DESCRIPTION
## Summary

Both \`filter/ngx_http_zstd_filter_module.c\` and \`static/ngx_http_zstd_static_module.c\` \`#include "../ngx_http_zstd_common.h"\`, but neither \`filter/config\` nor \`static/config\` registered the header with \`ngx_module_deps\`.

On an incremental rebuild — including the local develop loop — edits to \`common.h\` do not invalidate the \`.o\` files for the two modules. A fresh full build picks up the change, but local cycles can compile against a stale view of the parser. nginx's \`auto/sources\` consumes \`ngx_module_deps\` for exactly this case.

## Change

Add \`HTTP_ZSTD_DEPS=\$ngx_addon_dir/../ngx_http_zstd_common.h\` and \`ngx_module_deps=\$HTTP_ZSTD_DEPS\` to both configs, with a comment explaining why.

## Test plan

- [ ] CI: \`build-test.yml\` (full \`make\` build is unaffected; just adds the header to dep tracking)
- [ ] Manual: \`touch ngx_http_zstd_common.h && make\` — both \`.o\` files now rebuild instead of being skipped