### PR TITLE
refactor(config): dedup libzstd discovery into auto/zstd (CQ1)

### DIFF
--- a/auto/zstd
+++ b/auto/zstd
@@ -1,0 +1,152 @@
+# auto/zstd — shared libzstd discovery for the zstd filter and static modules.
+#
+# Sourced exactly once from the top-level addon config before either module is
+# declared, so the static/dynamic/pkg-config probe sequence lives in one place
+# instead of being duplicated (and silently drifting) between filter/config and
+# static/config. Exports:
+#   ngx_zstd_opt_I — compiler include flags for <zstd.h>
+#   ngx_zstd_opt_L — linker flags for libzstd
+# and appends the link flags to NGX_LD_OPT for static nginx builds.
+
+ngx_feature_incs="#include <zstd.h>"
+ngx_feature_test="(void) ZSTD_createCCtx();"
+ngx_feature_libs=
+ngx_feature_run=no
+
+ngx_zstd_opt_I=
+ngx_zstd_opt_L=
+
+if [ -n "$ZSTD_INC" -o -n "$ZSTD_LIB" ]; then
+    ngx_feature="ZStandard static library in $ZSTD_INC and $ZSTD_LIB"
+    ngx_feature_path=$ZSTD_INC
+
+    # we try the static shared library firstly
+    ngx_zstd_opt_I="-I$ZSTD_INC -DZSTD_STATIC_LINKING_ONLY"
+    ngx_zstd_opt_L="$ZSTD_LIB/libzstd.a"
+    SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
+    CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
+    SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
+    NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
+
+    . auto/feature
+
+    # restore
+    CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
+    NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
+
+    if [ $ngx_found = no ]; then
+        # then try the dynamic shared library
+        ngx_feature="ZStandard dynamic library in $ZSTD_INC and $ZSTD_LIB"
+        ngx_zstd_opt_L="-L$ZSTD_LIB -lzstd -Wl,-rpath,$ZSTD_LIB"
+
+        SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
+        CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
+        SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
+        NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
+
+        . auto/feature
+
+        # restore
+        CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
+        NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
+
+        if [ $ngx_found = no ]; then
+            cat << END
+            $0: error: the ngx_http_zstd modules require the ZStandard library, please be sure that "\$ZSTD_INC" and "\$ZSTD_LIB" are set correctly.
+END
+            exit 1
+        fi
+
+    fi
+else
+    # auto-discovery: prefer dynamic linking (static libzstd.a lacks -fPIC
+    # and cannot be linked into a shared .so dynamic module)
+    ngx_feature="ZStandard dynamic library"
+    ngx_zstd_opt_I=
+    ngx_zstd_opt_L="-lzstd"
+
+    SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
+    CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
+    SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
+    NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
+
+    . auto/feature
+
+    # restore
+    CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
+    NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
+
+    if [ $ngx_found = no ]; then
+        # Dynamic auto-discovery failed. Try pkg-config (portable across
+        # Linux, FreeBSD, OpenBSD, Gentoo, Rocky/RHEL) before giving up.
+        # Note: -l:libzstd.a is GNU ld only and not used here.
+        ngx_pkgconf=
+        if command -v pkgconf > /dev/null 2>&1; then
+            ngx_pkgconf=pkgconf
+        elif command -v pkg-config > /dev/null 2>&1; then
+            ngx_pkgconf=pkg-config
+        fi
+
+        if [ -n "$ngx_pkgconf" ] && $ngx_pkgconf --exists libzstd 2>/dev/null; then
+            ngx_feature="ZStandard library via pkg-config"
+            ngx_zstd_opt_I="$($ngx_pkgconf --cflags libzstd)"
+            ngx_zstd_opt_L="$($ngx_pkgconf --libs libzstd)"
+
+            SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
+            CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
+            SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
+            NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
+
+            . auto/feature
+
+            # restore
+            CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
+            NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
+        fi
+
+        if [ $ngx_found = no ]; then
+            cat << END
+            $0: error: the ngx_http_zstd modules require the ZStandard library.
+            Install libzstd-dev (Debian/Ubuntu), zstd-devel (RHEL/Rocky),
+            dev-libs/zstd (Gentoo), or security/zstd (FreeBSD/OpenBSD ports),
+            or set ZSTD_INC and ZSTD_LIB to the library location.
+END
+            exit 1
+        fi
+    fi
+
+fi
+
+NGX_LD_OPT="$ngx_zstd_opt_L $NGX_LD_OPT"
+
+# Advisory: check zstd version and warn if below recommended minimum.
+# The module compiles against older zstd (< 1.4.0) using fallback code
+# paths, but ZSTD_CCtx_reset() (1.5.0+) is used when available for
+# better performance. Versions below 1.4.0 are missing ZSTD_minCLevel().
+#
+# Extract ZSTD_VERSION_NUMBER directly from the header via the
+# preprocessor: feed "#include <zstd.h>" + the macro name through the
+# compiler's -E and read the expanded value off the last line.
+ngx_zstd_ver=$(echo "#include <zstd.h>
+ZSTD_VERSION_NUMBER" | \
+    $CC $ngx_zstd_opt_I -x c -E - 2>/dev/null | \
+    grep -v "^#" | grep -v "^$" | tail -1 | tr -d ' ')
+
+if [ -n "$ngx_zstd_ver" ]; then
+    if [ "$ngx_zstd_ver" -lt 10400 ] 2>/dev/null; then
+        cat << END
+        Warning: zstd version $ngx_zstd_ver detected (< 1.4.0 / 10400).
+        ZSTD_minCLevel() is not available; negative compression levels
+        are not supported and will be rejected at config load time.
+        Consider upgrading zstd to 1.4.0 or later for negative-level
+        support.
+END
+    elif [ "$ngx_zstd_ver" -lt 10500 ] 2>/dev/null; then
+        cat << END
+        Note: zstd version $ngx_zstd_ver detected (< 1.5.0 / 10500).
+        ZSTD_CCtx_reset() is not available; the module will fall back to
+        the deprecated ZSTD_initCStream_usingCDict() API. Consider
+        upgrading zstd to 1.5.0 or later for the best performance.
+END
+    fi
+fi

--- a/config
+++ b/config
@@ -1,5 +1,10 @@
 _ngx_zstd_root=$ngx_addon_dir
 
+# Discover libzstd once (sets ngx_zstd_opt_I / ngx_zstd_opt_L, appends to
+# NGX_LD_OPT, emits the version advisory). Both module configs below reuse the
+# result instead of repeating the probe.
+. $_ngx_zstd_root/auto/zstd
+
 ngx_addon_dir=$_ngx_zstd_root/filter
 . $_ngx_zstd_root/filter/config
 

--- a/filter/config
+++ b/filter/config
@@ -1,145 +1,6 @@
-ngx_feature_incs="#include <zstd.h>"
-ngx_feature_test="(void) ZSTD_createCCtx();"
-ngx_feature_libs=
-ngx_feature_run=no
-
-ngx_zstd_opt_I=
-ngx_zstd_opt_L=
-
-if [ -n "$ZSTD_INC" -o -n "$ZSTD_LIB" ]; then
-    ngx_feature="ZStandard static library in $ZSTD_INC and $ZSTD_LIB"
-    ngx_feature_path=$ZSTD_INC
-
-    # we try the static shared library firstly
-    ngx_zstd_opt_I="-I$ZSTD_INC -DZSTD_STATIC_LINKING_ONLY"
-    ngx_zstd_opt_L="$ZSTD_LIB/libzstd.a"
-    SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
-    CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
-    SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
-    NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
-
-    . auto/feature
-
-    # restore
-    CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
-    NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
-
-    if [ $ngx_found = no ]; then
-        # then try the dynamic shared library
-        ngx_feature="ZStandard dynamic library in $ZSTD_INC and $ZSTD_LIB"
-        ngx_zstd_opt_L="-L$ZSTD_LIB -lzstd -Wl,-rpath,$ZSTD_LIB"
-
-        SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
-        CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
-        SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
-        NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
-
-        . auto/feature
-
-        # restore
-        CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
-        NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
-
-        if [ $ngx_found = no ]; then
-            cat << END
-            $0: error: ngx_http_zstd_filter_module requires the ZStandard library, please be sure that "\$ZSTD_INC" and "\$ZSTD_LIB" are set correctly.
-END
-            exit 1
-        fi
-
-    fi
-else
-    # auto-discovery: prefer dynamic linking (static libzstd.a lacks -fPIC
-    # and cannot be linked into a shared .so dynamic module)
-    ngx_feature="ZStandard dynamic library"
-    ngx_zstd_opt_I=
-    ngx_zstd_opt_L="-lzstd"
-
-    SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
-    CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
-    SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
-    NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
-
-    . auto/feature
-
-    # restore
-    CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
-    NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
-
-    if [ $ngx_found = no ]; then
-        # Dynamic auto-discovery failed. Try pkg-config (portable across
-        # Linux, FreeBSD, OpenBSD, Gentoo, Rocky/RHEL) before giving up.
-        # Note: -l:libzstd.a is GNU ld only and not used here.
-        ngx_pkgconf=
-        if command -v pkgconf > /dev/null 2>&1; then
-            ngx_pkgconf=pkgconf
-        elif command -v pkg-config > /dev/null 2>&1; then
-            ngx_pkgconf=pkg-config
-        fi
-
-        if [ -n "$ngx_pkgconf" ] && $ngx_pkgconf --exists libzstd 2>/dev/null; then
-            ngx_feature="ZStandard library via pkg-config"
-            ngx_zstd_opt_I="$($ngx_pkgconf --cflags libzstd)"
-            ngx_zstd_opt_L="$($ngx_pkgconf --libs libzstd)"
-
-            SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
-            CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
-            SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
-            NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
-
-            . auto/feature
-
-            # restore
-            CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
-            NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
-        fi
-
-        if [ $ngx_found = no ]; then
-            cat << END
-            $0: error: ngx_http_zstd_filter_module requires the ZStandard library.
-            Install libzstd-dev (Debian/Ubuntu), zstd-devel (RHEL/Rocky),
-            dev-libs/zstd (Gentoo), or security/zstd (FreeBSD/OpenBSD ports),
-            or set ZSTD_INC and ZSTD_LIB to the library location.
-END
-            exit 1
-        fi
-    fi
-
-fi
-
-NGX_LD_OPT="$ngx_zstd_opt_L $NGX_LD_OPT"
-
-# Advisory: check zstd version and warn if below recommended minimum.
-# The module compiles against older zstd (< 1.4.0) using fallback code
-# paths, but ZSTD_CCtx_reset() (1.5.0+) is used when available for
-# better performance. Versions below 1.4.0 are missing ZSTD_minCLevel().
-#
-# Extract ZSTD_VERSION_NUMBER directly from the header via the
-# preprocessor: feed "#include <zstd.h>" + the macro name through the
-# compiler's -E and read the expanded value off the last line.
-ngx_zstd_ver=$(echo "#include <zstd.h>
-ZSTD_VERSION_NUMBER" | \
-    $CC $ngx_zstd_opt_I -x c -E - 2>/dev/null | \
-    grep -v "^#" | grep -v "^$" | tail -1 | tr -d ' ')
-
-if [ -n "$ngx_zstd_ver" ]; then
-    if [ "$ngx_zstd_ver" -lt 10400 ] 2>/dev/null; then
-        cat << END
-        Warning: zstd version $ngx_zstd_ver detected (< 1.4.0 / 10400).
-        ZSTD_minCLevel() is not available; negative compression levels
-        are not supported and will be rejected at config load time.
-        Consider upgrading zstd to 1.4.0 or later for negative-level
-        support.
-END
-    elif [ "$ngx_zstd_ver" -lt 10500 ] 2>/dev/null; then
-        cat << END
-        Note: zstd version $ngx_zstd_ver detected (< 1.5.0 / 10500).
-        ZSTD_CCtx_reset() is not available; the module will fall back to
-        the deprecated ZSTD_initCStream_usingCDict() API. Consider
-        upgrading zstd to 1.5.0 or later for the best performance.
-END
-    fi
-fi
+# libzstd discovery (ngx_zstd_opt_I / ngx_zstd_opt_L, NGX_LD_OPT, version
+# advisory) runs once in ../auto/zstd, sourced from the top-level config before
+# this file. Here we only declare the filter module itself.
 
 HTTP_ZSTD_SRCS="$ngx_addon_dir/ngx_http_zstd_filter_module.c"
 
@@ -155,7 +16,7 @@ ngx_module_name=ngx_http_zstd_filter_module
 ngx_module_incs="$ngx_zstd_opt_I"
 ngx_module_srcs=$HTTP_ZSTD_SRCS
 ngx_module_deps=$HTTP_ZSTD_DEPS
-ngx_module_libs=$NGX_LD_OPT
+ngx_module_libs="$ngx_zstd_opt_L"
 ngx_module_order="$ngx_module_name \
                   ngx_pagespeed \
                   ngx_http_postpone_filter_module \
@@ -198,4 +59,3 @@ if [ "$ngx_module_link" != DYNAMIC ]; then
                          | sed "s/ $next / $next $ngx_module_name /" \
                          | sed "s/^ *//;s/ *\$//"`
 fi
-

--- a/static/config
+++ b/static/config
@@ -1,113 +1,6 @@
-ngx_feature_incs="#include <zstd.h>"
-ngx_feature_test="(void) ZSTD_createCCtx();"
-ngx_feature_libs=
-ngx_feature_run=no
-
-ngx_zstd_opt_I=
-ngx_zstd_opt_L=
-
-if [ -n "$ZSTD_INC" -o -n "$ZSTD_LIB" ]; then
-    ngx_feature="ZStandard static library in $ZSTD_INC and $ZSTD_LIB"
-    ngx_feature_path=$ZSTD_INC
-
-    # we try the static shared library firstly
-    ngx_zstd_opt_I="-I$ZSTD_INC -DZSTD_STATIC_LINKING_ONLY"
-    ngx_zstd_opt_L="$ZSTD_LIB/libzstd.a"
-    SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
-    CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
-    SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
-    NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
-
-    . auto/feature
-
-    # restore
-    CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
-    NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
-
-    if [ $ngx_found = no ]; then
-        # then try the dynamic shared library
-        ngx_feature="ZStandard dynamic library in $ZSTD_INC and $ZSTD_LIB"
-        ngx_zstd_opt_L="-L$ZSTD_LIB -lzstd -Wl,-rpath,$ZSTD_LIB"
-
-        SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
-        CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
-        SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
-        NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
-
-        . auto/feature
-
-        # restore
-        CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
-        NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
-
-        if [ $ngx_found = no ]; then
-            cat << END
-            $0: error: ngx_http_zstd_filter_module requires the ZStandard library, please be sure that "\$ZSTD_INC" and "\$ZSTD_LIB" are set correctly.
-END
-            exit 1
-        fi
-
-    fi
-else
-    # auto-discovery: prefer dynamic linking (static libzstd.a lacks -fPIC
-    # and cannot be linked into a shared .so dynamic module)
-    ngx_feature="ZStandard dynamic library"
-    ngx_zstd_opt_I=
-    ngx_zstd_opt_L="-lzstd"
-
-    SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
-    CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
-    SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
-    NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
-
-    . auto/feature
-
-    # restore
-    CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
-    NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
-
-    if [ $ngx_found = no ]; then
-        # Dynamic auto-discovery failed. Try pkg-config (portable across
-        # Linux, FreeBSD, OpenBSD, Gentoo, Rocky/RHEL) before giving up.
-        # Note: -l:libzstd.a is GNU ld only and not used here.
-        ngx_pkgconf=
-        if command -v pkgconf > /dev/null 2>&1; then
-            ngx_pkgconf=pkgconf
-        elif command -v pkg-config > /dev/null 2>&1; then
-            ngx_pkgconf=pkg-config
-        fi
-
-        if [ -n "$ngx_pkgconf" ] && $ngx_pkgconf --exists libzstd 2>/dev/null; then
-            ngx_feature="ZStandard library via pkg-config"
-            ngx_zstd_opt_I="$($ngx_pkgconf --cflags libzstd)"
-            ngx_zstd_opt_L="$($ngx_pkgconf --libs libzstd)"
-
-            SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
-            CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
-            SAVED_NGX_TEST_LD_OPT=$NGX_TEST_LD_OPT
-            NGX_TEST_LD_OPT="$ngx_zstd_opt_L $NGX_TEST_LD_OPT"
-
-            . auto/feature
-
-            # restore
-            CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
-            NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
-        fi
-
-        if [ $ngx_found = no ]; then
-            cat << END
-            $0: error: ngx_http_zstd_static_module requires the ZStandard library.
-            Install libzstd-dev (Debian/Ubuntu), zstd-devel (RHEL/Rocky),
-            dev-libs/zstd (Gentoo), or security/zstd (FreeBSD/OpenBSD ports),
-            or set ZSTD_INC and ZSTD_LIB to the library location.
-END
-            exit 1
-        fi
-    fi
-
-fi
-
-NGX_LD_OPT="$ngx_zstd_opt_L $NGX_LD_OPT"
+# libzstd discovery (ngx_zstd_opt_I / ngx_zstd_opt_L, NGX_LD_OPT, version
+# advisory) runs once in ../auto/zstd, sourced from the top-level config before
+# this file. Here we only declare the static module itself.
 
 # build the ngx_http_zstd_static_module
 HTTP_ZSTD_SRCS="$ngx_addon_dir/ngx_http_zstd_static_module.c"
@@ -124,6 +17,7 @@ ngx_module_name=ngx_http_zstd_static_module
 ngx_module_incs="$ngx_zstd_opt_I"
 ngx_module_srcs=$HTTP_ZSTD_SRCS
 ngx_module_deps=$HTTP_ZSTD_DEPS
+ngx_module_libs="$ngx_zstd_opt_L"
 ngx_module_order="ngx_http_brotli_static_module \
                   $ngx_module_name"
 


### PR DESCRIPTION
## Issue CQ1 (Low — code quality)

`filter/config` and `static/config` each duplicated the entire libzstd static/dynamic/pkg-config discovery sequence. The copies had **drifted**: `static/config`'s not-found error reported that the *filter* module was missing. Any future portability/linker/version fix had to be made twice.

## Fix
- New `auto/zstd` holds the discovery probe, the `NGX_LD_OPT` append, and the libzstd version advisory.
- Top-level `config` sources it **once** before declaring either module.
- `filter/config` and `static/config` shrink to module-specific declarations only, reusing exported `ngx_zstd_opt_I` / `ngx_zstd_opt_L`; each sets `ngx_module_libs=\$ngx_zstd_opt_L` explicitly.
- Error text is module-generic ("the ngx_http_zstd modules require…") so it can't drift again.
- Version advisory now also covers static-only builds.

## Verification
- `sh -n` clean on all four scripts.
- Configure run reaches the shared probe and prints the new generic message (host lacks `libzstd-dev`; full compile covered by CI runners).