### PR TITLE
build: stop requesting -lzstd for the static module

### DIFF
--- a/static/config
+++ b/static/config
@@ -17,7 +17,14 @@ ngx_module_name=ngx_http_zstd_static_module
 ngx_module_incs="$ngx_zstd_opt_I"
 ngx_module_srcs=$HTTP_ZSTD_SRCS
 ngx_module_deps=$HTTP_ZSTD_DEPS
-ngx_module_libs="$ngx_zstd_opt_L"
+# No libs on purpose: the static module serves pre-compressed .zst files
+# and calls no libzstd function. Requesting $ngx_zstd_opt_L here only
+# produced a toolchain-dependent vestigial DT_NEEDED on the .so —
+# kept by linkers without --as-needed, dropped by toolchains that
+# default to it (e.g. Ubuntu) — encoding a linker default instead of
+# module behaviour, and differing from sibling static modules (the
+# brotli static module requests nothing).
+ngx_module_libs=
 ngx_module_order="ngx_http_brotli_static_module \
                   $ngx_module_name"
 


### PR DESCRIPTION
The follow-up promised in the #94 thread: the static module's `-lzstd` request is vestigial and is now gone.

The static module serves pre-compressed `.zst` files and calls no libzstd function (its only content inspection is a magic-number memcmp). `ngx_module_libs="$ngx_zstd_opt_L"` therefore bought nothing except a toolchain-dependent `DT_NEEDED` on the dynamic `.so`: kept by linkers without `--as-needed`, dropped by toolchains that default to it (Ubuntu, hence the CI runners — which is exactly how #94's linkage job tripped over it on its first run). Encoding a linker default rather than module behaviour, and inconsistent with sibling static modules (ngx_brotli's static module requests nothing) for no reason.

**Interplay with #94, deliberately kept independent:** this branch is based on `master`, and the two PRs touch different hunks of `static/config`, so they merge cleanly in either order. Behaviourally, the full effect on the dynamic `.so` lands only once both are in — until the `NGX_LD_OPT` append is gone, the build-global leak re-adds libzstd to every module regardless of `ngx_module_libs` (verified: on master + this change alone, the static `.so` still carries libzstd via the leak).

**Verified on the merged pair** (this branch + #94), non-`--as-needed` toolchain — the environment where the vestigial NEEDED previously always stuck:

- dynamic build: filter `.so` links libzstd; static `.so` links only libc;
- static `--add-module` build: the nginx binary still links libzstd (the filter module routes it through `CORE_LIBS`; the static module needs nothing there either);
- `t/01-static.t`: 345/345 assertions pass, including the zstd-frame-probe tests (the memcmp needs no library).

After both merge, `ldd` on the packaged modules reads the same on every distro: filter → libzstd, static → nothing, neighbours → their own libraries only.
