### PR TITLE
ci: split PR gates into fuzzing, valgrind, security-scanners workflows

### DIFF
--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -1,8 +1,10 @@
 name: CI Deep
 
 # Exhaustive dynamic analysis — monthly cron + on-demand only, NEVER on PR.
-# Consolidates the old fuzzing.yml + valgrind.yml + helgrind.yml +
-# security-scanners.yml into one workflow. codeql.yml is dropped entirely:
+# The fast PR-time gates live in standalone workflows: fuzzing.yml (120s fuzz
+# regression), valgrind.yml (60s memcheck-lite soak) and security-scanners.yml
+# (scanners) run on every PR/push; THIS file stays the exhaustive monthly +
+# workflow_dispatch run. codeql.yml is dropped entirely:
 # CodeQL / the GitHub Security tab is GitHub-Advanced-Security only and does
 # nothing on a private repo, so the SARIF-upload path is removed too — the
 # scanners still run and GATE on findings, they just don't upload.

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,0 +1,68 @@
+name: Fuzzing
+
+# Fast fuzz regression gate on every PR/push — 120s libFuzzer run on the
+# Accept-Encoding target so PR feedback stays quick. The long (hours) fuzz
+# run lives in ci-deep.yml (monthly cron + workflow_dispatch).
+#
+# Action pins (keep in sync with build-test.yml header):
+# actions/checkout@v5        -> 93cb6efe18208431cddfb8368fd83d5badbf9bfd
+# actions/upload-artifact@v5 -> 330a01c490aca151604b8cf639adc76d48f6c5d4
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  NGINX_VERSION: ""
+
+on:
+  push:
+    branches: [master, main, dev]
+  pull_request:
+    branches: [master, main]
+  workflow_dispatch: {}
+
+concurrency:
+  group: fuzzing-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz-regression:
+    name: Fuzz regression (120s)
+    runs-on: [self-hosted, builder02, lxc]
+    timeout-minutes: 30
+    steps:
+      - name: Checkout module
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Install clang + libFuzzer
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang
+
+      - name: Build fuzz target
+        run: bash fuzz/build.sh "$GITHUB_WORKSPACE/fuzz/fuzz_accept_encoding"
+
+      - name: Run fuzzer (120s regression)
+        run: |
+          set -euo pipefail
+          cd fuzz
+          set +e
+          ./fuzz_accept_encoding \
+            -max_total_time=120 \
+            -dict=fuzz.dict \
+            -print_final_stats=1 \
+            -artifact_prefix=crash- \
+            corpus/
+          rc=$?
+          set -e
+          [ $rc -eq 0 ] || { echo "❌ fuzzer crash (exit $rc)"; exit 1; }
+          echo "✓ no crashes in 120s"
+
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
+          name: fuzz-fast-crashes
+          path: ${{ github.workspace }}/fuzz/crash-*
+          retention-days: 14

