### PR TITLE
test: fix false-positive corruption in reload-under-load harness

### DIFF
--- a/tools/test_reload_under_load.py
+++ b/tools/test_reload_under_load.py
@@ -128,7 +128,7 @@ def wait_port(port: int, timeout: float = 10.0) -> None:
     raise RuntimeError(f"nothing listening on 127.0.0.1:{port}")
 
 
-def one(port: int, rid: int, zstd_bin: str) -> None:
+def one(port: int, rid: int, zstd_bin: str, dict_path: pathlib.Path) -> None:
     req = urllib.request.Request(
         f"http://127.0.0.1:{port}/r/{rid}",
         headers={"Accept-Encoding": "zstd",
@@ -141,8 +141,14 @@ def one(port: int, rid: int, zstd_bin: str) -> None:
         blob = resp.read()
     if blob[:4] != b"\x28\xb5\x2f\xfd":
         raise RuntimeError(f"rid={rid}: no zstd magic")
-    r = subprocess.run([zstd_bin, "-dq", "-c"], input=blob,
-                       capture_output=True)
+    # nginx.conf below sets zstd_dict_file, so every response is compressed
+    # against that dictionary (ZSTD_CCtx_refCDict in the filter module) --
+    # the decoder needs the same dictionary via -D, or libzstd correctly
+    # rejects the frame as "Data corruption detected" even though nothing is
+    # actually corrupt. Omitting -D here previously made this test fail on
+    # every run regardless of reload timing (any response, any size).
+    r = subprocess.run([zstd_bin, "-dq", "-c", "-D", str(dict_path)],
+                       input=blob, capture_output=True)
     if r.returncode != 0:
         raise RuntimeError(f"rid={rid}: zstd -d failed: "
                            + r.stderr.decode("utf-8", "replace"))
@@ -235,7 +241,7 @@ http {{
                             rid = counter["n"]
                             counter["n"] += 1
                         try:
-                            one(args.port, rid, args.zstd_bin)
+                            one(args.port, rid, args.zstd_bin, dict_path)
                         except Exception as e:  # noqa: BLE001
                             failures.append(str(e))
 


### PR DESCRIPTION
## Summary
Issue #80 reported "data corruption" under SIGHUP reload with large (CSTREAM_IN+1-sized) bodies. Root cause turned out to be the **test harness**, not the filter module: nginx.conf sets `zstd_dict_file`, so the filter compresses every response against that dictionary via `ZSTD_CCtx_refCDict`. The test's decode step never passed `-D <dict>` to `zstd -d`, so libzstd correctly rejected the dictionary-compressed frame as corrupted.

- Fixed `one()` in `tools/test_reload_under_load.py` to decode with `-D dict_path`.
- Verified 3x clean: 593-625 requests per run, 6 SIGHUP reloads, 4-way load, zero decode failures.
- No changes to `filter/ngx_http_zstd_filter_module.c` — the byte-accounting bug I originally suspected does not exist.

Closes #80.

## Test plan
- [x] `python3 tools/test_reload_under_load.py --nginx-binary <debug build> --reloads 6 --workers 4 --duration 18` — 3 consecutive clean runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved compression validation during server reloads.
  * Responses compressed with a configured Zstandard dictionary are now decoded and compared accurately, including responses spanning reloads.
  * This provides more reliable detection of data integrity issues under sustained load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->