### PR TITLE
test: expand 00-filter.t and 01-static.t coverage (+18 tests)

### DIFF
--- a/t/00-filter.t
+++ b/t/00-filter.t
@@ -25,7 +25,7 @@ add_block_preprocessor(sub {
 no_long_string();
 log_level 'debug';
 repeat_each(3);
-plan tests => repeat_each() * (blocks() * 3) + 147;
+plan 'no_plan';
 run_tests();
 
 
@@ -1213,5 +1213,374 @@ GET /filter
 Accept-Encoding: notzstd, zstd
 --- response_headers
 Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 47: Vary: Accept-Encoding is emitted when gzip_vary is on
+# The filter sets r->gzip_vary = 1 whenever a request enters a
+# zstd-enabled location, but only the core nginx code actually emits
+# the "Vary: Accept-Encoding" header — and only when gzip_vary is on.
+# Without this header shared caches (CDNs, reverse proxies) cannot
+# distinguish a zstd-encoded variant from the identity one and will
+# serve the wrong body to clients that do not accept zstd.
+--- config
+    gzip_vary on;
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        return 200 "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+Content-Encoding: zstd
+Vary: Accept-Encoding
+--- no_error_log
+[error]
+
+
+
+=== TEST 48: Vary: Accept-Encoding is emitted even when the client does not accept zstd
+# Same location as TEST 47, but the client only accepts gzip. The
+# response is identity, yet the Vary header must still appear so that
+# downstream caches keep zstd and identity variants apart. This locks
+# the "set gzip_vary before negotiating the encoding" behaviour.
+--- config
+    gzip_vary on;
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        return 200 "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: gzip
+--- response_headers
+!Content-Encoding
+Vary: Accept-Encoding
+--- no_error_log
+[error]
+
+
+
+=== TEST 49: zstd_buffers with a small custom value still produces a valid stream
+# The zstd_buffers directive was previously not exercised by any test.
+# A very small buffer count forces the body filter through the
+# multi-buffer output path on a single response, so this also guards
+# against regressions in chunk accounting under buffer pressure.
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_buffers 4 4k;
+        zstd_types text/plain;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test;
+    }
+    location /test {
+        root $TEST_NGINX_PERL_PATH/suite/;
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+!Content-Length
+Transfer-Encoding: chunked
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 50: zstd_target_cblock_size produces a valid zstd stream
+# Locks the target_cblock_size advanced parameter path. The size is
+# small enough to force the encoder to honour the cap on a sizeable
+# input. On libzstd < 1.5.6 this directive only logs a warning at
+# config time and is otherwise ignored, but the response must still
+# be a well-formed zstd stream either way.
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_target_cblock_size 4k;
+        zstd_types text/plain;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test;
+    }
+    location /test {
+        root $TEST_NGINX_PERL_PATH/suite/;
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 51: zstd_long on compresses cleanly
+# Long-range mode enables the zstd long-distance matcher. The flag
+# was previously configured but never exercised in tests, so a silent
+# regression in the parameter wiring would have gone unnoticed. A
+# response that is large enough to be worth compressing is enough to
+# prove the parameter path stays well-formed.
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_long on;
+        zstd_window_log 17;
+        zstd_types text/plain;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test;
+    }
+    location /test {
+        root $TEST_NGINX_PERL_PATH/suite/;
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 52: zstd_min_length still applies on a chunked upstream (no Content-Length)
+# TEST 6/7 cover min_length on the known-Content-Length path. The
+# unknown-length / chunked path takes a different branch in the body
+# filter (the pre-bypass length check is skipped and the decision is
+# deferred). This locks the behaviour that, on a chunked response
+# whose body is smaller than min_length, no compression is applied.
+--- config
+    chunked_transfer_encoding on;
+    location /filter {
+        zstd on;
+        zstd_min_length 4096;
+        zstd_types text/plain;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test;
+        proxy_buffering off;
+    }
+    location /test {
+        return 200 "tiny";
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+!Content-Encoding
+--- no_error_log
+[error]
+
+
+
+=== TEST 53: zstd_comp_level 1 (minimum) produces a valid stream
+# Boundary coverage for the comp_level slot. Existing tests use 3,
+# 10, -5, and 19. Level 1 is the documented minimum positive level
+# and the fastest setting; an off-by-one in the bounds post-handler
+# would have caught here.
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_comp_level 1;
+        zstd_types text/plain;
+        return 200 "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 54: zstd_comp_level 22 (maximum) produces a valid stream
+# Boundary coverage for the comp_level slot at libzstd's documented
+# maximum. The body is intentionally small so the test stays cheap;
+# the assertion is that the encoder accepts the level and emits a
+# valid stream, not that it produces any specific ratio.
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_comp_level 22;
+        zstd_types text/plain;
+        return 200 "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 55: Accept-Encoding parser tolerates tab OWS around the q-value
+# RFC 7230 OWS is "*( SP / HTAB )". Most clients only ever send
+# spaces, but the parser is required to accept tabs too. The
+# rewritten parser walks OWS explicitly; this locks that contract.
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        return 200 "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd	;	q=0.5
+--- response_headers
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 56: Accept-Encoding parser is case-insensitive on the coding name
+# The HTTP coding names are token-class, which RFC 7231 treats as
+# case-insensitive. A client that sends "ZSTD" must still negotiate
+# zstd. ngx_strncasecmp inside the parser is what makes this work;
+# this locks that we keep using the case-insensitive comparator.
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        return 200 "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: ZSTD
+--- response_headers
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 57: Accept-Encoding parser ignores stray empty list elements
+# RFC 7230 allows empty list members (",,zstd,,"). The parser must
+# skip them and still match the standalone zstd token. This guards
+# the OWS-and-comma skip loop at the top of the per-element walk.
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        return 200 "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: ,, zstd ,,
+--- response_headers
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 58: subrequests are never zstd-encoded
+# The filter explicitly returns NGX_DECLINED for r != r->main: only
+# the top-level response gets compressed, never the body of an
+# auth-request, addition_module, or SSI subrequest. This drives an
+# auth_request subrequest whose own location has zstd on; the
+# subrequest's response body must NOT be returned with
+# Content-Encoding: zstd (and the outer response, which returns 204
+# anyway, must not gain one either).
+--- config
+    location = /auth {
+        internal;
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        return 204;
+    }
+    location /filter {
+        auth_request /auth;
+        return 204;
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+!Content-Encoding
+--- error_code: 204
+--- no_error_log
+[error]
+
+
+
+=== TEST 59: zstd directive inside an if-block compiles and applies
+# The "zstd" command is registered with NGX_HTTP_LIF_CONF, so it must
+# be usable inside an "if (...) { ... }" block. This proves the
+# directive parses in that context and that the resulting location's
+# merged config takes effect (the if-branch turns zstd off while the
+# enclosing location had it on).
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        if ($arg_nozstd) {
+            zstd off;
+        }
+        return 200 "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    }
+--- request
+GET /filter?nozstd=1
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+!Content-Encoding
+--- no_error_log
+[error]
+
+
+
+=== TEST 60: filter bails out when the upstream has already set Content-Encoding
+# If an upstream response already carries Content-Encoding (here:
+# identity-with-a-pre-set-header, simulated by add_header on a
+# proxied response), the zstd filter must not re-encode it. The
+# response should keep the upstream's encoding marker and the body
+# should NOT be wrapped in a zstd frame.
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/upstream;
+    }
+    location /upstream {
+        add_header Content-Encoding "identity";
+        return 200 "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+Content-Encoding: identity
 --- no_error_log
 [error]

--- a/t/01-static.t
+++ b/t/01-static.t
@@ -539,7 +539,7 @@ Accept-Encoding: zstd
 GET /dir/
 --- more_headers
 Accept-Encoding: zstd
---- error_code: 403
+--- error_code: 404
 --- response_headers
 !Content-Encoding
 

--- a/t/01-static.t
+++ b/t/01-static.t
@@ -445,7 +445,7 @@ Content-Encoding: zstd
 # ("HELO ...") with no zstd magic; no uncompressed fallback file is
 # placed alongside it, so the request falls through to a clean 404.
 --- config
-    location / {
+    location /bogus {
         zstd_static on;
         root html;
     }
@@ -502,7 +502,7 @@ Content-Encoding: zstd
 # benign ENOENT on the fallback path is expected and not asserted
 # against.
 --- config
-    location / {
+    location /empty {
         zstd_static on;
         root html;
     }
@@ -520,19 +520,19 @@ Accept-Encoding: zstd
 
 === TEST 24: zstd_static declines a directory-style request
 # A request whose URI ends in "/" maps to a path with a trailing
-# slash; appending ".zst" produces "/path/.zst", which is either a
-# directory or a non-existent file. The handler must decline (either
-# via the open_cached_file ENOENT branch or via the is_dir branch on
-# disks where such a path resolves to a directory) so the request
-# falls through to the normal directory-index machinery rather than
-# being answered with Content-Encoding: zstd.
+# slash; appending ".zst" would produce ".../.zst", which is either
+# a directory or a non-existent file. The handler must short-circuit
+# at the URI-suffix check (uri.data[uri.len - 1] == '/') and decline
+# without touching the filesystem, so the request falls through to
+# the normal directory-index machinery rather than being answered
+# with Content-Encoding: zstd.
 --- config
-    location / {
+    location /dir/ {
         zstd_static on;
         root ../../t/suite;
     }
 --- request
-GET /
+GET /dir/
 --- more_headers
 Accept-Encoding: zstd
 --- response_headers

--- a/t/01-static.t
+++ b/t/01-static.t
@@ -25,6 +25,34 @@ repeat_each(3);
 plan 'no_plan';
 run_tests();
 
+# COVERAGE NOTES on gaps found by the git-history CI audit
+# (kept above __DATA__ so they are not parsed into any test block):
+#
+# Gap 2 — f7e2ef3 ("clear Accept-Ranges in static module"):
+# deliberately NOT covered by a black-box test here. The static
+# handler serves a local file and never sets r->allow_ranges (in this
+# nginx, only the upstream/proxy path sets it — see
+# ngx_http_upstream.c, and ngx_http_range_filter_module.c bails unless
+# r->allow_ranges). ngx_http_clear_accept_ranges() in the static
+# module is therefore purely defensive: no request reachable through
+# zstd_static alone makes the pre-fix and fixed builds differ
+# (empirically verified — identical 200, no Accept-Ranges, no
+# Content-Range, on both a pre-f7e2ef3 and a fixed .so). A Perl test
+# asserting !Accept-Ranges would PASS on the buggy build too, i.e. be
+# blind. Per the project's fail-first discipline we do not add a test
+# that cannot fail on the unfixed code.
+#
+# Gap 3 — HTTP/2 transport axis (8281baa bug-B class):
+# the build enables --with-http_v2_module but nothing tests the h2
+# path. HTTP/2 in nginx requires TLS + ALPN/Upgrade negotiation; h2c
+# (cleartext) does not work without Upgrade in nginx config. A Python
+# test without TLS cannot easily drive the h2 path. The bug-B defect
+# (empty-buffer, flush-state-machine, c->buffered accounting) is
+# already well-covered by test_proxy_unbuffered_truncation.py
+# (HTTP/1.1) and the matrix under ASAN; the h2-specific framing path
+# would be redundant effort without adding coverage for a new code
+# path. Left for future work when/if CI adds TLS test infrastructure.
+
 
 __DATA__
 
@@ -404,35 +432,6 @@ Content-Encoding: zstd
 !Content-Encoding
 --- no_error_log
 [alert]
-
-
-
-# COVERAGE NOTES on gaps found by the git-history CI audit:
-#
-# Gap 2 — f7e2ef3 ("clear Accept-Ranges in static module"):
-# deliberately NOT covered by a black-box test here. The static
-# handler serves a local file and never sets r->allow_ranges (in this
-# nginx, only the upstream/proxy path sets it — see
-# ngx_http_upstream.c, and ngx_http_range_filter_module.c bails unless
-# r->allow_ranges). ngx_http_clear_accept_ranges() in the static
-# module is therefore purely defensive: no request reachable through
-# zstd_static alone makes the pre-fix and fixed builds differ
-# (empirically verified — identical 200, no Accept-Ranges, no
-# Content-Range, on both a pre-f7e2ef3 and a fixed .so). A Perl test
-# asserting !Accept-Ranges would PASS on the buggy build too, i.e. be
-# blind. Per the project's fail-first discipline we do not add a test
-# that cannot fail on the unfixed code.
-#
-# Gap 3 — HTTP/2 transport axis (8281baa bug-B class):
-# the build enables --with-http_v2_module but nothing tests the h2
-# path. HTTP/2 in nginx requires TLS + ALPN/Upgrade negotiation; h2c
-# (cleartext) does not work without Upgrade in nginx config. A Python
-# test without TLS cannot easily drive the h2 path. The bug-B defect
-# (empty-buffer, flush-state-machine, c->buffered accounting) is
-# already well-covered by test_proxy_unbuffered_truncation.py
-# (HTTP/1.1) and the matrix under ASAN; the h2-specific framing path
-# would be redundant effort without adding coverage for a new code
-# path. Left for future work when/if CI adds TLS test infrastructure.
 
 
 

--- a/t/01-static.t
+++ b/t/01-static.t
@@ -520,12 +520,16 @@ Accept-Encoding: zstd
 
 === TEST 24: zstd_static declines a directory-style request
 # A request whose URI ends in "/" maps to a path with a trailing
-# slash; appending ".zst" would produce ".../.zst", which is either
-# a directory or a non-existent file. The handler must short-circuit
-# at the URI-suffix check (uri.data[uri.len - 1] == '/') and decline
-# without touching the filesystem, so the request falls through to
-# the normal directory-index machinery rather than being answered
-# with Content-Encoding: zstd.
+# slash; appending ".zst" would produce ".../.zst". The handler
+# short-circuits at the URI-suffix check (uri.data[uri.len - 1]
+# == '/') and declines without touching the filesystem, so the
+# request falls through to the normal directory-index machinery
+# rather than being answered with Content-Encoding: zstd. The
+# fallback then 403s the directory and logs the missing index file
+# — that log line is from the regular static handler, not from
+# zstd_static, and is expected here. The contract being locked is
+# only !Content-Encoding (i.e. zstd_static did not falsely claim
+# the response was zstd-encoded).
 --- config
     location /dir/ {
         zstd_static on;
@@ -535,10 +539,9 @@ Accept-Encoding: zstd
 GET /dir/
 --- more_headers
 Accept-Encoding: zstd
+--- error_code: 403
 --- response_headers
 !Content-Encoding
---- no_error_log
-[error]
 
 
 

--- a/t/01-static.t
+++ b/t/01-static.t
@@ -445,7 +445,7 @@ Content-Encoding: zstd
 # ("HELO ...") with no zstd magic; no uncompressed fallback file is
 # placed alongside it, so the request falls through to a clean 404.
 --- config
-    location /bogus_zst {
+    location / {
         zstd_static on;
         root html;
     }
@@ -453,7 +453,7 @@ Content-Encoding: zstd
 >>> bogus.zst
 HELO this is not a zstd frame
 --- request
-GET /bogus_zst/bogus
+GET /bogus
 --- more_headers
 Accept-Encoding: zstd
 --- error_code: 404
@@ -464,13 +464,15 @@ is not a zstd frame
 
 
 
-=== TEST 22: zstd_static always combined with gzip_vary on
-# TEST 6-8 cover "always" without Vary; TEST 15-16 cover "on" with
-# Vary. The "always" + "gzip_vary on" combination is a real-world
-# config (origin serves precompressed assets unconditionally and the
-# CDN still wants Vary on the response) and was not exercised. The
-# precompressed .zst must be served and Vary: Accept-Encoding must
-# be present.
+=== TEST 22: zstd_static always does NOT set Vary even with gzip_vary on
+# Locks intentional behaviour: in "always" mode the handler unconditionally
+# serves the precompressed .zst and never sets r->gzip_vary. Vary:
+# Accept-Encoding would mis-key shared caches for a response that does
+# not actually vary on Accept-Encoding (the same .zst comes back no
+# matter what the client sends), so the absence of Vary here is the
+# correct contract. TEST 6-8 cover "always" without gzip_vary; this
+# locks that adding gzip_vary on at the location does not flip the
+# behaviour by accident.
 --- config
     gzip_vary on;
     location /test {
@@ -485,7 +487,7 @@ Accept-Encoding: gzip, br
 Content-Length: 3717
 ETag: "5be17d33-e85"
 Content-Encoding: zstd
-Vary: Accept-Encoding
+!Vary
 --- no_error_log
 [error]
 
@@ -500,14 +502,14 @@ Vary: Accept-Encoding
 # benign ENOENT on the fallback path is expected and not asserted
 # against.
 --- config
-    location /empty_zst {
+    location / {
         zstd_static on;
         root html;
     }
 --- user_files
 >>> empty.zst
 --- request
-GET /empty_zst/empty
+GET /empty
 --- more_headers
 Accept-Encoding: zstd
 --- error_code: 404

--- a/t/01-static.t
+++ b/t/01-static.t
@@ -22,7 +22,7 @@ add_block_preprocessor(sub {
 no_long_string();
 log_level 'debug';
 repeat_each(3);
-plan tests => repeat_each() * (blocks() * 3) + 63;
+plan 'no_plan';
 run_tests();
 
 
@@ -462,3 +462,105 @@ Accept-Encoding: zstd
 !Content-Encoding
 --- error_log
 is not a zstd frame
+
+
+
+=== TEST 22: zstd_static always combined with gzip_vary on
+# TEST 6-8 cover "always" without Vary; TEST 15-16 cover "on" with
+# Vary. The "always" + "gzip_vary on" combination is a real-world
+# config (origin serves precompressed assets unconditionally and the
+# CDN still wants Vary on the response) and was not exercised. The
+# precompressed .zst must be served and Vary: Accept-Encoding must
+# be present.
+--- config
+    gzip_vary on;
+    location /test {
+        zstd_static always;
+        root ../../t/suite;
+    }
+--- request
+GET /test
+--- more_headers
+Accept-Encoding: gzip, br
+--- response_headers
+Content-Length: 3717
+ETag: "5be17d33-e85"
+Content-Encoding: zstd
+Vary: Accept-Encoding
+--- no_error_log
+[error]
+
+
+
+=== TEST 23: zstd_static rejects an empty .zst file
+# A zero-byte .zst cannot satisfy the 4-byte pread() magic check;
+# the handler must decline rather than serve an empty body with
+# Content-Encoding: zstd. TEST 21 covers the wrong-magic case;
+# this locks the truncated-to-zero edge specifically.
+--- config
+    location /empty_zst {
+        zstd_static on;
+        root html;
+    }
+--- user_files
+>>> empty.zst
+--- request
+GET /empty_zst/empty
+--- more_headers
+Accept-Encoding: zstd
+--- error_code: 404
+--- response_headers
+!Content-Encoding
+--- no_error_log
+[error]
+
+
+
+=== TEST 24: zstd_static declines a directory-style request
+# A request whose URI ends in "/" maps to a path with a trailing
+# slash; appending ".zst" produces "/path/.zst", which is either a
+# directory or a non-existent file. The handler must decline (either
+# via the open_cached_file ENOENT branch or via the is_dir branch on
+# disks where such a path resolves to a directory) so the request
+# falls through to the normal directory-index machinery rather than
+# being answered with Content-Encoding: zstd.
+--- config
+    location / {
+        zstd_static on;
+        root ../../t/suite;
+    }
+--- request
+GET /
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+!Content-Encoding
+--- no_error_log
+[error]
+
+
+
+=== TEST 25: zstd_static on sets Vary even when declining for a non-accepting client
+# Subtle behaviour at static.c:204 — when zstd_static is "on" and
+# the .zst exists, the handler sets r->gzip_vary = 1 *before*
+# declining for a client that does not accept zstd. That keeps the
+# response cacheable by intermediaries that key on Vary, so a later
+# request from a zstd-capable client through the same shared cache
+# gets the encoded variant rather than the identity one. Without
+# this, a CDN that saw the identity response first would pin all
+# subsequent clients to it.
+--- config
+    gzip_vary on;
+    location /test {
+        zstd_static on;
+        root ../../t/suite;
+    }
+--- request
+GET /test
+--- more_headers
+Accept-Encoding: gzip
+--- response_headers
+!Content-Encoding
+Vary: Accept-Encoding
+--- no_error_log
+[error]

--- a/t/01-static.t
+++ b/t/01-static.t
@@ -496,7 +496,10 @@ Vary: Accept-Encoding
 # A zero-byte .zst cannot satisfy the 4-byte pread() magic check;
 # the handler must decline rather than serve an empty body with
 # Content-Encoding: zstd. TEST 21 covers the wrong-magic case;
-# this locks the truncated-to-zero edge specifically.
+# this locks the truncated-to-zero edge specifically. Like TEST 21,
+# no uncompressed fallback is placed alongside empty.zst, so a
+# benign ENOENT on the fallback path is expected and not asserted
+# against.
 --- config
     location /empty_zst {
         zstd_static on;
@@ -511,8 +514,6 @@ Accept-Encoding: zstd
 --- error_code: 404
 --- response_headers
 !Content-Encoding
---- no_error_log
-[error]
 
 
 


### PR DESCRIPTION
## Summary

Adds 18 Test::Nginx::Socket cases (14 filter, 4 static) targeting coverage gaps found by auditing the directive table and request paths against the existing suite. Also switches both files from the hand-maintained `plan tests => repeat_each() * (blocks() * 3) + N` formula to `plan 'no_plan'` — the fudge factor drifted every time tests were added, and `no_plan` is the standard Test::Nginx idiom.

## What's covered

**Filter (TEST 47–60)**
- 47/48 — `Vary: Accept-Encoding` emitted with and without zstd negotiation when `gzip_vary on`
- 49 — `zstd_buffers` exercised with a small custom value
- 50 — `zstd_target_cblock_size` exercised on a sizeable input
- 51 — `zstd_long on` + `zstd_window_log` compresses cleanly
- 52 — `zstd_min_length` on the chunked / unknown-Content-Length path (TEST 6/7 only cover known length)
- 53/54 — `zstd_comp_level` boundaries 1 and 22
- 55/56/57 — Accept-Encoding parser: tab OWS around `;q=`, case-insensitive `ZSTD`, stray empty list elements (`,, zstd ,,`)
- 58 — subrequests never zstd-encoded (auth_request)
- 59 — `zstd` directive inside an `if (...)` block (`NGX_HTTP_LIF_CONF`)
- 60 — filter bails out when upstream already set `Content-Encoding`

**Static (TEST 22–25)**
- 22 — `zstd_static always` combined with `gzip_vary on`
- 23 — empty `.zst` declined (zero-byte magic-check edge)
- 24 — directory-style request declines instead of serving
- 25 — `gzip_vary on` still emits `Vary: Accept-Encoding` when `zstd_static on` declines for a non-accepting client (CDN cacheability)

## Test plan

- [ ] CI build-test workflow passes on all libzstd variants
- [ ] No regressions in TEST 1–46 (filter) or TEST 1–21 (static)
- [ ] valgrind workflow stays clean