### PR TITLE
ci: fix CI Deep's nginx build and test environment

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -590,6 +590,12 @@ jobs:
     env:
       # Resolved mainline nginx — names the build artifact to download.
       NGINX_VERSION: ${{ needs.resolve.outputs.nginx_version }}
+      # Every Test::Nginx job on this self-hosted runner needs its own listen
+      # port: the 1984 default collides across concurrent jobs (and with
+      # ci-deep.yml's matrix), and the loser dies with "Address already in
+      # use" at whatever test it happened to reach. Spaced by 10 because
+      # Test::Nginx reserves port+1..+3 for its stream servers.
+      TEST_NGINX_SERVER_PORT: "2014"
 
     steps:
       - name: Checkout module
@@ -850,6 +856,9 @@ jobs:
     runs-on: [self-hosted, builder02, lxc]
     timeout-minutes: 20
     needs: build-asan
+    env:
+      # Own Test::Nginx listen port — see the tests job for why.
+      TEST_NGINX_SERVER_PORT: "2024"
 
     steps:
       - name: Checkout module
@@ -970,6 +979,8 @@ jobs:
     needs: resolve
     env:
       NGINX_VERSION: ${{ needs.resolve.outputs.nginx_version }}
+      # Own Test::Nginx listen port — see the tests job for why.
+      TEST_NGINX_SERVER_PORT: "2034"
 
     steps:
       - name: Checkout module

--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -119,13 +119,20 @@ jobs:
           TEST_NGINX_SERVER_PORT: "${{ matrix.port }}"
         run: |
           export PERL5LIB="$HOME/perl5/lib/perl5:${PERL5LIB:-}"
-          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-${{ matrix.flavor }}-${{ matrix.version }}"
-          mkdir -p "$TEST_NGINX_SERVROOT"
           cd "$GITHUB_WORKSPACE"
           # t/01-static.t asserts on fixture mtimes (Last-Modified/If-Modified-Since);
           # pin them to a fixed timestamp, same as build-test.yml's tests job.
           touch -d @1541504307 t/suite/test t/suite/test.zst
-          prove -v t/00-filter.t t/01-static.t t/02-conf-warn.t
+          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-${{ matrix.flavor }}-${{ matrix.version }}"
+          mkdir -p "$TEST_NGINX_SERVROOT"
+          prove -v t/00-filter.t t/02-conf-warn.t
+          # 01-static.t serves fixtures via "root ../../t/suite", which only
+          # resolves when the servroot sits two levels under the checkout —
+          # a /tmp servroot makes every static case 404. Same split as
+          # build-test.yml's tests job.
+          export TEST_NGINX_SERVROOT="$GITHUB_WORKSPACE/t/servroot-static"
+          mkdir -p "$TEST_NGINX_SERVROOT"
+          prove -v t/01-static.t
 
   fuzz:
     name: Fuzz (Accept-Encoding, long)

--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -58,15 +58,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # port: every leg of this matrix runs concurrently on the SAME
+          # self-hosted runner, so each needs its own Test::Nginx listen port
+          # — the 1984 default makes the losers die with "Address already in
+          # use" and bail out at whatever test they happened to reach.
+          # Spaced by 10 because Test::Nginx reserves port+1..+3 for its
+          # stream servers. Kept distinct from build-test.yml's ports too,
+          # since both workflows can run at once on this runner.
           - flavor: nginx
             version: "1.31.2"
             label: mainline
+            port: 1984
           - flavor: nginx
             version: "1.30.3"
             label: stable
+            port: 1994
           - flavor: angie
             version: "1.11.5"
             label: angie
+            port: 2004
     steps:
       - name: Checkout module
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -105,6 +115,8 @@ jobs:
           # See build-test.yml's identical setting for why this must be 20,
           # not the ~2s Test::Nginx::Socket default.
           TEST_NGINX_TIMEOUT: "20"
+          # Per-leg listen port — see the matrix comment above.
+          TEST_NGINX_SERVER_PORT: "${{ matrix.port }}"
         run: |
           export PERL5LIB="$HOME/perl5/lib/perl5:${PERL5LIB:-}"
           export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-${{ matrix.flavor }}-${{ matrix.version }}"

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -211,13 +211,29 @@ echo "Phase 2: Configuring $FLAVOR with zstd module"
 echo "=========================================================================="
 echo ""
 
