### PR TITLE
fix(static): add missing enum sentinel to ngx_http_zstd_static[]

### DIFF
--- a/static/ngx_http_zstd_static_module.c
+++ b/static/ngx_http_zstd_static_module.c
@@ -32,6 +32,7 @@ static ngx_conf_enum_t  ngx_http_zstd_static[] = {
     { ngx_string("off"), NGX_HTTP_ZSTD_STATIC_OFF },
     { ngx_string("on"), NGX_HTTP_ZSTD_STATIC_ON },
     { ngx_string("always"), NGX_HTTP_ZSTD_STATIC_ALWAYS },
+    { ngx_null_string, 0 }
 };
 
 

--- a/t/02-conf-warn.t
+++ b/t/02-conf-warn.t
@@ -74,3 +74,41 @@ GET /paired
 Accept-Encoding: zstd
 --- no_error_log eval
 [qr/zstd_bypass_vary.*without/, qr/\[error\]/]
+
+
+
+=== TEST 3: zstd_static rejects an invalid enum value cleanly
+# Regression for the missing ngx_null_string sentinel in the
+# ngx_http_zstd_static[] ngx_conf_enum_t array. ngx_conf_set_enum_slot()
+# scans until name.len == 0; without the terminating { ngx_null_string, 0 }
+# an unmatched value walked off the array end (OOB read, wild-pointer
+# ngx_strcasecmp -> possible crash / ASAN abort). With the sentinel an
+# unknown value is a clean "invalid value" config error. The ASAN CI job
+# runs this binary, so a re-introduced OOB read aborts here.
+--- config
+    location /bad {
+        zstd_static maybe;
+        root html;
+    }
+--- must_die
+--- error_log
+invalid value "maybe"
+--- no_error_log
+[alert]
+
+
+
+=== TEST 4: zstd_static accepts the last valid enum value ("always")
+# Positive counterpart: the sentinel must not shorten the valid range.
+# "always" is the final real entry, immediately before the sentinel — it
+# still parses and loads.
+--- config
+    location /ok {
+        zstd_static always;
+        root html;
+    }
+--- request
+GET /ok/nope
+--- error_code: 404
+--- no_error_log
+invalid value


### PR DESCRIPTION
BLOCKER from module audit.

## Problem
`ngx_http_zstd_static[]` (the `off`/`on`/`always` `ngx_conf_enum_t` array) is missing the terminating `{ ngx_null_string, 0 }` sentinel. `ngx_conf_set_enum_slot()` scans with `for (i = 0; e[i].name.len != 0; i++)`, so an unmatched value such as `zstd_static maybe;` walks off the array end — an **out-of-bounds read**, after which `ngx_strcasecmp()` dereferences a wild pointer (possible crash / ASAN abort at config load).

## Fix
Add the sentinel. Every stock nginx enum carries it. Unknown values now produce a clean `invalid value` config error.

## Tests
- `t/02-conf-warn.t` TEST 3 — `zstd_static maybe;` -> `must_die` with `invalid value "maybe"` (the ASAN CI job aborts here if the OOB read returns).
- TEST 4 — `always` (last real entry) still parses/loads.

Local: `prove t/02-conf-warn.t` = 11/11 PASS.