--- a/.github/workflows/security-scanners.yml
+++ b/.github/workflows/security-scanners.yml
@@ -1,0 +1,95 @@
+name: Security scanners
+
+# Static/security scanners gate on every PR/push — flawfinder, clang-tidy
+# (cert-* / clang-analyzer-security.*) and semgrep over the module sources,
+# with the reports uploaded as build artifacts.
+#
+# Action pins (keep in sync with build-test.yml header):
+# actions/checkout@v5        -> 93cb6efe18208431cddfb8368fd83d5badbf9bfd
+# actions/upload-artifact@v5 -> 330a01c490aca151604b8cf639adc76d48f6c5d4
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+on:
+  push:
+    branches: [master, main, dev]
+  pull_request:
+    branches: [master, main]
+  workflow_dispatch: {}
+
+concurrency:
+  group: security-scanners-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scanners:
+    name: Security scanners
+    runs-on: [self-hosted, builder02, lxc]
+    timeout-minutes: 20
+    steps:
+      - name: Checkout module
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flawfinder clang-tidy python3 python3-pip pipx nginx-dev
+          # semgrep: isolate via pipx (PEP 668 blocks a bare pip3 install into the
+          # system Python on the Ubuntu 24.04 self-hosted runner). Fall back to a
+          # user pip install with --break-system-packages if pipx is unavailable.
+          if command -v pipx >/dev/null; then
+            pipx install --quiet semgrep
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          else
+            pip3 install --quiet --user --break-system-packages semgrep
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          fi
+      - name: Configure nginx src tree (clang-tidy headers)
+        run: |
+          set -euo pipefail
+          ver=$(curl -fsSL https://nginx.org/en/download.html \
+            | grep -oP 'nginx-\K[0-9]+\.[0-9]+\.[0-9]+(?=\.tar\.gz)' | sort -V | tail -1)
+          wget -q "https://nginx.org/download/nginx-${ver}.tar.gz"
+          tar -xzf "nginx-${ver}.tar.gz"; cd "nginx-${ver}"
+          CC=gcc ./configure --with-compat --add-dynamic-module="$GITHUB_WORKSPACE" >/dev/null
+          echo "NGINX_SRC_TREE=$PWD" >> "$GITHUB_ENV"
+      - name: flawfinder
+        run: |
+          flawfinder --minlevel=1 \
+            "$GITHUB_WORKSPACE/filter/ngx_http_zstd_filter_module.c" \
+            "$GITHUB_WORKSPACE/static/ngx_http_zstd_static_module.c" 2>&1 | tee flawfinder.log
+      - name: clang-tidy (cert-*, security.*)
+        run: |
+          set -euo pipefail
+          N="$NGINX_SRC_TREE"
+          INCLUDES="-I$N/src/core -I$N/src/event -I$N/src/event/modules -I$N/src/event/quic \
+            -I$N/src/os/unix -I$N/objs -I$N/src/http -I$N/src/http/modules -I$N/src/http/v2 -I/usr/include"
+          status=0
+          for f in \
+            "$GITHUB_WORKSPACE/filter/ngx_http_zstd_filter_module.c" \
+            "$GITHUB_WORKSPACE/static/ngx_http_zstd_static_module.c"; do
+            # shellcheck disable=SC2086,SC2046
+            clang-tidy "$f" \
+              --checks='-*,cert-*,clang-analyzer-security.*,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling' \
+              --warnings-as-errors='*' \
+              -- -DZSTD_STATIC_LINKING_ONLY $INCLUDES $(pkg-config --cflags libzstd) \
+              2>&1 | tee -a clang-tidy.log || status=1
+          done
+          exit "$status"
+      - name: semgrep
+        run: |
+          semgrep scan --config p/c --config p/security-audit \
+            "$GITHUB_WORKSPACE/filter/" "$GITHUB_WORKSPACE/static/" 2>&1 | tee semgrep.log || true
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
+          name: security-reports
+          path: |
+            ${{ github.workspace }}/flawfinder.log
+            ${{ github.workspace }}/clang-tidy.log
+            ${{ github.workspace }}/semgrep.log
+          retention-days: 14

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -1,17 +1,11 @@
-name: CI Fast
+name: Valgrind
 
-# Fast dynamic analysis on every PR/push — kept short so PR feedback stays
-# quick. build-test.yml already does the full build + ASan/UBSan unit/soak
-# matrix; THIS file adds only the two cheap dynamic gates:
-#   fuzz-regression : 120s on the Accept-Encoding target, only when the parser
-#                     or the fuzz harness changed (path-filtered on PRs)
-#   memcheck-lite   : 60s valgrind memcheck soak (helgrind is deep-only)
-# Long discovery (hours fuzz, full memcheck+helgrind soak, scanners) lives in
-# ci-deep.yml (monthly cron + workflow_dispatch).
+# Valgrind memcheck-lite soak on every PR/push — 60s soak against a debug
+# nginx build so PR feedback stays quick. The full memcheck + helgrind soak
+# lives in ci-deep.yml (monthly cron + workflow_dispatch).
 #
 # Action pins (keep in sync with build-test.yml header):
 # actions/checkout@v5        -> 93cb6efe18208431cddfb8368fd83d5badbf9bfd
-# actions/upload-artifact@v5 -> 330a01c490aca151604b8cf639adc76d48f6c5d4
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -25,53 +19,13 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: ci-fast-${{ github.workflow }}-${{ github.ref }}
+  group: valgrind-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
-  fuzz-regression:
-    name: Fuzz regression (120s)
-    runs-on: [self-hosted, builder02, lxc]
-    timeout-minutes: 30
-    steps:
-      - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-
-      - name: Install clang + libFuzzer
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang
-
-      - name: Build fuzz target
-        run: bash fuzz/build.sh "$GITHUB_WORKSPACE/fuzz/fuzz_accept_encoding"
-
-      - name: Run fuzzer (120s regression)
-        run: |
-          set -euo pipefail
-          cd fuzz
-          set +e
-          ./fuzz_accept_encoding \
-            -max_total_time=120 \
-            -dict=fuzz.dict \
-            -print_final_stats=1 \
-            -artifact_prefix=crash- \
-            corpus/
-          rc=$?
-          set -e
-          [ $rc -eq 0 ] || { echo "❌ fuzzer crash (exit $rc)"; exit 1; }
-          echo "✓ no crashes in 120s"
-
-      - name: Upload crash artifacts
-        if: failure()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
-        with:
-          name: fuzz-fast-crashes
-          path: ${{ github.workspace }}/fuzz/crash-*
-          retention-days: 14
-
   memcheck-lite:
     name: Memcheck lite (60s soak)
     runs-on: [self-hosted, builder02, lxc]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,131 @@
