### PR TITLE
docs: sync README badges to ci-fast/ci-deep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 [![Build & Test](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/build-test.yml/badge.svg)](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/build-test.yml)
-[![CodeQL](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/codeql.yml/badge.svg)](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/codeql.yml)
-[![Security Scanners](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/security-scanners.yml/badge.svg)](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/security-scanners.yml)
-[![Fuzzing](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/fuzzing.yml/badge.svg)](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/fuzzing.yml)
-[![Valgrind Memcheck](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/valgrind.yml/badge.svg)](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/valgrind.yml)
+[![CI Fast](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/ci-fast.yml/badge.svg)](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/ci-fast.yml)
+[![CI Deep](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/ci-deep.yml/badge.svg)](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/ci-deep.yml)
 
 📖 **Background reading:** 
 - [zstd nginx module: what it does, bugs fixed](https://deb.myguard.nl/2026/05/zstd-nginx-module-what-it-does-bugs-fixed/)


### PR DESCRIPTION
Swap codeql/security-scanners/fuzzing/valgrind badges for consolidated `ci-fast.yml` + `ci-deep.yml`. README-only.