### PR TITLE
ci(codeql): anchor nginx-* paths-ignore glob

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -82,7 +82,7 @@ jobs:
             *.c
             *.h
           paths-ignore: |
-            nginx-*
+            nginx-*/**
 
       - name: Build module sources for CodeQL
         run: |


### PR DESCRIPTION
Bare `nginx-*` matched only the extracted dir entry, not files under it, so CodeQL kept re-flagging vendored nginx core source on every version bump (alerts #16-20, previously dismissed at #5-9). Anchor with `/**` so the whole extracted `nginx-<ver>/` tree is excluded, leaving only module code (filter/ static/).

Verified by: CodeQL check on this PR should report 0 alerts in nginx core.