+# Contributing
+
+Thank you for contributing — genuinely. Small modules like this live or die
+on people who show up with a patch, a bug report, or an awkward question.
+You are welcome here.
+
+That said: this document is not decoration. Every rule below exists because
+someone (usually us) broke something in a way that took a weekend to clean
+up. Read it once before your first PR and you will save us both a round
+trip. Break the rules and CI will catch you anyway — the robots are
+patient, but they do not negotiate.
+
+If anything here is unclear, **ask**. Asking early is a sign you're doing it
+right, not that you're slow. Open an issue, open a draft PR, or mail
+**github@myguard.nl**. We answer, and we mentor — everyone who works on
+this code started by not knowing nginx internals either.
+
+## TL;DR checklist
+
+- [ ] One feature or fix per PR — no stacked PRs, no drive-by refactors.
+- [ ] Code follows nginx style and matches the code around it.
+- [ ] Every new feature or bugfix ships a test in the same PR.
+- [ ] README updated in the same PR if behaviour changed.
+- [ ] All CI checks green. No skipping, no "it works on my machine".
+- [ ] Commit messages: imperative subject, body explains *why*.
+      No AI co-author trailers.
+
+## How CI works here
+
+Every push and every PR runs four short gates. They exist to catch the
+classes of bugs that C code in a web server cannot afford:
+
+- **Build & Test** — builds the module against current nginx (and, where
+  applicable, Angie) and runs the unit tests under **ASan/UBSan**.
+  AddressSanitizer and UndefinedBehaviorSanitizer are compiler
+  instrumentation that make memory bugs (use-after-free, buffer overflows,
+  signed overflow) crash loudly at the exact line instead of corrupting
+  memory silently. If ASan complains, the bug is real — fix it, don't
+  suppress it.
+- **Security scanners** (`security-scanners.yml`) — flawfinder, clang-tidy
+  (`cert-*`, `clang-analyzer-security.*`) and semgrep over the module
+  sources. Static analysis: it reads the code without running it and
+  flags dangerous patterns.
+- **Fuzzing** (`fuzzing.yml`) — a ~120-second libFuzzer regression run over
+  the module's input parsers. Fuzzing feeds a parser millions of mutated
+  inputs and watches for crashes. Short on PRs so feedback stays fast.
+- **Valgrind** (`valgrind.yml`) — a short Memcheck soak. Valgrind executes
+  the code in an emulated CPU and reports every invalid read/write and
+  every leaked byte.
+
+The expensive versions of these — hours-long fuzzing per target, full
+Memcheck **and** Helgrind (thread-race detection) soaks — run monthly and
+on manual dispatch in `ci-deep.yml`, not on your PR. Some modules also run
+an extra runtime test suite; check the repo's `.github/workflows/` and the
+badges at the top of the README for the exact set.
+
+Your PR merges when **all** checks are green. If a gate fails and you
+believe the gate is wrong, say so in the PR — with evidence, not vibes.
+
+Before pushing a parser or fuzz-harness change, fuzz locally first:
+`fuzz/build.sh` compiles every `fuzz/fuzz_*.c` with `-Werror`, so a stale
+harness signature fails right there instead of in CI.
+
+## Coding conventions
+
+- **nginx style.** This is an nginx module: follow the
+  [nginx style guide](https://nginx.org/en/docs/dev/development_guide.html#code_style)
+  — 4-space indents, `ngx_` types (`ngx_int_t`, `ngx_str_t`, …), K&R-ish
+  bracing as used by nginx core, `/* comments */`.
+- **Match the surrounding code.** When in doubt, the file you are editing
+  is the style guide. A patch that reads like the code around it is a
+  patch we can review quickly.
+- **Memory comes from pools.** Allocate from the request/config pool
+  (`ngx_palloc`) unless you have a documented reason not to. If you
+  `malloc`, you own the cleanup handler.
+- **Handle every error path.** nginx runs for months; "can't happen"
+  happens. Check return values, log with `ngx_log_error`, fail closed.
+- **Comments explain *why*, not *what*.** A surprising nginx-internals
+  fact, a footgun, a rejected alternative — write it down at the call
+  site or in the README. No undocumented behaviour ships.
+
+## Tests
+
+Every function and every feature gets a test **in the same PR** that adds
+it. Not a follow-up PR. Not "later". Same PR.
+
+- New parser or handler → a unit or runtime test exercising it, including
+  the ugly inputs (empty, oversized, malformed, truncated).
+- Bug fix → a regression test that **fails before the fix and passes
+  after**. That's the proof the test actually tests something.
+- New input parser → a libFuzzer target in `fuzz/`.
+
+Where tests live varies slightly per module (unit suites, `t/*.t`
+Test::Nginx files, runtime suites under `tools/`) — look at the existing
+tests in this repo and put yours next to them. A PR that adds code without
+a test will not be merged, and yes, we check.
+
+## Pull requests
+
+- **One feature or issue per PR.** The title says what it does. If a PR
+  grows a second concern, split it.
+- **No stacked PRs.** Every PR branches from and targets the default
+  branch independently. Stacks fall over the moment PR #1 gets review
+  changes, and untangling them costs more than the stacking saved.
+- **Open an issue first** for anything non-trivial; the PR references it
+  (`Closes #N`).
+- **Keep it reviewable in one sitting.** Small PRs merge fast; 2000-line
+  PRs grow moss while we find an afternoon to do them justice.
+- **Update the README in the same PR** when behaviour, directives, or
+  defaults change. The README must never lag the default branch.
+- The default branch is protected by convention: changes land via PR with
+  green CI, not direct push.
+
+## Commits
+
+- Imperative subject line ("add X", "fix Y"), ≤ 72 chars.
+- Body explains *why* — the design choice made and what was rejected.
+- No AI co-author trailers. None.
+
+## Ask for help
+
+Stuck on nginx internals? Not sure where a test belongs? Fuzzer output
+looks like hieroglyphics? Ask. Open a draft PR with what you have and say
+what you're unsure about — a draft PR full of questions is a perfectly
+good contribution. We would much rather spend ten minutes pointing you in
+the right direction than review a week of effort aimed at the wrong wall.
+
+## Contact
+
+Questions, security reports, or anything that doesn't fit an issue:
+**github@myguard.nl**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Build & Test](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/build-test.yml/badge.svg)](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/build-test.yml)
-[![CI Fast](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/ci-fast.yml/badge.svg)](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/ci-fast.yml)
+[![Security scanners](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/security-scanners.yml/badge.svg)](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/security-scanners.yml)
+[![Fuzzing](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/fuzzing.yml/badge.svg)](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/fuzzing.yml)
+[![Valgrind](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/valgrind.yml/badge.svg)](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/valgrind.yml)
 [![CI Deep](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/ci-deep.yml/badge.svg)](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/ci-deep.yml)
 
 📖 **Background reading:** 
