### PR TITLE
fix: warn when zstd_target_cblock_size set on libzstd < 1.5.6

### DIFF
--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -1728,11 +1728,40 @@ static char *
 ngx_http_zstd_check_size_int_max(ngx_conf_t *cf, void *post, void *data)
 {
     ssize_t  *sp = data;
+    char     *rc;
 
     (void) post;
 
-    return ngx_http_zstd_int_max_bound(cf, (ngx_int_t) *sp,
-                                       "zstd_target_cblock_size");
+    rc = ngx_http_zstd_int_max_bound(cf, (ngx_int_t) *sp,
+                                     "zstd_target_cblock_size");
+    if (rc != NGX_CONF_OK) {
+        return rc;
+    }
+
+    /*
+     * ZSTD_c_targetCBlockSize first appears in libzstd 1.5.6. On older
+     * versions the parameter is undefined and the apply-site at
+     * ngx_http_zstd_filter_init_cctx() is #ifdef'd out — meaning the
+     * directive is silently ignored at runtime with no feedback to the
+     * operator. Warn loudly at config load so the config is
+     * recognisable as a no-op rather than appearing to "work" while
+     * having no effect. The directive is still accepted (a hard reject
+     * would break configs that intentionally target newer libzstd at
+     * runtime via library upgrades without rebuilding nginx). Suppress
+     * the warning when the value is 0 (the unset default).
+     */
+#ifndef ZSTD_c_targetCBlockSize
+    if (*sp > 0) {
+        ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                           "\"zstd_target_cblock_size\" is set but the "
+                           "module was built against libzstd without "
+                           "ZSTD_c_targetCBlockSize support (requires "
+                           "libzstd >= 1.5.6); the directive will have "
+                           "no effect at runtime");
+    }
+#endif
+
+    return NGX_CONF_OK;
 }
 
 


### PR DESCRIPTION
## Summary

\`ZSTD_c_targetCBlockSize\` first appears in libzstd 1.5.6. On older libraries the apply-site at \`ngx_http_zstd_filter_init_cctx()\` is \`#ifdef\`'d out (see \`filter/ngx_http_zstd_filter_module.c:1024\`), so a config that sets the directive is **silently ignored at runtime** — the operator sees no effect and no log line explaining why.

The README documents the version requirement, but the in-process feedback was nothing.

## Change

Extend the existing config-parse post-handler \`ngx_http_zstd_check_size_int_max()\` to emit \`NGX_LOG_WARN\` when the directive is set and \`ZSTD_c_targetCBlockSize\` is undefined at compile time. Suppress for the unset-default value 0.

The directive is **still accepted** — refusing it would break configs that target libzstd upgrades via shared-library replacement without rebuilding nginx.

## Behaviour delta

| libzstd | \`zstd_target_cblock_size 65536\` set | Before | After |
|---|---|---|---|
| ≥ 1.5.6 | yes | applies | applies (unchanged) |
| < 1.5.6 | yes | silently no-op | \`[warn]\` at config load + no-op |
| any | unset / 0 | silently no-op | silently no-op (unchanged) |

## Test plan

- [ ] CI: \`build-test.yml\` (build matrix exercises new + old libzstd via the \`build-old-libzstd-job\`)
- [ ] CI: existing \`validation\` job (no test-suite churn)