### PR TITLE
Update repo URLs to myguard-labs org

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,6 +282,6 @@ Rules:
   user-visible directive/variable change. Keep `.github/CI_SETUP.md`
   truthful if you change CI structure.
 - `gh` may resolve the wrong repo here (multiple remotes — `origin` =
-  `eilandert/zstd-nginx-module`, `upstream` = `tokers/zstd-nginx-module`). Pass
-  `--repo eilandert/zstd-nginx-module` or rely on the configured
+  `myguard-labs/nginx-zstd-module`, `upstream` = `tokers/zstd-nginx-module`). Pass
+  `--repo myguard-labs/nginx-zstd-module` or rely on the configured
   default.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Build & Test](https://github.com/eilandert/zstd-nginx-module/actions/workflows/build-test.yml/badge.svg)](https://github.com/eilandert/zstd-nginx-module/actions/workflows/build-test.yml)
-[![CodeQL](https://github.com/eilandert/zstd-nginx-module/actions/workflows/codeql.yml/badge.svg)](https://github.com/eilandert/zstd-nginx-module/actions/workflows/codeql.yml)
-[![Security Scanners](https://github.com/eilandert/zstd-nginx-module/actions/workflows/security-scanners.yml/badge.svg)](https://github.com/eilandert/zstd-nginx-module/actions/workflows/security-scanners.yml)
-[![Fuzzing](https://github.com/eilandert/zstd-nginx-module/actions/workflows/fuzzing.yml/badge.svg)](https://github.com/eilandert/zstd-nginx-module/actions/workflows/fuzzing.yml)
-[![Valgrind Memcheck](https://github.com/eilandert/zstd-nginx-module/actions/workflows/valgrind.yml/badge.svg)](https://github.com/eilandert/zstd-nginx-module/actions/workflows/valgrind.yml)
+[![Build & Test](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/build-test.yml/badge.svg)](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/build-test.yml)
+[![CodeQL](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/codeql.yml/badge.svg)](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/codeql.yml)
+[![Security Scanners](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/security-scanners.yml/badge.svg)](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/security-scanners.yml)
+[![Fuzzing](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/fuzzing.yml/badge.svg)](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/fuzzing.yml)
+[![Valgrind Memcheck](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/valgrind.yml/badge.svg)](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/valgrind.yml)
 
 📖 **Background reading:** 
 - [zstd nginx module: what it does, bugs fixed](https://deb.myguard.nl/2026/05/zstd-nginx-module-what-it-does-bugs-fixed/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ taken seriously.
 **Do not open a public issue for security vulnerabilities.**
 
 Report privately via GitHub's
-[private vulnerability reporting](https://github.com/eilandert/zstd-nginx-module/security/advisories/new)
+[private vulnerability reporting](https://github.com/myguard-labs/nginx-zstd-module/security/advisories/new)
 ("Report a vulnerability" under the repository's Security tab). If that
 is unavailable, contact the maintainers at the address on the
 [deb.myguard.nl](https://deb.myguard.nl/) site.


### PR DESCRIPTION
Repo transferred from eilandert to the myguard-labs org. This points README badges and links (and other doc surfaces: SECURITY.md, AGENTS.md, example compose) at the org.

The zstd module was additionally renamed zstd-nginx-module -> nginx-zstd-module; its links reflect the new name. No code changes.