### PR TITLE
build: stop leaking -lzstd into every dynamic module via NGX_LD_OPT

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,3 +22,7 @@ fuzz/fuzz.dict -text
 # (Content-Length and the size half of the ETag) — CRLF smudging changes
 # the on-disk size and fails every identity-response assertion.
 t/suite/* -text
+
+# CI-only stub module for the linkage-isolation job; keep it out of
+# release tarballs (git archive).
+/tools/ci-linkcheck-module export-ignore

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -527,6 +527,8 @@ jobs:
     steps:
       - name: Checkout module
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -508,6 +508,103 @@ jobs:
             --nginx-binary "$TEST_NGINX_BINARY" --port 18200
           echo "✓ libzstd 1.4.x fallback paths produce correct output"
 
+  # ── Dynamic-module linkage isolation — the NGX_LD_OPT regression test.
+  #    Builds the zstd modules alongside an unrelated stub dynamic module
+  #    (tools/ci-linkcheck-module) in ONE configure and asserts both
+  #    directions: the zstd .so's DO carry a libzstd DT_NEEDED (positive
+  #    control — proves the per-module ngx_module_libs channel works and
+  #    that the assertions are not vacuously passing) and the stub does
+  #    NOT (the actual fix: an addon appending to build-global NGX_LD_OPT
+  #    signs its neighbours up for its libraries). ─────────────────────────
+  linkage:
+    name: Dynamic-module linkage isolation
+    runs-on: [self-hosted, builder02, lxc]
+    timeout-minutes: 15
+    needs: resolve
+    env:
+      NGINX_VERSION: ${{ needs.resolve.outputs.nginx_version }}
+
+    steps:
+      - name: Checkout module
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config libzstd-dev \
+            libpcre2-dev zlib1g-dev wget binutils
+
+      - name: Cache nginx source tarball
+        id: nginx-tarball
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: nginx-${{ env.NGINX_VERSION }}.tar.gz
+          key: nginx-src-${{ env.NGINX_VERSION }}
+
+      - name: Download nginx source tarball
+        if: steps.nginx-tarball.outputs.cache-hit != 'true'
+        run: wget -q "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz"
+
+      - name: Verify nginx tarball PGP signature
+        run: |
+          set -euo pipefail
+          wget -q "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz.asc" \
+            -O "nginx-${NGINX_VERSION}.tar.gz.asc"
+          gnupghome="$(mktemp -d)"
+          export GNUPGHOME="$gnupghome"
+          chmod 700 "$gnupghome"
+          for keyfile in tools/keys/*.key; do
+            gpg --quiet --import "$keyfile" 2>/dev/null
+          done
+          gpg --quiet --verify "nginx-${NGINX_VERSION}.tar.gz.asc" "nginx-${NGINX_VERSION}.tar.gz"
+          rm -rf "$gnupghome"
+
+      - name: Configure with zstd + stub as dynamic modules, build modules
+        run: |
+          tar -xzf "nginx-${NGINX_VERSION}.tar.gz"
+          cd "nginx-${NGINX_VERSION}"
+          ./configure \
+            --with-compat \
+            --add-dynamic-module="$GITHUB_WORKSPACE" \
+            --add-dynamic-module="$GITHUB_WORKSPACE/tools/ci-linkcheck-module" \
+            > /dev/null
+          make -j"$(nproc)" modules
+
+      - name: Assert linkage isolation (both directions)
+        run: |
+          set -euo pipefail
+          cd "nginx-${NGINX_VERSION}/objs"
+
+          # Existence first: a renamed/missing .so must fail here, not
+          # let the negative assertion below pass vacuously.
+          for so in ngx_http_zstd_filter_module.so \
+                    ngx_http_zstd_static_module.so \
+                    ngx_http_linkcheck_module.so; do
+            test -f "$so" || { echo "✗ missing $so"; exit 1; }
+          done
+
+          # Positive control: the zstd modules carry the libzstd
+          # DT_NEEDED through ngx_module_libs.
+          for so in ngx_http_zstd_filter_module.so \
+                    ngx_http_zstd_static_module.so; do
+            if ! readelf -d "$so" | grep -E 'NEEDED.*libzstd' > /dev/null; then
+              echo "✗ $so does not link libzstd (ngx_module_libs broken?)"
+              readelf -d "$so" | grep NEEDED || true
+              exit 1
+            fi
+            echo "✓ $so links libzstd"
+          done
+
+          # The fix under test: an unrelated module in the same build
+          # must NOT inherit libzstd.
+          if readelf -d ngx_http_linkcheck_module.so \
+               | grep -E 'NEEDED.*libzstd' > /dev/null; then
+            echo "✗ stub module inherited a libzstd DT_NEEDED (NGX_LD_OPT leak)"
+            readelf -d ngx_http_linkcheck_module.so | grep NEEDED
+            exit 1
+          fi
+          echo "✓ stub module free of libzstd — no NGX_LD_OPT leak"
+
   # ── ASAN + UBSAN build — catches the lifetime/UB bugs in this module's
   #    history (per-request ctx, terminal-frame). Uses valgrind.suppress'd
   #    knowledge; ASAN is faster than valgrind for CI. ───────────────────────

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -561,6 +561,7 @@ jobs:
 
       - name: Configure with zstd + stub as dynamic modules, build modules
         run: |
+          set -euo pipefail
           tar -xzf "nginx-${NGINX_VERSION}.tar.gz"
           cd "nginx-${NGINX_VERSION}"
           ./configure \
@@ -573,40 +574,73 @@ jobs:
       - name: Assert linkage isolation (both directions)
         run: |
           set -euo pipefail
-          cd "nginx-${NGINX_VERSION}/objs"
+          cd "nginx-${NGINX_VERSION}"
 
           # Existence first: a renamed/missing .so must fail here, not
-          # let the negative assertion below pass vacuously.
+          # let the negative assertions below pass vacuously.
           for so in ngx_http_zstd_filter_module.so \
                     ngx_http_zstd_static_module.so \
                     ngx_http_linkcheck_module.so; do
-            test -f "$so" || { echo "✗ missing $so"; exit 1; }
+            test -f "objs/$so" || { echo "✗ missing objs/$so"; exit 1; }
           done
 
-          # Positive control: the FILTER module carries the libzstd
-          # DT_NEEDED through ngx_module_libs — it references libzstd
-          # symbols, so no toolchain may drop it. The static module is
-          # deliberately NOT asserted either way: it serves pre-compressed
-          # files and calls no libzstd function, so an --as-needed
-          # toolchain (Ubuntu's default) legitimately drops its libzstd
-          # NEEDED while other toolchains keep it.
-          if ! readelf -d ngx_http_zstd_filter_module.so \
-               | grep -E 'NEEDED.*libzstd' > /dev/null; then
-            echo "✗ filter module does not link libzstd (ngx_module_libs broken?)"
-            readelf -d ngx_http_zstd_filter_module.so | grep NEEDED || true
-            exit 1
-          fi
-          echo "✓ filter module links libzstd"
+          # PRIMARY assertions target the GENERATED LINK COMMAND, not
+          # the linked artifact: a toolchain defaulting to --as-needed
+          # (the gcc on these runners included) drops an unused libzstd
+          # NEEDED from the stub's .so even when the NGX_LD_OPT leak is
+          # present — a readelf-only negative therefore passes either
+          # way and tests nothing. The Makefile records what nginx's
+          # build system emitted, before the linker gets a vote. Grab
+          # the "$(LINK) -o objs/<so>" recipe line plus its backslash
+          # continuations (a plain target-to-blank-line sed range stops
+          # at the dependency list and never reaches the recipe).
+          rule() {
+            awk -v so="objs/$1.so" \
+              '$0 ~ ("-o " so) { grab = 1 }
+               grab { print; if ($0 !~ /\\$/) exit }' objs/Makefile
+          }
 
-          # The fix under test: an unrelated module in the same build
-          # must NOT inherit libzstd.
-          if readelf -d ngx_http_linkcheck_module.so \
-               | grep -E 'NEEDED.*libzstd' > /dev/null; then
-            echo "✗ stub module inherited a libzstd DT_NEEDED (NGX_LD_OPT leak)"
-            readelf -d ngx_http_linkcheck_module.so | grep NEEDED
+          # Positive control: the filter module's rule must carry
+          # -lzstd via ngx_module_libs — also proves rule() extracts a
+          # non-empty block, so the negative below cannot pass because
+          # the sed matched nothing.
+          if ! rule ngx_http_zstd_filter_module | grep -q -- '-lzstd'; then
+            echo "✗ filter module link rule lacks -lzstd (ngx_module_libs broken?)"
+            rule ngx_http_zstd_filter_module
             exit 1
           fi
-          echo "✓ stub module free of libzstd — no NGX_LD_OPT leak"
+          echo "✓ filter module link rule carries -lzstd"
+
+          # The fix under test: an unrelated module's link rule must
+          # NOT mention libzstd.
+          if rule ngx_http_linkcheck_module | grep -q -- '-lzstd'; then
+            echo "✗ stub module link rule carries -lzstd (NGX_LD_OPT leak)"
+            rule ngx_http_linkcheck_module
+            exit 1
+          fi
+          echo "✓ stub module link rule free of -lzstd — no NGX_LD_OPT leak"
+
+          # readelf belt under the Makefile suspenders: the filter's
+          # DT_NEEDED may not be dropped by any toolchain (it references
+          # libzstd symbols), and on toolchains without --as-needed the
+          # stub check additionally guards link inputs that reach the
+          # command line outside the module's own rule text. The static
+          # module is deliberately not asserted either way: it calls no
+          # libzstd function, so its NEEDED reflects the linker default,
+          # not module behaviour.
+          if ! readelf -d objs/ngx_http_zstd_filter_module.so \
+               | grep -E 'NEEDED.*libzstd' > /dev/null; then
+            echo "✗ filter module .so does not link libzstd"
+            readelf -d objs/ngx_http_zstd_filter_module.so | grep NEEDED || true
+            exit 1
+          fi
+          if readelf -d objs/ngx_http_linkcheck_module.so \
+               | grep -E 'NEEDED.*libzstd' > /dev/null; then
+            echo "✗ stub module .so inherited a libzstd DT_NEEDED"
+            readelf -d objs/ngx_http_linkcheck_module.so | grep NEEDED
+            exit 1
+          fi
+          echo "✓ readelf agrees on both"
 
   # ── ASAN + UBSAN build — catches the lifetime/UB bugs in this module's
   #    history (per-request ctx, terminal-frame). Uses valgrind.suppress'd

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -583,17 +583,20 @@ jobs:
             test -f "$so" || { echo "✗ missing $so"; exit 1; }
           done
 
-          # Positive control: the zstd modules carry the libzstd
-          # DT_NEEDED through ngx_module_libs.
-          for so in ngx_http_zstd_filter_module.so \
-                    ngx_http_zstd_static_module.so; do
-            if ! readelf -d "$so" | grep -E 'NEEDED.*libzstd' > /dev/null; then
-              echo "✗ $so does not link libzstd (ngx_module_libs broken?)"
-              readelf -d "$so" | grep NEEDED || true
-              exit 1
-            fi
-            echo "✓ $so links libzstd"
-          done
+          # Positive control: the FILTER module carries the libzstd
+          # DT_NEEDED through ngx_module_libs — it references libzstd
+          # symbols, so no toolchain may drop it. The static module is
+          # deliberately NOT asserted either way: it serves pre-compressed
+          # files and calls no libzstd function, so an --as-needed
+          # toolchain (Ubuntu's default) legitimately drops its libzstd
+          # NEEDED while other toolchains keep it.
+          if ! readelf -d ngx_http_zstd_filter_module.so \
+               | grep -E 'NEEDED.*libzstd' > /dev/null; then
+            echo "✗ filter module does not link libzstd (ngx_module_libs broken?)"
+            readelf -d ngx_http_zstd_filter_module.so | grep NEEDED || true
+            exit 1
+          fi
+          echo "✓ filter module links libzstd"
 
           # The fix under test: an unrelated module in the same build
           # must NOT inherit libzstd.

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -595,17 +595,31 @@ jobs:
           # build system emitted, before the linker gets a vote. Grab
           # the "$(LINK) -o objs/<so>" recipe line plus its backslash
           # continuations (a plain target-to-blank-line sed range stops
-          # at the dependency list and never reaches the recipe).
+          # at the dependency list and never reaches the recipe —
+          # nginx emits a blank line between the two). index() rather
+          # than a regex match, so the dots in "<name>.so" are literal.
           rule() {
             awk -v so="objs/$1.so" \
-              '$0 ~ ("-o " so) { grab = 1 }
+              'index($0, "-o " so) { grab = 1 }
                grab { print; if ($0 !~ /\\$/) exit }' objs/Makefile
           }
 
+          # Every assertion below is only as good as rule() returning
+          # the recipe it was asked for: an empty block makes a
+          # negative grep pass for free. Check extraction itself first,
+          # for both targets, before reading anything into the result.
+          for mod in ngx_http_zstd_filter_module ngx_http_linkcheck_module; do
+            rule "$mod" | grep -q . || {
+              echo "✗ no link rule extracted for $mod — objs/Makefile shape changed?"
+              exit 1
+            }
+          done
+
           # Positive control: the filter module's rule must carry
-          # -lzstd via ngx_module_libs — also proves rule() extracts a
-          # non-empty block, so the negative below cannot pass because
-          # the sed matched nothing.
+          # -lzstd via ngx_module_libs. Proves the per-module channel
+          # the fix relies on is live, so the negative below is a
+          # statement about NGX_LD_OPT and not about a build that
+          # linked no zstd at all.
           if ! rule ngx_http_zstd_filter_module | grep -q -- '-lzstd'; then
             echo "✗ filter module link rule lacks -lzstd (ngx_module_libs broken?)"
             rule ngx_http_zstd_filter_module
@@ -614,13 +628,19 @@ jobs:
           echo "✓ filter module link rule carries -lzstd"
 
           # The fix under test: an unrelated module's link rule must
-          # NOT mention libzstd.
-          if rule ngx_http_linkcheck_module | grep -q -- '-lzstd'; then
-            echo "✗ stub module link rule carries -lzstd (NGX_LD_OPT leak)"
+          # not mention zstd in any form. Matching bare "zstd" rather
+          # than the "-lzstd" spelling on purpose — pkg-config can hand
+          # back an absolute /usr/lib/.../libzstd.so or -l:libzstd.a,
+          # and a leak wearing either spelling is still a leak. Safe
+          # only for this target: the filter module's own rule names
+          # objs/ngx_http_zstd_filter_module.so, so the same pattern
+          # would match its filename and assert nothing.
+          if rule ngx_http_linkcheck_module | grep -qi zstd; then
+            echo "✗ stub module link rule references zstd (NGX_LD_OPT leak)"
             rule ngx_http_linkcheck_module
             exit 1
           fi
-          echo "✓ stub module link rule free of -lzstd — no NGX_LD_OPT leak"
+          echo "✓ stub module link rule free of zstd — no NGX_LD_OPT leak"
 
           # readelf belt under the Makefile suspenders: the filter's
           # DT_NEEDED may not be dropped by any toolchain (it references

--- a/auto/zstd
+++ b/auto/zstd
@@ -6,7 +6,16 @@
 # static/config. Exports:
 #   ngx_zstd_opt_I — compiler include flags for <zstd.h>
 #   ngx_zstd_opt_L — linker flags for libzstd
-# and appends the link flags to NGX_LD_OPT for static nginx builds.
+#
+# The link flags flow ONLY through each module's ngx_module_libs (see
+# filter/config and static/config): nginx's auto/module routes those to
+# CORE_LIBS for a static (--add-module) build and to the module's own
+# link line for a dynamic (--add-dynamic-module) build. They must NOT be
+# appended to NGX_LD_OPT — that variable is global to the whole build, so
+# every OTHER dynamic module in the same nginx configure (e.g. an
+# ngx_brotli pair) would pick up a spurious DT_NEEDED on libzstd, which
+# surfaces as dependency bloat in distro packaging (this module's .so
+# requirements leaking onto unrelated module packages).
 
 ngx_feature_incs="#include <zstd.h>"
 # ZSTD_compressStream2() (and ZSTD_CCtx_reset(), used unconditionally by the
@@ -124,8 +133,6 @@ END
     fi
 
 fi
-
-NGX_LD_OPT="$ngx_zstd_opt_L $NGX_LD_OPT"
 
 # Advisory: report the detected zstd version when a directive's full
 # functionality needs a newer library than the 1.4.0 floor enforced above.

--- a/config
+++ b/config
@@ -1,8 +1,10 @@
 _ngx_zstd_root=$ngx_addon_dir
 
-# Discover libzstd once (sets ngx_zstd_opt_I / ngx_zstd_opt_L, appends to
-# NGX_LD_OPT, emits the version advisory). Both module configs below reuse the
-# result instead of repeating the probe.
+# Discover libzstd once (sets ngx_zstd_opt_I / ngx_zstd_opt_L, emits the
+# version advisory). Both module configs below reuse the result instead of
+# repeating the probe. The link flags flow only through each module's
+# ngx_module_libs — never NGX_LD_OPT, which is build-global and would leak
+# a libzstd DT_NEEDED onto every other dynamic module (see auto/zstd).
 . $_ngx_zstd_root/auto/zstd
 
 ngx_addon_dir=$_ngx_zstd_root/filter

--- a/filter/config
+++ b/filter/config
@@ -1,6 +1,8 @@
-# libzstd discovery (ngx_zstd_opt_I / ngx_zstd_opt_L, NGX_LD_OPT, version
-# advisory) runs once in ../auto/zstd, sourced from the top-level config before
-# this file. Here we only declare the filter module itself.
+# libzstd discovery (ngx_zstd_opt_I / ngx_zstd_opt_L, version advisory) runs
+# once in ../auto/zstd, sourced from the top-level config before this file.
+# Here we only declare the filter module itself; the link flags are passed
+# via ngx_module_libs only (never the build-global NGX_LD_OPT — see
+# ../auto/zstd).
 
 HTTP_ZSTD_SRCS="$ngx_addon_dir/ngx_http_zstd_filter_module.c"
 

--- a/static/config
+++ b/static/config
@@ -1,6 +1,8 @@
-# libzstd discovery (ngx_zstd_opt_I / ngx_zstd_opt_L, NGX_LD_OPT, version
-# advisory) runs once in ../auto/zstd, sourced from the top-level config before
-# this file. Here we only declare the static module itself.
+# libzstd discovery (ngx_zstd_opt_I / ngx_zstd_opt_L, version advisory) runs
+# once in ../auto/zstd, sourced from the top-level config before this file.
+# Here we only declare the static module itself; the link flags are passed
+# via ngx_module_libs only (never the build-global NGX_LD_OPT — see
+# ../auto/zstd).
 
 # build the ngx_http_zstd_static_module
 HTTP_ZSTD_SRCS="$ngx_addon_dir/ngx_http_zstd_static_module.c"

--- a/tools/ci-linkcheck-module/config
+++ b/tools/ci-linkcheck-module/config
@@ -1,0 +1,18 @@
+# CI-only stub module: an unrelated dynamic module built in the same
+# nginx configure as the zstd modules, so CI can assert that libzstd
+# does NOT leak onto its DT_NEEDED (the NGX_LD_OPT regression this
+# repo fixed: that variable is build-global, and an addon appending
+# link flags there signs up every neighbouring module). Declares no
+# libs, no directives, no handlers — its only job is to exist and be
+# linked by the same build.
+
+ngx_addon_name=ngx_http_linkcheck_module
+ngx_module_type=HTTP
+ngx_module_name=ngx_http_linkcheck_module
+ngx_module_incs=
+ngx_module_deps=
+ngx_module_srcs="$ngx_addon_dir/ngx_http_linkcheck_module.c"
+ngx_module_libs=
+ngx_module_order=
+
+. auto/module

--- a/tools/ci-linkcheck-module/ngx_http_linkcheck_module.c
+++ b/tools/ci-linkcheck-module/ngx_http_linkcheck_module.c
@@ -1,0 +1,49 @@
+
+/*
+ * CI-only stub module. Built as an unrelated dynamic module in the same
+ * nginx configure as the zstd modules so the linkage-isolation CI job
+ * can assert libzstd does not leak onto its DT_NEEDED (see ../../auto/zstd:
+ * link flags must flow through ngx_module_libs, never the build-global
+ * NGX_LD_OPT). No directives, no handlers, no behaviour.
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+
+static ngx_http_module_t  ngx_http_linkcheck_module_ctx = {
+    NULL,                                   /* preconfiguration */
+    NULL,                                   /* postconfiguration */
+
+    NULL,                                   /* create main configuration */
+    NULL,                                   /* init main configuration */
+
+    NULL,                                   /* create server configuration */
+    NULL,                                   /* merge server configuration */
+
+    NULL,                                   /* create location configuration */
+    NULL,                                   /* merge location configuration */
+};
+
+
+static ngx_command_t  ngx_http_linkcheck_commands[] = {
+    ngx_null_command
+};
+
+
+ngx_module_t  ngx_http_linkcheck_module = {
+    NGX_MODULE_V1,
+    &ngx_http_linkcheck_module_ctx,         /* module context */
+    ngx_http_linkcheck_commands,            /* module directives */
+    NGX_HTTP_MODULE,                        /* module type */
+    NULL,                                   /* init master */
+    NULL,                                   /* init module */
+    NULL,                                   /* init process */
+    NULL,                                   /* init thread */
+    NULL,                                   /* exit thread */
+    NULL,                                   /* exit process */
+    NULL,                                   /* exit master */
+    NGX_MODULE_V1_PADDING
+};


