### PR TITLE
ci: add F5 signer key "arut" to nginx PGP verification list

### DIFF
--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -70,7 +70,7 @@ wget -q "https://nginx.org/download/${tarball}.asc" -O "${tarball}.asc"
 gnupghome="$(mktemp -d)"
 export GNUPGHOME="$gnupghome"
 chmod 700 "$gnupghome"
-for key in nginx_signing mdounin maxim sb thresh pluknet; do
+for key in nginx_signing mdounin maxim sb thresh pluknet arut; do
     wget -q "https://nginx.org/keys/${key}.key" -O - 2>/dev/null \
         | gpg --quiet --import 2>/dev/null || true
 done


### PR DESCRIPTION
MINOR (infra) found during audit-fix validation.

## Problem
`tools/ci-build.sh` imports nginx release-signing keys before verifying the source tarball’s detached PGP signature. Current nginx releases (1.31.2 tested) are signed by **Roman Arutyunyan `<r.arutyunyan@f5.com>`**, RSA key `43387825DDB1BB97EC36BA5D007C8D7C15D87369` (the F5-era signer). That key was **missing** from the import loop, so `gpg --verify` had no matching key → verification failed → `ci-build.sh` exited before any build.

## Fix
Add `arut` (served at `https://nginx.org/keys/arut.key`) to the loop.

Verified locally: importing `arut.key` and checking `nginx-1.31.2.tar.gz.asc` →
```
gpg: Good signature from "Roman Arutyunyan <r.arutyunyan@f5.com>"
Primary key fingerprint: 4338 7825 DDB1 BB97 EC36  BA5D 007C 8D7C 15D8 7369
```
The loop tolerates missing keys (`|| true`), so this stays safe as signers rotate.