### PR TITLE
ci: ci-deep fuzz 14400s -> 3600s, stagger monthly cron

### DIFF
--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -24,14 +24,15 @@ env:
 
 on:
   schedule:
-    # Monthly, 1st @ 03:30 UTC.
+    # Monthly, day 1 @ 03:30 UTC — staggered per repo so ci-deep runs
+    # don't pile up on the shared self-hosted runners.
     - cron: "30 3 1 * *"
   workflow_dispatch:
     inputs:
       fuzz_seconds:
         description: "Per-target fuzz duration (seconds)"
         required: false
-        default: "14400"
+        default: "3600"
 
 concurrency:
   group: ci-deep-${{ github.workflow }}-${{ github.ref }}
@@ -59,7 +60,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "FUZZ_SECS=${{ github.event.inputs.fuzz_seconds }}" >> "$GITHUB_ENV"
           else
-            echo "FUZZ_SECS=14400" >> "$GITHUB_ENV"
+            echo "FUZZ_SECS=3600" >> "$GITHUB_ENV"
           fi
 
       - name: Build fuzz target


### PR DESCRIPTION
Per-target libFuzzer time 14400s -> 3600s (dispatch default + monthly fallback). The committed corpora are already coverage-saturated for these small parsers; hours 2-4 add almost nothing while hogging the shared self-hosted runners. Long-term depth comes from the persisted corpus, not single-run duration.

Monthly cron staggered per repo (this repo: day 1 @ 03:30 UTC) so the seven ci-deep runs stop landing on the runner pool simultaneously (zstd=1 autocert=2 strip=3 error-abuse=4 cache-turbo=5 sentinel=6 label=7).

Workflow-only change.