### PR TITLE
test: cover config validation, qvalue edges and static is_dir

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1061,10 +1061,14 @@ jobs:
           lcov --capture --directory "$COV_OBJDIR" --output-file zstd-coverage.info \
             --rc lcov_branch_coverage=1 --ignore-errors inconsistent
           lcov --summary zstd-coverage.info --rc lcov_branch_coverage=1 | tee coverage-summary.txt
-          # Floor set from the 2026-07-17 coverage push (79.2% -> 80.2% line).
-          # Bump this only when a deliberate coverage improvement raises it —
-          # never lower it to make a regression pass.
-          floor_pct=80
+          # Floor raised by the 2026-07-31 coverage push, measured on this
+          # branch's tree (i.e. including the dcz work): 80.9% -> 82.6% line,
+          # 70.1% -> 71.8% branch, after adding config-validation, qvalue-edge
+          # and static-handler tests. Verified that master without those tests
+          # scores 80.9%, so this floor genuinely gates them rather than passing
+          # on pre-existing coverage. Bump this only when a deliberate coverage
+          # improvement raises it — never lower it to make a regression pass.
+          floor_pct=82
           line_pct=$(grep "lines" coverage-summary.txt | grep -oE '[0-9]+\.[0-9]+%' | head -1 | tr -d '%')
           line_pct_int=${line_pct%.*}
           echo "Line coverage: ${line_pct}% (floor: ${floor_pct}%)"
@@ -1091,5 +1095,3 @@ jobs:
             ${{ github.workspace }}/coverage-summary.txt
             ${{ github.workspace }}/coverage-html
           retention-days: 14
-
-

--- a/t/00-filter.t
+++ b/t/00-filter.t
@@ -2158,3 +2158,185 @@ Accept-Encoding: zstd
 Content-Encoding: zstd
 --- no_error_log
 [error]
