### PR TITLE
fix(bump): authenticate the angie release lookup

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -49,6 +49,10 @@ jobs:
 
       - name: Run bump script
         id: bump
+        env:
+          # The angie release lookup hits api.github.com; unauthenticated the
+          # shared runner IP is rate-limited to 403s.
+          GH_TOKEN: ${{ secrets.BUMP_PR_TOKEN }}
         run: bash tools/bump-versions.sh
 
       - name: Open PR if anything changed

--- a/tools/bump-versions.sh
+++ b/tools/bump-versions.sh
@@ -53,7 +53,15 @@ latest_nginx_stable() {
 
 latest_angie() {
     local json
-    json="$(curl -fsSL https://api.github.com/repos/webserver-llc/angie/releases/latest)"
+    # The runners share an egress IP, so the unauthenticated API allowance
+    # (60/hr) is routinely exhausted and this call 403s. Send GH_TOKEN when
+    # one is present -- authenticated requests get their own, far larger quota.
+    local -a auth=()
+    [ -n "${GH_TOKEN:-}" ] && auth=(-H "Authorization: Bearer $GH_TOKEN")
+    if ! json="$(curl -fsSL "${auth[@]}" https://api.github.com/repos/webserver-llc/angie/releases/latest)"; then
+        echo "error: could not query the angie release API (rate limit? set GH_TOKEN)" >&2
+        return 1
+    fi
     echo "$json" | grep -m1 '"tag_name"' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'
 }
 


### PR DESCRIPTION
`tools/bump-versions.sh` queries the angie release API unauthenticated:

```
curl -fsSL https://api.github.com/repos/webserver-llc/angie/releases/latest
```

The CI runners share an egress IP whose anonymous allowance (60/hr) is routinely exhausted, so the call 403s and the job dies with a bare `curl: (22)`. Confirmed from this network: `unauth remaining: 0 / 60`.

Latent until now — the job used to fail earlier at the push step, so it never reached the bump script.

- send `GH_TOKEN` when present (authenticated requests get a much larger quota)
- fail with an explanatory message instead of a raw curl error
- pass `BUMP_PR_TOKEN` into the bump step, which previously had no env

Verified locally: with a token `latest_angie` returns `1.12.1`; without one it now fails with `could not query the angie release API (rate limit? set GH_TOKEN)` instead of the opaque 403.