### PR TITLE
build: make a Windows checkout buildable and testable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,24 @@
 *.t linguist-language=Text
+
+# Files that are executed or sourced by POSIX sh/perl on Linux (including
+# WSL builds from a Windows checkout) must stay LF: nginx's ./configure
+# sources `config`/`auto/zstd` with sh, which treats a CR as part of the
+# line and fails with "$'\r': command not found" when core.autocrlf=true
+# has smudged the checkout to CRLF.
+config text eol=lf
+auto/* text eol=lf
+*/config text eol=lf
+*.sh text eol=lf
+*.t text eol=lf
+
+# Byte-exact fixtures: fuzz corpus entries are raw Accept-Encoding header
+# bytes and .zst files are compressed frames — any EOL conversion corrupts
+# them.
+fuzz/corpus/* -text
+fuzz/fuzz.dict -text
+*.zst binary
+
+# t/suite/test's byte length is asserted verbatim by the static suite
+# (Content-Length and the size half of the ETag) — CRLF smudging changes
+# the on-disk size and fails every identity-response assertion.
+t/suite/* -text

--- a/fuzz/extract_parser.sh
+++ b/fuzz/extract_parser.sh
@@ -29,7 +29,12 @@ fi
 # two parsers), so match on the following definition line. Capture them in
 # source order (skip_quoted, then eval_qvalue, then accept_encoding) so the
 # generated .inc compiles without forward declarations.
+# The leading sub() strips a CR so extraction also works from a Windows
+# checkout smudged to CRLF (core.autocrlf=true): the `$0 == "}"`
+# terminator and the anchored regexes below otherwise never match and
+# the build fails with the "header layout changed?" error misleadingly.
 awk '
+    { sub(/\r$/, "") }
     /^static (ngx_int_t|u_char \*)$/ { pending = 1; buf = $0 ORS; next }
     pending && /^ngx_http_zstd_(skip_quoted|eval_qvalue|accept_encoding)\(/ {
         capture = 1; pending = 0; print buf; print; next


### PR DESCRIPTION
A Windows checkout with `core.autocrlf=true` (the Git for Windows default) smudges the working tree to CRLF, which breaks this module in three independent ways:

1. **No build at all** — nginx's `./configure` sources `config` and `auto/zstd` with POSIX sh, which treats the CR as part of the line and dies with `$'\r': command not found`.
2. **Static suite fails** — `t/suite/test`'s byte length is asserted verbatim (`Content-Length` and the size half of the ETag), so the CR-inflated file fails every identity-response assertion.
3. **Fuzz build fails misleadingly** — `fuzz/extract_parser.sh`'s awk matches an exact `}` terminator and column-0-anchored regexes; against CRLF input it extracts nothing and dies with "header layout changed?".

The fix pins LF via `.gitattributes` for everything executed or sourced on Linux (rather than relying on every contributor's `core.autocrlf`), marks the fuzz corpus and `.zst` fixtures conversion-exempt so checkout can never corrupt their bytes, and strips a trailing CR in the extractor's awk so the fuzz target also builds from a checkout that predates the attributes file.

**Testing:** from a real `core.autocrlf=true` Windows checkout (building under WSL on `/mnt/c`): `./configure` + `make` succeed, the full Perl suite passes (999 + 11 + 333 assertions — the static suite's Content-Length/ETag assertions were the original tell), and `fuzz/build.sh` extracts all parser functions and the target runs clean. No behavior change on Linux checkouts: all files already have LF in the index; the attributes only stop the smudge.
