### PR TITLE
test: window-cap/dict frame-inspection effect test + config-warning coverage

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -592,6 +592,19 @@ jobs:
           if [ "${PIPESTATUS[0]}" -ne 0 ]; then echo "❌ Filter tests FAILED"; exit 1; fi
           echo "✓ Filter module: All tests passed"
 
+      - name: Run config-load warning tests
+        run: |
+          export PERL5LIB="$HOME/perl5/lib/perl5:${PERL5LIB:-}"
+          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-confwarn"
+          mkdir -p "$TEST_NGINX_SERVROOT"
+          cd "$GITHUB_WORKSPACE"
+          # Startup-time warnings (e.g. zstd_bypass_vary without zstd_bypass)
+          # are only observable on the first request cycle, so they live in
+          # their own repeat_each(1) file.
+          perl t/02-conf-warn.t 2>&1 | sed 's/^Error:/Err:/' | tee t/conf-warn-tests.log
+          if [ "${PIPESTATUS[0]}" -ne 0 ]; then echo "❌ Config-warning tests FAILED"; exit 1; fi
+          echo "✓ Config-load warning tests passed"
+
       - name: Run static module tests
         run: |
           export PERL5LIB="$HOME/perl5/lib/perl5:${PERL5LIB:-}"
@@ -721,6 +734,20 @@ jobs:
             --nginx-binary "$TEST_NGINX_BINARY" \
             --port 18102 --backend-port 18103
           echo "✓ zstd_long (LDM) directive regression passed"
+
+      - name: Run window-cap + dictionary effect test
+        timeout-minutes: 6
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          # Frame-inspection effect test: with zstd_dict_file AND
+          # zstd_window_log 15 set, the emitted frame must declare a
+          # window <= 2^15 and reference the trained dictID (audit
+          # C2/R1 CDict-path regression); decode requires the dict and
+          # round-trips byte-exact.
+          python3 tools/test_window_cap.py \
+            --nginx-binary "$TEST_NGINX_BINARY" \
+            --port 18104 --backend-port 18105
+          echo "✓ window-cap + dictionary effect test passed"
 
       - name: Test summary
         if: success()

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -596,6 +596,7 @@ jobs:
         run: |
           export PERL5LIB="$HOME/perl5/lib/perl5:${PERL5LIB:-}"
           export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-confwarn"
+          rm -rf "$TEST_NGINX_SERVROOT"
           mkdir -p "$TEST_NGINX_SERVROOT"
           cd "$GITHUB_WORKSPACE"
           # Startup-time warnings (e.g. zstd_bypass_vary without zstd_bypass)

--- a/t/02-conf-warn.t
+++ b/t/02-conf-warn.t
@@ -1,0 +1,76 @@
+use Test::Nginx::Socket;
+use File::Basename;
+use lib 'lib';
+
+my $dirname = dirname(__FILE__);
+$ENV{'TEST_NGINX_PERL_PATH'}="$ENV{'PWD'}/$dirname";
+
+my @dynamic_modules;
+if (defined $ENV{'TEST_NGINX_BINARY'}) {
+    my $nginx_dir = dirname($ENV{'TEST_NGINX_BINARY'});
+    for my $module_name (qw(ngx_http_zstd_filter_module.so ngx_http_zstd_static_module.so)) {
+        my $module_path = "$nginx_dir/$module_name";
+        push @dynamic_modules, $module_path if -f $module_path;
+    }
+}
+
+add_block_preprocessor(sub {
+    my $block = shift;
+    return if !@dynamic_modules;
+
+    my $main_config = join "\n", map { "load_module $_;" } @dynamic_modules;
+    $block->set_value("main_config", $main_config);
+});
+
+no_long_string();
+log_level 'warn';
+# Config-load warnings are emitted ONCE at startup; with repeat_each > 1
+# the error.log is wiped between repeats and later iterations cannot
+# re-observe them (why these blocks live outside t/00-filter.t).
+repeat_each(1);
+plan 'no_plan';
+run_tests();
+
+__DATA__
+
+
+=== TEST 1: zstd_bypass_vary without zstd_bypass warns at config load
+# zstd_bypass_vary names the header the zstd_bypass decision varies on;
+# set alone it emits a Vary field no response varies on (silent cache
+# hit-rate degradation). merge_loc_conf warns — assert the warning is
+# actually emitted so the misconfig stays visible.
+--- config
+    location /warn {
+        zstd on;
+        zstd_bypass_vary X-No-Compression;
+        default_type text/plain;
+        return 200 "hello world padding padding padding\n";
+    }
+--- request
+GET /warn
+--- more_headers
+Accept-Encoding: zstd
+--- error_log
+"zstd_bypass_vary" is set without a "zstd_bypass" predicate
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: zstd_bypass_vary WITH zstd_bypass does not warn
+# The complementary half: a correctly paired configuration must load
+# silently, so the warning cannot become noise on valid configs.
+--- config
+    location /paired {
+        zstd on;
+        zstd_bypass $http_x_no_compression;
+        zstd_bypass_vary X-No-Compression;
+        default_type text/plain;
+        return 200 "hello world padding padding padding\n";
+    }
+--- request
+GET /paired
+--- more_headers
+Accept-Encoding: zstd
+--- no_error_log eval
+[qr/zstd_bypass_vary.*without/, qr/\[error\]/]