### PR DESCRIPTION
Found while packaging this module together with other dynamic modules in one nginx build: every *other* module's `.so` in the build links `libzstd.so.1` — compression-adjacent or not.

```
ngx_http_brotli_filter_module.so:
        libzstd.so.1 => /lib64/libzstd.so.1          <-- spurious
        libbrotlienc.so.1 => /lib64/libbrotlienc.so.1
        ...
ngx_http_brotli_static_module.so:
        libzstd.so.1 => /lib64/libzstd.so.1          <-- needs NO compression lib at all
ngx_http_headers_more_filter_module.so:
        libzstd.so.1 => /lib64/libzstd.so.1          <-- entirely unrelated module
ngx_http_accept_language_module.so:
        libzstd.so.1 => /lib64/libzstd.so.1          <-- entirely unrelated module
```

**Cause:** `auto/zstd` ends with `NGX_LD_OPT="$ngx_zstd_opt_L $NGX_LD_OPT"`. `NGX_LD_OPT` is global to the whole nginx build — the main binary and every dynamic module link with it — so the discovered `-lzstd` (or the full pkg-config libs) lands on every unrelated `.so` in the same configure. Distro packaging then converts the stray `DT_NEEDED` into real dependency bloat through automatic `.so` requires.

**The append is also redundant for this module itself:** the same flags already flow through each module's `ngx_module_libs` (`filter/config` / `static/config`), and nginx's `auto/module` routes those to `CORE_LIBS` for a static `--add-module` build and to the module's own link line for a dynamic build. So deleting the append changes nothing for either build shape of *this* module — it only stops contaminating the neighbors.

**Verification** (combined `--add-dynamic-module` build of this module + an ngx_brotli pair, after the fix):

```
ngx_http_brotli_filter_module.so: libbrotlicommon.so.1 libbrotlienc.so.1
ngx_http_brotli_static_module.so: (no compression libs)
ngx_http_zstd_filter_module.so:   libzstd.so.1
ngx_http_zstd_static_module.so:   libzstd.so.1
```

plus: a static `--add-module` nginx still links libzstd (the `CORE_LIBS` path), and `tools/test_encoding.py` and `tools/test_dcz.py` pass against the rebuilt static binary. The `auto/zstd` header comment now documents why the flags must stay per-module, so the append does not quietly come back.
