### PR TITLE
soak: dump valgrind error logs + gen-suppressions on failure

### DIFF
--- a/tools/soak.sh
+++ b/tools/soak.sh
@@ -71,14 +71,14 @@ if [ "${USE_VALGRIND:-0}" = "1" ]; then
     SUPP="$(cd "$(dirname "$0")/.." && pwd)/valgrind.suppress"
     RUN=(valgrind --error-exitcode=99 --leak-check=full
          --errors-for-leak-kinds=definite
-         --suppressions="$SUPP" --log-file="$WORK/logs/valgrind.%p"
+         --suppressions="$SUPP" --gen-suppressions=all --log-file="$WORK/logs/valgrind.%p"
          "${RUN[@]}")
 elif [ "${USE_HELGRIND:-0}" = "1" ]; then
     # Data-race / lock-order checking under helgrind (thread pool + any
     # shared state). Reuses the same suppression file.
     SUPP="$(cd "$(dirname "$0")/.." && pwd)/valgrind.suppress"
     RUN=(valgrind --tool=helgrind --error-exitcode=99
-         --suppressions="$SUPP" --log-file="$WORK/logs/helgrind.%p"
+         --suppressions="$SUPP" --gen-suppressions=all --log-file="$WORK/logs/helgrind.%p"
          "${RUN[@]}")
 fi
 
@@ -134,6 +134,16 @@ if ls "$WORK"/logs/valgrind.* "$WORK"/logs/helgrind.* >/dev/null 2>&1; then
         echo "FAIL: valgrind/helgrind errors:"
         grep -E 'ERROR SUMMARY|definitely lost' \
             "$WORK"/logs/valgrind.* "$WORK"/logs/helgrind.* 2>/dev/null
+        # Dump every log holding errors in full: the WORK dir is wiped on
+        # exit, so this is the only place the stacks (and the exact
+        # suppression blocks from --gen-suppressions=all) survive, e.g.
+        # in a CI job log.
+        for _vglog in "$WORK"/logs/valgrind.* "$WORK"/logs/helgrind.*; do
+            [ -f "$_vglog" ] || continue
+            grep -qE 'ERROR SUMMARY: [1-9]|definitely lost: [1-9]' "$_vglog" || continue
+            echo "---- $_vglog ----"
+            cat "$_vglog"
+        done
         problems=1
     fi
 fi


### PR DESCRIPTION
The soak WORK dir is wiped on exit, so a CI valgrind/helgrind failure only showed ERROR SUMMARY lines — stacks lost (bit sentinel in ci-deep run 28830331261: `suppressed: 0 from 0` remotely while the suppression matches locally, undiagnosable without stacks).

- On failure, `cat` every valgrind/helgrind log holding errors before cleanup.
- Run both tools with `--gen-suppressions=all` so the exact suppression block for each error appears in the job log. Same fix as sentinel #42.