### PR TITLE
ci: wide+long fuzz/valgrind/helgrind on self-hosted (monthly)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,2 @@
+self-hosted-runner:
+  labels: [builder02, lxc, docker]

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -39,7 +39,9 @@ jobs:
   fuzz:
     name: Accept-Encoding parser fuzz
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # WIDE+LONG monthly discovery on self-hosted (free, no GitHub 6h cap) —
+    # replaces the local nginx-module-stress cron. 1 target x 14400s = ~4h.
+    timeout-minutes: 300
 
     steps:
       - name: Checkout module
@@ -61,7 +63,8 @@ jobs:
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "FUZZ_SECS=${{ github.event.inputs.duration }}" >> "$GITHUB_ENV"
           else
-            echo "FUZZ_SECS=900" >> "$GITHUB_ENV"
+            # Monthly self-hosted budget: 1 target x 14400s = ~4h/module.
+            echo "FUZZ_SECS=14400" >> "$GITHUB_ENV"
           fi
 
       - name: Run fuzzer
@@ -106,3 +109,16 @@ jobs:
           name: fuzz-corpus
           path: ${{ github.workspace }}/fuzz/corpus-min
           retention-days: 30
+
+      - name: Notify Discord on failure
+        if: failure() && github.event_name == 'schedule'
+        env:
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_CHANNEL_BUILDS: ${{ secrets.DISCORD_CHANNEL_BUILDS }}
+        run: |
+          [ -n "$DISCORD_BOT_TOKEN" ] || exit 0
+          curl -fsS -X POST \
+            -H "Authorization: Bot $DISCORD_BOT_TOKEN" \
+            -H "Content-Type: application/json" \
+            "https://discord.com/api/v10/channels/$DISCORD_CHANNEL_BUILDS/messages" \
+            -d "{\"content\":\"🔴 ${{ github.repository }} — ${{ github.workflow }} FAILED (scheduled). ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" || true

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   fuzz:
     name: Accept-Encoding parser fuzz
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, builder02, lxc]
     # WIDE+LONG monthly discovery on self-hosted (free, no GitHub 6h cap) —
     # replaces the local nginx-module-stress cron. 1 target x 14400s = ~4h.
     timeout-minutes: 300

--- a/.github/workflows/helgrind.yml
+++ b/.github/workflows/helgrind.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   memcheck:
     name: Helgrind
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, builder02, lxc]
     # Long monthly helgrind soak on self-hosted — no GitHub 6h cap.
     timeout-minutes: 240
     steps:

--- a/.github/workflows/helgrind.yml
+++ b/.github/workflows/helgrind.yml
@@ -1,4 +1,4 @@
-name: Valgrind Memcheck
+name: Helgrind
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -6,12 +6,12 @@ env:
 
 on:
   schedule:
-    # Monthly, 1st @ 03:30 UTC.
-    - cron: "30 3 1 * *"
+    # Monthly, 1st @ 04:30 UTC.
+    - cron: "30 4 1 * *"
   workflow_dispatch: {}
 
 concurrency:
-  group: valgrind-${{ github.workflow }}-${{ github.ref }}
+  group: helgrind-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -19,9 +19,9 @@ permissions:
 
 jobs:
   memcheck:
-    name: Memcheck soak
+    name: Helgrind
     runs-on: ubuntu-latest
-    # Long monthly memcheck soak on self-hosted — no GitHub 6h cap.
+    # Long monthly helgrind soak on self-hosted — no GitHub 6h cap.
     timeout-minutes: 240
     steps:
       - name: Checkout module
@@ -44,8 +44,8 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: /var/cache/apt/archives
-          key: apt-valgrind-${{ runner.os }}-build-zstd-nginx
-          restore-keys: apt-valgrind-${{ runner.os }}-
+          key: apt-helgrind-${{ runner.os }}-build-zstd-nginx
+          restore-keys: apt-helgrind-${{ runner.os }}-
 
       - name: Install dependencies
         run: |