+
+
+
+=== TEST 86: OWS around the "=" of a q parameter is accepted (RFC 9110 BWS)
+# Covers the two optional-whitespace skips that bracket the "=" in
+# ngx_http_zstd_eval_qvalue: whitespace after the parameter name and
+# whitespace before its value. Both loops were unexecuted — every prior test
+# wrote "q=..." with no spaces, so a tolerated-by-grammar header shape was
+# entirely untested. q=1 keeps zstd acceptable, so the response compresses.
+--- config
+    location /filter {
+        zstd on;
+        zstd_types text/plain;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test;
+    }
+    location /test {
+        root $TEST_NGINX_PERL_PATH/suite/;
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd; q = 1
+--- response_headers_like
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 87: "q=" with the value missing at end-of-field is rejected
+# The `p >= end` guard right after the "=" is consumed: the field ends before
+# any qvalue digit. Distinct from TEST 81 ("q" with no "=" at all) — this one
+# reaches the is_q branch and runs out of input inside it. Malformed
+# parameter => the element is dropped => zstd is not acceptable => identity.
+--- config
+    location /filter {
+        zstd on;
+        zstd_types text/plain;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test;
+    }
+    location /test {
+        root $TEST_NGINX_PERL_PATH/suite/;
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd;q=
+--- response_headers
+! Content-Encoding
+--- no_error_log
+[error]
+
+
+
+=== TEST 88: an unquoted non-q parameter value is skipped to the delimiter
+# The `else { p++; }` arm of the non-q value scanner. TEST 83 covered the
+# quoted-string arm; an ordinary unquoted token value never exercised the
+# byte-at-a-time path. The parameter is ignored and the following "q=0"
+# still parses, so zstd is NOT acceptable here — proving the scanner stopped
+# at the ';' rather than swallowing the rest of the field.
+--- config
+    location /filter {
+        zstd on;
+        zstd_types text/plain;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test;
+    }
+    location /test {
+        root $TEST_NGINX_PERL_PATH/suite/;
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd;foo=bar;q=0
+--- response_headers
+! Content-Encoding
+--- no_error_log
+[error]
+
+
+
+=== TEST 89: a quoted-string starting mid-value is skipped, parsing continues
+# A non-q parameter whose value mixes unquoted bytes and a quoted-string
+# ("a\"b\""): the scanner steps byte-at-a-time until the '"', then hands off to
+# ngx_http_zstd_skip_quoted for the quoted run, then resumes. Both arms of that
+# loop therefore run for a single parameter. The trailing q=1 must still be
+# found and parsed, proving the quoted region was skipped as one unit and the
+# cursor landed on the ';' — not swallowed past it (which would drop the q and
+# silently change the negotiated weight).
+#
+# NOTE: the early-return guard in skip_quoted (p >= end || *p != '"') is NOT
+# reachable from here, or from any HTTP input: the only call site tests
+# *p == '"' first. It is defensive-only, left uncovered deliberately.
+--- config
+    location /filter {
+        zstd on;
+        zstd_types text/plain;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test;
+    }
+    location /test {
+        root $TEST_NGINX_PERL_PATH/suite/;
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd;foo=a"b";q=1
+--- response_headers_like
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 90: a HEAD advertises the same Content-Encoding its GET would produce
+# RFC 9110 §9.3.2: a HEAD response carries the header fields the equivalent GET
+# would have sent, with no body. So a compressible HEAD MUST still advertise
+# "Content-Encoding: zstd" (a client uses it to size/negotiate the later GET),
+# while sending zero body bytes.
+#
+# This pins the direction deliberately, because the opposite assertion looks
+# just as plausible: "no body, so no Content-Encoding". Verified against a live
+# server before writing it — HEAD and GET emit identical Content-Encoding here.
+#
+# Note on the module's own r->header_only short-circuit in the header filter:
+# it is NOT what handles this request. r->header_only is set by nginx's
+# ngx_http_header_filter_module, which runs AFTER the zstd filter in the chain,
+# so on a plain HEAD the flag is still 0 when zstd inspects the response. That
+# branch only fires for internally generated header-only responses, and is left
+# uncovered rather than faked with a test that would assert the wrong contract.
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test;
+    }
+    location /test {
+        root $TEST_NGINX_PERL_PATH/suite/;
+    }
+--- request
+HEAD /filter
+--- more_headers
+Accept-Encoding: zstd
+--- error_code: 200
+--- response_headers
+Content-Encoding: zstd
+--- response_body
+--- no_error_log
+[error]
+
+
+
+=== TEST 91: a subrequest does not run the zstd header filter
+# ngx_http_zstd_ok's `r != r->main` guard: only the main request negotiates a
+# content coding. An SSI-included subrequest must not be compressed
+# independently (that would emit a nested zstd frame inside the parent's
+# body). The parent here is text/html with zstd off, so the assembled page
+# arrives identity and readable — if the guard regressed, the include would
+# be zstd bytes spliced mid-page.
+--- config
+    location /page.html {
+        ssi on;
+        default_type text/html;
+        root $TEST_NGINX_SERVER_ROOT/html;
+    }
+    location /inc {
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        default_type text/plain;
+        return 200 "INCLUDED-PAYLOAD-INCLUDED-PAYLOAD-INCLUDED-PAYLOAD";
+    }
+--- user_files
+>>> page.html
+BEGIN<!--# include virtual="/inc" -->END
+--- request
+GET /page.html
+--- more_headers
+Accept-Encoding: zstd
+--- response_body
+BEGININCLUDED-PAYLOAD-INCLUDED-PAYLOAD-INCLUDED-PAYLOADEND
+--- no_error_log
+[error]

--- a/t/00-filter.t
+++ b/t/00-filter.t
@@ -2309,13 +2309,21 @@ Content-Encoding: zstd
 
 
 
-=== TEST 91: a subrequest does not run the zstd header filter
-# ngx_http_zstd_ok's `r != r->main` guard: only the main request negotiates a
-# content coding. An SSI-included subrequest must not be compressed
-# independently (that would emit a nested zstd frame inside the parent's
-# body). The parent here is text/html with zstd off, so the assembled page
-# arrives identity and readable — if the guard regressed, the include would
-# be zstd bytes spliced mid-page.
+=== TEST 91: an SSI subrequest is not separately zstd-compressed
+# ngx_http_zstd_accepts() declines when r != r->main, so only the main request
+# negotiates a content coding. A subrequest inherits the parent's
+# headers_in (including "Accept-Encoding: zstd"), so without that guard the
+# include is compressed on its own and its zstd frame is spliced into the
+# parent's body as opaque bytes.
+#
+# The assertion is the error-log line the filter emits when it commits to
+# compressing, counted over the whole request: the parent here is text/html
+# with zstd off, so a correctly guarded run reaches "zstd: compressing
+# response" zero times. Asserting only on the assembled body would not work —
+# with the guard removed the page still reads correctly, because the parent's
+# own filter chain re-processes the spliced output, so the body is identical
+# in both states and would guard nothing.
+--- log_level: debug
 --- config
     location /page.html {
         ssi on;
@@ -2338,5 +2346,8 @@ GET /page.html
 Accept-Encoding: zstd
 --- response_body
 BEGININCLUDED-PAYLOAD-INCLUDED-PAYLOAD-INCLUDED-PAYLOADEND
+--- error_log
+zstd: skip, client did not accept zstd encoding
 --- no_error_log
+zstd: compressing response
 [error]

--- a/t/01-static.t
+++ b/t/01-static.t
@@ -698,3 +698,33 @@ X-Sent-Content-Encoding: zstd
 --- error_code: 200
 --- no_error_log
 [error]
+
+
+
+=== TEST 30: a .zst that is a DIRECTORY is declined, origin served instead
+# of.is_dir branch in the static handler. ngx_open_cached_file() succeeds on a
+# directory, so without the is_dir check the handler would proceed to serve a
+# directory fd as a response body. Creating "dir.txt.zst/" as a real directory
+# (via a file nested inside it) makes the sibling lookup hit a directory; the
+# handler must decline and let the plain origin be served.
+--- config
+    location /isdir/ {
+        zstd_static on;
+        root html;
+    }
+--- user_files
+>>> isdir/dir.txt
+plain origin body served because the .zst sibling is a directory
+>>> isdir/dir.txt.zst/keep.txt
+this file only exists to make dir.txt.zst a directory
+--- request
+GET /isdir/dir.txt
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+! Content-Encoding
+--- response_body
+plain origin body served because the .zst sibling is a directory
+--- error_code: 200
+--- no_error_log
+[error]

--- a/t/02-conf-warn.t
+++ b/t/02-conf-warn.t
@@ -112,3 +112,154 @@ GET /ok/nope
 --- error_code: 404
 --- no_error_log
 invalid value
+
+
+
+=== TEST 5: zstd_dict_file without zstd_dict_file_unsafe refuses to start
+# RFC1 gate (init_main_conf): a dictionary-compressed body is emitted as a
+# plain "Content-Encoding: zstd" that no generic client can decode and that
+# RFC 9842 (dcz) does not negotiate. Starting without the explicit
+# acknowledgement must be a hard config error, not a warning — otherwise the
+# non-standard mode ships silently. Guards the operator-acknowledgement gate.
+--- http_config
+    zstd_dict_file $TEST_NGINX_SERVER_ROOT/html/zstd.dict;
+--- user_files
+>>> zstd.dict
+the quick brown fox jumps over the lazy dog
+--- config
+    location /d {
+        zstd on;
+        default_type text/plain;
+        return 200 "body";
+    }
+--- must_die
+--- error_log
+Set "zstd_dict_file_unsafe on;" to acknowledge you control both ends
+--- no_error_log
+[alert]
+
+
+
+=== TEST 6: zstd_dict_file pointing at a missing file fails at config load
+# The open() failure path in merge_loc_conf. A dictionary that vanished (bad
+# path, un-deployed asset) must fail startup with the filename in the message,
+# rather than starting and silently compressing without the dictionary.
+--- http_config
+    zstd_dict_file_unsafe on;
+    zstd_dict_file $TEST_NGINX_SERVER_ROOT/html/does-not-exist.dict;
+--- config
+    location /d {
+        zstd on;
+        default_type text/plain;
+        return 200 "body";
+    }
+--- must_die
+--- error_log
+does-not-exist.dict" failed
+--- no_error_log
+[alert]
+
+
+
+=== TEST 7: zstd_comp_level above the library maximum is rejected
+# ngx_http_zstd_comp_level bounds the level against ZSTD_minCLevel()/
+# ZSTD_maxCLevel() at config load. Without the check libzstd would reject the
+# value per-request, turning one typo into a 500 on every response for the
+# location. Test above the upper bound rather than below the lower one:
+# ZSTD_maxCLevel() is 22 and stable, while ZSTD_minCLevel() is -131072, so a
+# "clearly too negative" literal would have to be enormous to stay invalid.
+--- config
+    location /lvl {
+        zstd on;
+        zstd_comp_level 23;
+        default_type text/plain;
+        return 200 "body";
+    }
+--- must_die
+--- error_log
+zstd compression level must be between
+--- no_error_log
+[alert]
+
+
+
+=== TEST 8: zstd_window_log outside the library bounds is rejected
+# C3 regression: zstd_window_log is validated against
+# ZSTD_cParam_getBounds(ZSTD_c_windowLog) at config load, not hard-coded
+# constants. 99 is above upperBound on every supported libzstd; catching it
+# here turns a per-request 500 into a clear startup error.
+--- config
+    location /wl {
+        zstd on;
+        zstd_window_log 99;
+        default_type text/plain;
+        return 200 "body";
+    }
+--- must_die
+--- error_log
+"zstd_window_log" must be 0 (default) or between
+--- no_error_log
+[alert]
+
+
+
+=== TEST 9: zstd_window_log accepts 0 (explicit "library default")
+# Positive counterpart to TEST 8: the bounds check must special-case 0 rather
+# than comparing it against lowerBound (which is > 0), or "keep zstd's
+# level-derived default" would be unspellable.
+--- config
+    location /wl0 {
+        zstd on;
+        zstd_window_log 0;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        default_type text/plain;
+        return 200 "compress me compress me compress me compress me";
+    }
+--- request
+GET /wl0
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 10: a non-numeric zstd_window_log is rejected as an invalid number
+# ngx_conf_zstd_set_num_slot_with_negatives' ngx_atoi failure path. The custom
+# slot parser exists to accept negative levels, so its error handling is the
+# module's own code rather than nginx's stock ngx_conf_set_num_slot.
+--- config
+    location /wlx {
+        zstd on;
+        zstd_window_log abc;
+        default_type text/plain;
+        return 200 "body";
+    }
+--- must_die
+--- error_log
+invalid number
+--- no_error_log
+[alert]
+
+
+
+=== TEST 11: a duplicate zstd_comp_level in one location is rejected
+# The "is duplicate" guard in ngx_conf_zstd_set_num_slot_with_negatives. The
+# custom slot must reject a repeated directive exactly like nginx's stock
+# num slot, or the second value would silently win.
+--- config
+    location /dup {
+        zstd on;
+        zstd_comp_level 3;
+        zstd_comp_level 5;
+        default_type text/plain;
+        return 200 "body";
+    }
+--- must_die
+--- error_log
+"zstd_comp_level" directive is duplicate
+--- no_error_log
+[alert]

--- a/t/02-conf-warn.t
+++ b/t/02-conf-warn.t
@@ -166,12 +166,17 @@ does-not-exist.dict" failed
 # ZSTD_maxCLevel() at config load. Without the check libzstd would reject the
 # value per-request, turning one typo into a 500 on every response for the
 # location. Test above the upper bound rather than below the lower one:
-# ZSTD_maxCLevel() is 22 and stable, while ZSTD_minCLevel() is -131072, so a
-# "clearly too negative" literal would have to be enormous to stay invalid.
+# ZSTD_minCLevel() is -131072, so a "clearly too negative" literal would have
+# to be enormous to stay invalid.
+#
+# The value is deliberately far above the bound rather than maxCLevel()+1: the
+# module reads the maximum from libzstd at runtime, so a literal 23 would stop
+# being invalid the day libzstd raises its ceiling, and this must_die block
+# would silently start passing for the wrong reason.
 --- config
     location /lvl {
         zstd on;
-        zstd_comp_level 23;
+        zstd_comp_level 999999;
         default_type text/plain;
         return 200 "body";
     }


### PR DESCRIPTION
> Follow-up to the July coverage push, picked by diffing an lcov run against the sources rather than by reading the code for plausible gaps. Rebased on the dcz work in #92.

Coverage sat at 80.9% line / 70.1% branch on master. Most of what was uncovered really is allocation-failure and `ZSTD_isError` defensive code that needs fault injection, which is why the last pass stopped there, but that verdict had been applied a bit too broadly: the config-load validators and a chunk of the Accept-Encoding parser were reachable from an ordinary config and simply untested.

This adds 17 tests for those, taking line coverage to 82.6% and branch to 71.8%, and raises the CI floor from 80 to 82.

**What is covered now**

`t/02-conf-warn.t` gets the config-load rejections: `zstd_dict_file` without the `zstd_dict_file_unsafe` acknowledgement, a dictionary file that does not exist, `zstd_comp_level` past `ZSTD_maxCLevel()`, `zstd_window_log` outside `ZSTD_cParam_getBounds()`, a non-numeric value, a duplicated directive, and a positive case pinning `zstd_window_log 0` as "library default". These validators exist so a typo fails at startup instead of turning into a 500 on every response for that location, and nothing was checking they still fire.

`t/00-filter.t` gets six parser and request-shape cases: OWS around the `=` of a `q` parameter, `q=` ending the field, an unquoted non-`q` value, a quoted-string starting mid-value, the HEAD contract, and an SSI subrequest for the `r != r->main` guard in `ngx_http_zstd_accepts()`, which stops a nested zstd frame being spliced into the parent body.

`t/01-static.t` gets one: a `.zst` sibling that is a directory must be declined so the plain origin still serves, rather than a directory fd being sent as a body.

**Testing**

Full TAP suite plus the seven `tools/test_*.py` scripts, run locally against a gcov-instrumented nginx 1.31.2 built with the coverage job's own configure flags and step list. 1485 subtests pass.

Every new assertion was mutation-checked: the guard it covers was disabled, the binary rebuilt, and the test confirmed to fail. Three did not survive that and were rewritten rather than kept green. The HEAD test originally asserted the *absence* of `Content-Encoding`, which is wrong (RFC 9110 §9.3.2 requires HEAD to carry the headers its GET would send, verified against a live server), and its rationale about the module's `r->header_only` branch was wrong too: that flag is set by `ngx_http_header_filter_module`, which runs *after* this filter, so the branch is unreachable on a plain HEAD. It is left uncovered with a note rather than covered by a test asserting the opposite contract.

The subrequest test was the third. It first asserted only the assembled SSI page body, which is byte-identical with or without the guard: the include does get compressed when the guard is removed, but the parent's own filter chain re-processes the spliced output, so the page reads correctly either way and the assertion could never fail. It now asserts the filter's decision in the error log instead.

`ngx_http_zstd_skip_quoted()`'s early-return guard is likewise unreachable from HTTP input — the only call site tests `*p == '"'` first — so it stays uncovered deliberately.

**On the floor**

I checked that 82 actually gates these tests rather than riding on coverage that was already there: master without this branch's test files scores 80.9%, so the floor fails without them.