+# The flags below are what t/ requires, not preferences — build-test.yml's
+# nginx carries the same set, and CI Deep's binary has to match or the suite
+# fails on the build rather than on the module:
+#   http_sub_module      — t/00-filter.t TEST 33 uses sub_filter
+#   http_auth_request    — t/00-filter.t TEST 58 uses auth_request
+#     (without either, config load fails with "unknown directive" and
+#      Test::Nginx bails out of the whole TAP file)
+#   --with-debug         — TEST 91 asserts on a debug-level error.log line
+#   ZSTD_STATIC_LINKING_ONLY — TEST 45 needs the memory-estimation API that
+#     zstd_max_cctx_memory is built on; auto/zstd only defines it on the
+#     explicit ZSTD_INC path, not on the pkg-config auto-discovery path this
+#     script takes.
 ./configure \
     --prefix=/etc/nginx \
     --sbin-path=/usr/sbin/"$FLAVOR" \
+    --with-debug \
     --with-http_ssl_module \
     --with-http_gzip_static_module \
     --with-http_realip_module \
     --with-http_v2_module \
+    --with-http_sub_module \
+    --with-http_auth_request_module \
+    --with-cc-opt="-DZSTD_STATIC_LINKING_ONLY" \
     --add-dynamic-module="$ZSTD_MODULE_DIR" \
     2>&1 | tail -5
 


### PR DESCRIPTION
> Fixes the scheduled CI Deep failure (run 30687286852). CI-only; no module code touched.

**TL;DR** — CI Deep built an nginx that couldn't load the test suite's config, so all three build-flavor legs died before finishing. The build now includes what `t/` actually uses.

`tools/ci-build.sh` — used only by CI Deep's `build-flavors` matrix — configured nginx without `--with-http_sub_module` or `--with-http_auth_request_module`. `t/00-filter.t` TEST 33 uses `sub_filter` and TEST 58 uses `auth_request`, so nginx refused to start with `unknown directive`, which Test::Nginx reports as `Cannot start nginx ... (status code 256)` and turns into a bailout. Test::Nginx shuffles test order, which is why each leg bailed at a different test — 1.31.2 and 1.30.3 at TEST 33, angie at TEST 58 — with zero assertion failures anywhere.

Fixing that exposed three more gaps between this build and `build-test.yml`'s, which have been there as long as the matrix has:

- TEST 91 asserts on a debug-level `error.log` line → needs `--with-debug`.
- TEST 45 exercises `zstd_max_cctx_memory`, built on libzstd's memory-estimation API → needs `-DZSTD_STATIC_LINKING_ONLY`. `auto/zstd` defines it on the explicit `ZSTD_INC` path but not on the pkg-config auto-discovery path this script takes.
- `t/01-static.t` serves fixtures through `root ../../t/suite`, which resolves only when the servroot sits two levels under the checkout. The shared `/tmp` servroot 404'd every static case, so the `prove` call is split the way `build-test.yml`'s tests job splits it.

Separately, every Test::Nginx job on the `builder02` runner bound the default port 1984 — the three matrix legs concurrently, plus `tests`, `tests-asan` and `coverage` in `build-test.yml`. That never caused the failure above, but it is a live race: with a socket already on the port, nginx exits 1 and produces the same bailout signature. Each job now gets its own `TEST_NGINX_SERVER_PORT`, spaced by 10 because Test::Nginx reserves `port+1..+3` for its stream servers. `t/` already templates the variable into every `proxy_pass`, so no test changes.

## Testing

- `bash tools/ci-build.sh nginx 1.31.2` locally, then the exact CI Deep step against that binary: `prove t/00-filter.t t/02-conf-warn.t` (1094 tests) and `prove t/01-static.t` (345 tests) — all pass. Before the flag change the same build bailed on TEST 58 and failed all of `01-static.t`.
- Port change verified independently: run with `TEST_NGINX_SERVER_PORT=2094` passes and the generated `nginx.conf` contains `listen 2094;`; the same run with a socket already bound to 127.0.0.1:2094 exits 255 with `Cannot start nginx ... (status code 256)`.
- CI Deep dispatched on this branch at 1e80780: all three matrix legs green, plus both Valgrind soaks, fuzz and scanners (run 30702321329). The intermediate dispatch on the port-only commit is what surfaced the auth_request gap.
- `actionlint` and `shellcheck` clean on the changed files.