@@ -58,7 +58,7 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: nginx-${{ env.NGINX_VERSION }}.tar.gz
-          key: nginx-src-valgrind-${{ env.NGINX_VERSION }}
+          key: nginx-src-helgrind-${{ env.NGINX_VERSION }}
 
       - name: Download nginx source tarball
         run: |
@@ -85,9 +85,9 @@ jobs:
             --add-module="$GITHUB_WORKSPACE"
           make -j"$(nproc)"
 
-      - name: Soak under Valgrind Memcheck
+      - name: Soak under Helgrind
         env:
-          USE_VALGRIND: "1"
+          USE_HELGRIND: "1"
         run: |
           bash tools/soak.sh \
             "$GITHUB_WORKSPACE/nginx-${NGINX_VERSION}/objs/nginx" \

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   memcheck:
     name: Memcheck soak
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, builder02, lxc]
     # Long monthly memcheck soak on self-hosted — no GitHub 6h cap.
     timeout-minutes: 240
     steps:

--- a/tools/soak.sh
+++ b/tools/soak.sh
@@ -73,6 +73,13 @@ if [ "${USE_VALGRIND:-0}" = "1" ]; then
          --errors-for-leak-kinds=definite
          --suppressions="$SUPP" --log-file="$WORK/logs/valgrind.%p"
          "${RUN[@]}")
+elif [ "${USE_HELGRIND:-0}" = "1" ]; then
+    # Data-race / lock-order checking under helgrind (thread pool + any
+    # shared state). Reuses the same suppression file.
+    SUPP="$(cd "$(dirname "$0")/.." && pwd)/valgrind.suppress"
+    RUN=(valgrind --tool=helgrind --error-exitcode=99
+         --suppressions="$SUPP" --log-file="$WORK/logs/helgrind.%p"
+         "${RUN[@]}")
 fi
 
 "${RUN[@]}" &
@@ -83,7 +90,7 @@ for _ in $(seq 1 100); do
     sleep 0.1
 done
 
-echo "soak: ${DURATION}s, concurrency ${CONC}$( [ "${USE_VALGRIND:-0}" = 1 ] && echo ' (valgrind)')"
+echo "soak: ${DURATION}s, concurrency ${CONC}$( [ "${USE_VALGRIND:-0}" = 1 ] && echo ' (valgrind)'; [ "${USE_HELGRIND:-0}" = 1 ] && echo ' (helgrind)')"
 END=$(( $(date +%s) + DURATION ))
 fail=0
 
@@ -121,11 +128,12 @@ problems=0
 if ls "$WORK"/logs/asan* >/dev/null 2>&1; then
     echo "FAIL: ASAN/UBSAN report:"; cat "$WORK"/logs/asan*; problems=1
 fi
-if ls "$WORK"/logs/valgrind.* >/dev/null 2>&1; then
+if ls "$WORK"/logs/valgrind.* "$WORK"/logs/helgrind.* >/dev/null 2>&1; then
     if grep -qE 'ERROR SUMMARY: [1-9]|definitely lost: [1-9]' \
-            "$WORK"/logs/valgrind.* 2>/dev/null; then
-        echo "FAIL: valgrind errors:"
-        grep -E 'ERROR SUMMARY|definitely lost' "$WORK"/logs/valgrind.*
+            "$WORK"/logs/valgrind.* "$WORK"/logs/helgrind.* 2>/dev/null; then
+        echo "FAIL: valgrind/helgrind errors:"
+        grep -E 'ERROR SUMMARY|definitely lost' \
+            "$WORK"/logs/valgrind.* "$WORK"/logs/helgrind.* 2>/dev/null
         problems=1
     fi
 fi


### PR DESCRIPTION
Monthly stress pass wide+long on self-hosted; adds helgrind (soak.sh USE_HELGRIND) + actionlint.yaml. Replaces local nginx-module-stress cron.