### PR TITLE
chore: bump nginx-stable/angie pins (2026-07-20)

### DIFF
--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -62,10 +62,10 @@ jobs:
             version: "1.31.2"
             label: mainline
           - flavor: nginx
-            version: "1.30.3"
+            version: "1.30.4"
             label: stable
           - flavor: angie
-            version: "1.11.5"
+            version: "1.12.1"
             label: angie
     steps:
       - name: Checkout module

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -64,6 +64,7 @@ fi
 
 # --- pinned sha256 for angie tarballs we've actually verified ---
 declare -A ANGIE_SHA256=(
+    ["1.12.1"]="5f4f203be2aca6fe20770b489c720e46e51d337e521065e7e472b61e24e3d2f5"
     ["1.11.5"]="b5f297c6df2a74b9d0091a7cdd747fffd2d0e1d0be43632da61c1c7539db2043"
 )
 
@@ -71,6 +72,7 @@ declare -A ANGIE_SHA256=(
 # actually verified (floating mainline, resolved at CI run time, has no
 # entry here and relies on the PGP check alone) ---
 declare -A NGINX_SHA256=(
+    ["1.30.4"]="4261dc90e9e47c1c4041276e9aaa3d48ebe2e664f728e14fa95ae6c67d57a08b"
     ["1.30.3"]="e5823dc6f45610993def93ebf6cfce68264af4958c77e874b7d20f3709001b8f"
 )
 


### PR DESCRIPTION
Automated weekly version check (tools/bump-versions.sh). Review the diff and let required CI checks gate the merge.