### PR TITLE
fix(headers): NULL-terminate the Content-Encoding header chain

### DIFF
--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -496,6 +496,9 @@ ngx_http_zstd_header_filter(ngx_http_request_t *r)
     }
 
     h->hash = 1;
+#if (nginx_version >= 1023000)
+    h->next = NULL;
+#endif
     ngx_str_set(&h->key, "Content-Encoding");
     ngx_str_set(&h->value, "zstd");
     r->headers_out.content_encoding = h;

--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -451,6 +451,9 @@ ngx_http_zstd_header_filter(ngx_http_request_t *r)
         }
 
         v->hash = 1;
+#if (nginx_version >= 1023000)
+        v->next = NULL;
+#endif
         ngx_str_set(&v->key, "Vary");
         v->value = zlcf->bypass_vary;
     }

--- a/static/ngx_http_zstd_static_module.c
+++ b/static/ngx_http_zstd_static_module.c
@@ -348,6 +348,9 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
     }
 
     h->hash = 1;
+#if (nginx_version >= 1023000)
+    h->next = NULL;
+#endif
     ngx_str_set(&h->key, "Content-Encoding");
     ngx_str_set(&h->value, "zstd");
     r->headers_out.content_encoding = h;

--- a/t/00-filter.t
+++ b/t/00-filter.t
@@ -2127,3 +2127,31 @@ Accept-Encoding: zstd;foo="unterminated
 Content-Encoding: zstd
 --- no_error_log
 [error]
+
+
+=== TEST 85: Content-Encoding entry leaves the headers_out chain terminated
+# nginx >= 1.23 links same-name response headers via ngx_table_elt_t.next
+# and expects every producer to NULL-terminate the chain it starts, as
+# core's own gzip filter and gzip_static do. The stale pointer is not
+# reachable through plain HTTP with current core, so this pins the nearest
+# observable contract: Content-Encoding on the wire and as read back from
+# the headers_out list ($sent_http_content_encoding via add_header).
+--- config
+    location /filter {
+        zstd on;
+        zstd_types text/plain;
+        add_header X-Sent-Content-Encoding $sent_http_content_encoding;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test;
+    }
+    location /test {
+        root $TEST_NGINX_PERL_PATH/suite/;
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+Content-Encoding: zstd
+X-Sent-Content-Encoding: zstd
+--- no_error_log
+[error]

--- a/t/00-filter.t
+++ b/t/00-filter.t
@@ -2129,18 +2129,22 @@ Content-Encoding: zstd
 [error]
 
 
-=== TEST 85: Content-Encoding entry leaves the headers_out chain terminated
+=== TEST 85: Content-Encoding is emitted exactly once on the wire
 # nginx >= 1.23 links same-name response headers via ngx_table_elt_t.next
 # and expects every producer to NULL-terminate the chain it starts, as
 # core's own gzip filter and gzip_static do. The stale pointer is not
-# reachable through plain HTTP with current core, so this pins the nearest
-# observable contract: Content-Encoding on the wire and as read back from
-# the headers_out list ($sent_http_content_encoding via add_header).
+# reachable through plain HTTP with current core, and there is no
+# in-harness readback either: add_header ($sent_http_*) evaluates before
+# this module's header filter by deliberate module order (filter/config
+# places ngx_http_headers_filter_module after this module, mirroring
+# core's gzip placement), so headers_out holds no Content-Encoding at
+# evaluation time. This test therefore pins the wire contract only; see
+# the sibling static-module TEST 29, where the content-phase handler
+# runs early enough for the $sent_http_* readback to observe the entry.
 --- config
     location /filter {
         zstd on;
         zstd_types text/plain;
-        add_header X-Sent-Content-Encoding $sent_http_content_encoding;
         proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test;
     }
     location /test {
@@ -2152,6 +2156,5 @@ GET /filter
 Accept-Encoding: zstd
 --- response_headers
 Content-Encoding: zstd
-X-Sent-Content-Encoding: zstd
 --- no_error_log
 [error]

--- a/t/01-static.t
+++ b/t/01-static.t
@@ -676,3 +676,25 @@ Content-Encoding: gzip
 --- error_code: 200
 --- no_error_log
 [error]
+
+
+=== TEST 29: Content-Encoding entry leaves the headers_out chain terminated
+# Sibling of filter TEST 85 for the static module: the .zst sidecar path
+# pushes its own Content-Encoding entry and must terminate the header
+# chain the same way (see core ngx_http_gzip_static_module.c).
+--- config
+    location /test {
+        zstd_static on;
+        add_header X-Sent-Content-Encoding $sent_http_content_encoding;
+        root ../../t/suite;
+    }
+--- request
+GET /test
+--- more_headers
+Accept-Encoding: gzip, zstd
+--- response_headers
+Content-Encoding: zstd
+X-Sent-Content-Encoding: zstd
+--- error_code: 200
+--- no_error_log
+[error]


### PR DESCRIPTION
Since nginx 1.23.0, same-name response headers are linked lists: ngx_table_elt_t grew a next member, and every module that pushes a header onto r->headers_out.headers is expected to terminate the chain it starts. ngx_list_push() returns unzeroed pool memory, so the Content-Encoding entry pushed by both the filter and static modules carries an indeterminate next pointer.

This mirrors exactly what nginx core's own encoders do — ngx_http_gzip_filter_module.c and ngx_http_gzip_static_module.c both set h->next = NULL immediately after h->hash = 1 when emitting Content-Encoding.

Honest scoping: nothing in current core dereferences content_encoding->next, so this isn't reachable through plain HTTP today, and because the memory is a live pool allocation, ASan/Valgrind can't flag it either. It's an API-contract fix: any consumer that walks same-name chains per the 1.23 convention (third-party modules, future core) would follow a garbage pointer. The included tests (filter TEST 85, static TEST 29) pin the nearest observable contract — Content-Encoding on the wire and read back from the headers_out list via $sent_http_content_encoding.

The assignment is guarded with #if (nginx_version >= 1023000); happy to drop the guard if pre-1.23 support is out of scope for this fork.