@@ -10,7 +12,7 @@
 
 An nginx module for [Zstandard (zstd)](https://facebook.github.io/zstd/) compression. Zstandard typically achieves better compression ratios than gzip at comparable or faster speeds, making it a good choice for reducing transmitted response sizes.
 
-This is a hardened fork: every build is exercised against **nginx mainline and [Angie](https://angie.software/)**, the full test suite runs under **ASAN/UBSAN**, the `Accept-Encoding` parser is **continuously fuzzed**, and **CodeQL** plus flawfinder/semgrep/clang-tidy run on every change (see the badges above and [Testing & CI](#testing--ci)).
+This is a hardened fork: every build is exercised against **nginx mainline and [Angie](https://angie.software/)**, the full test suite runs under **ASAN/UBSAN**, the `Accept-Encoding` parser is **continuously fuzzed**, and flawfinder/semgrep/clang-tidy run on every change (see the badges above and [Testing & CI](#testing--ci)).
 
 # Table of Contents
 
@@ -840,16 +842,16 @@ log_format zstd '$request in=$zstd_bytes_in out=$zstd_bytes_out '
 
 # Testing & CI
 
-Five workflows guard every change (badges at the top); their cadence
-differs so PR feedback stays fast:
+Five workflows guard the module (badges at the top): four gate every
+push & PR, and CI Deep runs the exhaustive monthly pass:
 
 | Workflow | Cadence | What it does |
 |---|---|---|
 | **Build & Test** | every push & PR | Compiles the module against **nginx 1.31.0 mainline** and **Angie 1.11.5** with strict `-Werror` flags, then runs the full test suite: 46 `Test::Nginx::Socket` filter tests, 21 static-module tests, and end-to-end Python smoke tests (truncation, `Vary`, boundary sizes, repeated/concurrent requests, terminal-frame, the proxy-unbuffered and compression-matrix regressions, per-request CCtx isolation, reload-under-load, `zstd_long`/LDM, `$zstd_ratio`). A separate matrix entry rebuilds against **libzstd 1.4.x** (from source) to exercise the `< 1.5.6` and `≥ 1.4.0` fallback paths, and a parallel job rebuilds with **ASAN+UBSAN** and re-runs the smoke tests plus a `zstd_dict_file` config-reload leak check. A 10-minute mixed-load soak under ASAN+UBSAN runs on the weekly schedule. |
-| **CodeQL** | every push & PR + weekly | GitHub's `security-extended` C/C++ analysis against a real module build. |
-| **Security Scanners** | every push & PR + weekly | flawfinder, clang-tidy (`cert-*`, `bugprone-*`), and semgrep, with results uploaded as SARIF to the Security tab. |
-| **Fuzzing** | nightly + PRs touching the parser | A libFuzzer harness for the `ngx_http_zstd_accept_encoding()` / `ngx_http_zstd_eval_qvalue()` RFC 9110 `Accept-Encoding`/q-value parser. The fuzz target is sliced from the shipped header at build time, so there is no copy drift. See [`fuzz/README.md`](fuzz/README.md). |
-| **Valgrind Memcheck** | monthly + manual dispatch | A full Memcheck soak with `--track-origins=yes`, catching uninitialised-value reads and leaks that ASAN cannot. Monthly because a valgrind soak is ~20–50× slower than native. |
+| **Security scanners** | every push & PR | flawfinder, clang-tidy (`cert-*`, `clang-analyzer-security.*`), and semgrep, with the reports uploaded as build artifacts. |
+| **Fuzzing** | every push & PR | A 120-second libFuzzer regression run for the `ngx_http_zstd_accept_encoding()` / `ngx_http_zstd_eval_qvalue()` RFC 9110 `Accept-Encoding`/q-value parser. The fuzz target is sliced from the shipped header at build time, so there is no copy drift. See [`fuzz/README.md`](fuzz/README.md). |
+| **Valgrind** | every push & PR | A 60-second Memcheck-lite soak against a debug nginx build, catching uninitialised-value reads and leaks that ASAN cannot. |
+| **CI Deep** | monthly + manual dispatch | The exhaustive run: hours-long fuzzing on the same target, full Memcheck and Helgrind soaks (a valgrind soak is ~20–50× slower than native), and the same security scanners. |
 
 The test suite includes a dedicated regression test for every known
 historical bug class:


### PR DESCRIPTION
Split the PR-time CI gates out of the consolidated `ci-fast.yml` into three standalone workflows so each gate gets its own badge, concurrency group, and pass/fail signal:

- **`.github/workflows/fuzzing.yml`** — the `fuzz-regression` job (120s libFuzzer run on the Accept-Encoding target) copied verbatim from `ci-fast.yml`; runs on every PR/push. Long fuzzing stays in `ci-deep.yml`.
- **`.github/workflows/valgrind.yml`** — the `memcheck-lite` job (60s valgrind soak against a debug nginx build) copied verbatim from `ci-fast.yml`; runs on every PR/push. Full memcheck + helgrind soaks stay in `ci-deep.yml`.
- **`.github/workflows/security-scanners.yml`** — the `scanners` job (flawfinder, clang-tidy `cert-*`/`clang-analyzer-security.*`, semgrep) copied verbatim from `ci-deep.yml`, now also gating every PR/push.
- **`ci-fast.yml` deleted** — nothing left in it.
- **`ci-deep.yml`** — jobs untouched; only the stale header comment rewritten to describe the new layout (PR gates in fuzzing/valgrind/security-scanners; ci-deep remains the exhaustive monthly + dispatch run).
- **README** — `CI Fast` badge replaced by Security scanners / Fuzzing / Valgrind badges, and the Testing & CI table updated to match the actual workflow layout (it still described the pre-consolidation CodeQL/SARIF/nightly setup).

All jobs kept verbatim (steps, runners, timeouts, action pins). All workflow YAML validated with PyYAML.