### PR TITLE
ci: move ci-deep security-scanners to self-hosted lxc runner

### DIFF
--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -221,7 +221,7 @@ jobs:
 
   scanners:
     name: Security scanners
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, builder02, lxc]
     timeout-minutes: 20
     steps:
       - name: Checkout module
@@ -229,8 +229,17 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y flawfinder clang-tidy python3 python3-pip nginx-dev
-          pip3 install --quiet semgrep
+          sudo apt-get install -y flawfinder clang-tidy python3 python3-pip pipx nginx-dev
+          # semgrep: isolate via pipx (PEP 668 blocks a bare pip3 install into the
+          # system Python on the Ubuntu 24.04 self-hosted runner). Fall back to a
+          # user pip install with --break-system-packages if pipx is unavailable.
+          if command -v pipx >/dev/null; then
+            pipx install --quiet semgrep
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          else
+            pip3 install --quiet --user --break-system-packages semgrep
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          fi
       - name: Configure nginx src tree (clang-tidy headers)
         run: |
           set -euo pipefail


### PR DESCRIPTION
Converts the ci-deep `scanners` job to `[self-hosted, builder02, lxc]` and hardens the semgrep install (pipx / --break-system-packages) for the Ubuntu 24.04 runner's PEP 668 managed Python. Verified green on nginx-cache-turbo-module first (ci-deep scanners passed on lxc). Completes the CI-selfhost sweep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated validation setup to use dedicated runners, improving consistency and reliability.
  * Improved tool installation handling so checks can run more smoothly across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->