--- a/tools/test_window_cap.py
+++ b/tools/test_window_cap.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Effect test: ``zstd_dict_file`` + ``zstd_window_log`` bound the window.
+
+TEST 38 in t/00-filter.t only proves a window-capped stream still decodes;
+it never inspects the frame, so a silently ignored ``ZSTD_c_windowLog``
+(e.g. a CDict path that resets parameters) would pass it. This test parses
+the RFC 8878 frame header of a response compressed WITH a trained
+dictionary and a ``zstd_window_log 15`` cap and asserts:
+
+1. the frame is not Single_Segment (a chunked body must carry a
+   Window_Descriptor);
+2. the declared window is <= 2^15 bytes — the directive actually reached
+   libzstd on the dictionary code path (audit C2/R1 regression);
+3. the frame references the trained dictionary's real dictID, and only
+   ``zstd -d -D <dict>`` can decode it byte-exact (plain ``zstd -d``
+   must refuse) — the CDict engaged, we did not fall back to dictless
+   compression.
+"""
+
+import argparse
+import http.server
+import pathlib
+import shutil
+import socket
+import socketserver
+import struct
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.request
+
+BODY_SIZE = 1024 * 1024  # >> 2^15 so the cap is load-bearing
+WINDOW_LOG = 15
+
+ZSTD_MAGIC = b"\x28\xb5\x2f\xfd"
+DICT_MAGIC = b"\x37\xa4\x30\xec"
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--nginx-binary", required=True)
+    p.add_argument("--filter-module")
+    p.add_argument("--static-module")
+    p.add_argument("--zstd-bin", default="zstd")
+    p.add_argument("--port", type=int, default=18104)
+    p.add_argument("--backend-port", type=int, default=18105)
+    return p.parse_args()
+
+
+def detect(explicit, nginx: pathlib.Path, name: str):
+    if explicit:
+        return pathlib.Path(explicit)
+    sib = nginx.parent / name
+    return sib if sib.exists() else None
+
+
+def make_payload() -> bytes:
+    """Compressible body: repeated structured records with a counter."""
+    out = bytearray()
+    i = 0
+    while len(out) < BODY_SIZE:
+        out += (b'{"record":%08d,"name":"window-cap-effect-test",'
+                b'"path":"/var/lib/example/data/%04d/blob.bin",'
+                b'"flags":["a","b","c"],"pad":"%s"}\n'
+                % (i, i % 1000, b"x" * (i % 37)))
+        i += 1
+    return bytes(out[:BODY_SIZE])
+
+
+def train_dict(zstd_bin: str, work: pathlib.Path) -> pathlib.Path:
+    """Train a real dictionary (nonzero dictID) on payload-like samples."""
+    samples = work / "samples"
+    samples.mkdir()
+    payload = make_payload()
+    n, step = 64, len(make_payload()) // 64
+    for k in range(n):
+        (samples / f"s{k:03d}").write_bytes(payload[k * step:(k + 1) * step])
+    dict_path = work / "test.dict"
+    r = subprocess.run(
+        [zstd_bin, "--train", *sorted(str(f) for f in samples.iterdir()),
+         "-o", str(dict_path), "--maxdict=16384", "-q"],
+        capture_output=True)
+    if r.returncode != 0 or not dict_path.exists():
+        raise RuntimeError("zstd --train failed: "
+                           + r.stderr.decode("utf-8", "replace"))
+    raw = dict_path.read_bytes()
+    if raw[:4] != DICT_MAGIC:
+        raise RuntimeError("trained dict lacks dictionary magic")
+    return dict_path
+
+
+def dict_id(dict_path: pathlib.Path) -> int:
+    return struct.unpack("<I", dict_path.read_bytes()[4:8])[0]
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    payload = b""
+
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        # Chunked (no Content-Length) so the filter cannot take the
+        # pledged-src-size / Single_Segment path.
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+        mv = memoryview(self.payload)
+        for i in range(0, len(mv), 16384):
+            c = bytes(mv[i:i + 16384])
+            self.wfile.write(b"%X\r\n" % len(c) + c + b"\r\n")
+        self.wfile.write(b"0\r\n\r\n")
+
+
+class _Srv(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+def wait_port(port: int, timeout: float = 10.0) -> None:
+    end = time.time() + timeout
+    while time.time() < end:
+        try:
+            with socket.create_connection(("127.0.0.1", port), 0.5):
+                return
+        except OSError:
+            time.sleep(0.1)
+    raise RuntimeError(f"nothing listening on 127.0.0.1:{port}")
+
+
+def parse_frame_header(blob: bytes):
+    """Return (single_segment, window_size_or_None, dict_id_or_0)."""
+    if blob[:4] != ZSTD_MAGIC:
+        raise RuntimeError(f"no zstd magic (hex={blob[:8].hex()})")
+    fhd = blob[4]
+    did_flag = fhd & 0x03
+    single_segment = bool(fhd & 0x20)
+    pos = 5
+    window = None
+    if not single_segment:
+        wd = blob[pos]
+        pos += 1
+        exp, mantissa = wd >> 3, wd & 7
+        base = 1 << (10 + exp)
+        window = base + (base // 8) * mantissa
+    did_size = (0, 1, 2, 4)[did_flag]
+    did = int.from_bytes(blob[pos:pos + did_size], "little") if did_size else 0
+    return single_segment, window, did
+
+
+def main() -> int:
+    args = parse_args()
+    nginx = pathlib.Path(args.nginx_binary).resolve()
+    mods = [m for m in (
+        detect(args.filter_module, nginx, "ngx_http_zstd_filter_module.so"),
+        detect(args.static_module, nginx, "ngx_http_zstd_static_module.so"),
+    ) if m]
+
+    payload = make_payload()
+    _Handler.payload = payload
+
+    with tempfile.TemporaryDirectory(prefix="zstd-wincap-") as td:
+        root = pathlib.Path(td)
+        logs = root / "logs"
+        logs.mkdir()
+        # nginx -p prefix wants these to exist for temp paths
+        for d in ("client_body_temp", "proxy_temp"):
+            (root / d).mkdir()
+
+        dict_path = train_dict(args.zstd_bin, root)
+        did_expected = dict_id(dict_path)
+        if did_expected == 0:
+            raise RuntimeError("trained dict has dictID 0; cannot assert")
+
+        load = "".join(f"load_module {m};\n" for m in mods)
+        conf = root / "nginx.conf"
+        conf.write_text(f"""{load}worker_processes 1;
+error_log {logs}/error.log warn;
+pid {root}/nginx.pid;
+events {{ worker_connections 64; }}
+http {{
+    access_log off;
+    client_body_temp_path {root}/client_body_temp;
+    proxy_temp_path {root}/proxy_temp;
+    default_type application/octet-stream;
+    zstd on;
+    zstd_comp_level 6;
+    zstd_min_length 1;
+    zstd_types application/octet-stream;
+    zstd_dict_file {dict_path};
+    zstd_dict_file_unsafe on;
+    zstd_window_log {WINDOW_LOG};
+    server {{
+        listen 127.0.0.1:{args.port};
+        location / {{
+            proxy_pass http://127.0.0.1:{args.backend_port}/;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+        }}
+    }}
+}}
+""", encoding="utf-8")
+
+        backend = _Srv(("127.0.0.1", args.backend_port), _Handler)
+        threading.Thread(target=backend.serve_forever, daemon=True).start()
+
+        proc = subprocess.Popen(
+            [str(nginx), "-p", str(root) + "/", "-c", str(conf),
+             "-g", "daemon off;"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+        try:
+            wait_port(args.port)
+
+            req = urllib.request.Request(
+                f"http://127.0.0.1:{args.port}/blob",
+                headers={"Accept-Encoding": "zstd",
+                         "User-Agent": "zstd-wincap/1.0"})
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                ce = (resp.headers.get("Content-Encoding") or "").lower()
+                if ce != "zstd":
+                    raise RuntimeError(f"not zstd-encoded (C-E={ce!r})")
+                blob = resp.read()
+
+            single, window, did = parse_frame_header(blob)
+
+            if single:
+                raise RuntimeError(
+                    "frame is Single_Segment: no Window_Descriptor, the "
+                    "window equals the full content size — cap not applied")
+            cap = 1 << WINDOW_LOG
+            if window > cap:
+                raise RuntimeError(
+                    f"declared window {window} exceeds zstd_window_log "
+                    f"cap {cap} — directive ignored on the dict path")
+            if did != did_expected:
+                raise RuntimeError(
+                    f"frame dictID {did} != trained dict {did_expected} — "
+                    "CDict not engaged")
+
+            # Dictless decode must refuse (frame demands the dict) ...
+            r = subprocess.run([args.zstd_bin, "-dq", "-c"], input=blob,
+                               capture_output=True)
+            if r.returncode == 0:
+                raise RuntimeError("decoded WITHOUT the dictionary — "
+                                   "dict not actually load-bearing")
+            # ... and dict-aware decode must round-trip byte-exact.
+            r = subprocess.run(
+                [args.zstd_bin, "-dq", "-c", "-D", str(dict_path)],
+                input=blob, capture_output=True)
+            if r.returncode != 0:
+                raise RuntimeError("zstd -d -D failed: "
+                                   + r.stderr.decode("utf-8", "replace"))
+            if r.stdout != payload:
+                raise RuntimeError("dict decode not byte-exact")
+
+            print(f"✓ window {window} <= {cap} (log {WINDOW_LOG}), "
+                  f"dictID {did} engaged, {len(blob)} compressed bytes "
+                  f"round-trip {len(payload)} exactly")
+            return 0
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            backend.shutdown()
+            err = (logs / "error.log")
+            if err.exists():
+                tail = err.read_text(errors="replace").strip()
+                if "[error]" in tail or "[crit]" in tail:
+                    print("error.log tail:\n" + tail[-2000:], file=sys.stderr)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:
+        print(f"FAIL: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/tools/test_window_cap.py
+++ b/tools/test_window_cap.py
@@ -134,6 +134,9 @@ def wait_port(port: int, timeout: float = 10.0) -> None:
 
 def parse_frame_header(blob: bytes):
     """Return (single_segment, window_size_or_None, dict_id_or_0)."""
+    if len(blob) < 10:
+        raise RuntimeError(f"truncated response: {len(blob)} bytes is too "
+                           "short for a zstd frame header")
     if blob[:4] != ZSTD_MAGIC:
         raise RuntimeError(f"no zstd magic (hex={blob[:8].hex()})")
     fhd = blob[4]


### PR DESCRIPTION
Closes three carried TODO effect-test items:

- **tools/test_window_cap.py** — frame-inspection effect test: with `zstd_dict_file` + `zstd_window_log 15`, the emitted RFC 8878 frame must not be Single_Segment, must declare a window <= 2^15, must reference the trained dictID; dictless decode must refuse and dict-aware decode round-trips byte-exact. Regression for the CDict-path parameter handling (audit C2/R1).
- **t/02-conf-warn.t** — asserts the `zstd_bypass_vary`-without-`zstd_bypass` config-load warning fires, and the correctly paired config stays silent. Separate repeat_each(1) file because startup warnings are wiped from error.log after the first repeat.
- **build-test.yml** — both wired into the tests job (ports 18104/18105, unique).

**Lying known-Content-Length overrun test investigated and NOT added:** nginx's upstream input layer truncates the body at the declared Content-Length, so the overrun never reaches the filter via any stock proxy path (verified with a raw TCP mock declaring CL 50 and streaming 5000 bytes — zero filter aborts). The body-phase running-total check for known-length responses is defense-in-depth; the reachable chunked half is already covered by TEST 42.

All new tests pass locally against the prebuilt ASAN nginx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coverage for zstd configuration warnings so invalid compression settings are more reliably detected during testing.
  * Added an end-to-end check for compressed responses using trained dictionaries and window-size limits.

* **Tests**
  * Expanded automated checks in the test pipeline with two new validation steps for compression-related behavior.
  * Improved confidence in response compression handling, especially around warning messages and dictionary-based encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->