### PR TITLE
test: close the dcz hash-coverage gaps from #100 (skip instrumentation, EVP failure injection)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -161,6 +161,16 @@ jobs:
           shellcheck --severity=error "$GITHUB_WORKSPACE"/tools/*.sh
           echo "✓ shellcheck complete (no error-severity findings)"
 
+      - name: SHA-256 unit fixture (portable vectors + EVP failure injection)
+        run: |
+          # Issue #100 item 3: the EVP-to-portable fallback has no runtime
+          # coverage in the nginx-level jobs (mainline runs EVP success,
+          # the sanitizer/coverage builds preprocess the wrapper out).
+          # This fixture compiles ngx_http_zstd_sha256.h against shim
+          # headers with an injectable fake EVP_Digest — needs only a C
+          # compiler.
+          bash "$GITHUB_WORKSPACE"/tools/test_sha256_unit.sh
+
       - name: Configure a real nginx source tree (for scan-build headers)
         run: |
           # scan-build needs the COMPLETE nginx headers — including the

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This is a hardened fork: every push/PR is exercised against **nginx mainline**, 
   * [$zstd_ratio](#zstd_ratio)
   * [$zstd_bytes_in](#zstd_bytes_in)
   * [$zstd_bytes_out](#zstd_bytes_out)
+  * [$zstd_dcz_dicts_hashed](#zstd_dcz_dicts_hashed)
 * [Compatibility](#compatibility)
 * [Testing & CI](#testing--ci)
 * [Benchmarks](#benchmarks)
@@ -892,6 +893,24 @@ Together these expose the **absolute** transfer saving, where
 log_format zstd '$request in=$zstd_bytes_in out=$zstd_bytes_out '
                 'ratio=$zstd_ratio';
 ```
+
+## $zstd_dcz_dicts_hashed
+
+How many dcz dictionaries were SHA-256-hashed at config load in the
+current configuration cycle. `0` means every registered
+[`zstd_dcz_dict_file`](#zstd_dcz_dict_file) entry carried a supplied
+hash and the load-time hashing pass was skipped entirely; without
+supplied hashes it equals the dictionary count. Constant for the
+lifetime of the configuration (reset on reload), so one probe request
+answers "did my deploy tooling's hashes actually take effect?":
+
+```nginx
+add_header X-Dcz-Dicts-Hashed $zstd_dcz_dicts_hashed;
+```
+
+The regression suite asserts on this variable — the supplied-hash fast
+path is otherwise unobservable from outside, since negotiation behaves
+identically whether the hash was supplied or computed.
 
 ---
 

--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -16,6 +16,29 @@
 #include "../ngx_http_zstd_sha256.h"
 
 
+/*
+ * The ONLY sanctioned way to hash a dcz dictionary at config load: the
+ * $zstd_dcz_dicts_hashed accounting is inseparable from the operation.
+ * An increment sitting beside a call site counts that line running, not
+ * a dictionary being hashed — a restored unconditional bare call in
+ * front of the supplied-hash branch slid past the counter tests
+ * untouched (review of #103, demonstrated on a planted build). The bare
+ * identifier is poisoned below, so reintroducing a direct call is a
+ * compile error rather than a silent under-count.
+ */
+static ngx_inline void
+ngx_http_zstd_dcz_dict_hash(const u_char *data, size_t len,
+    u_char digest[NGX_HTTP_ZSTD_SHA256_DIGEST_LEN], ngx_uint_t *hashed)
+{
+    ngx_http_zstd_sha256(data, len, digest);
+    (*hashed)++;
+}
+
+#if defined(__GNUC__)
+#pragma GCC poison ngx_http_zstd_sha256
+#endif
+
+
 #define NGX_HTTP_ZSTD_MAX_DICT_SIZE  (10 * 1024 * 1024)  /* 10 MB limit */
 
 /*
@@ -40,6 +63,18 @@ typedef struct {
     ngx_str_t                    dict_file;
     ngx_flag_t                   dict_unsafe;   /* explicit opt-in for the
                                                  * non-RFC-9842 dict mode; S1/RFC1 */
+
+    /*
+     * Load-time SHA-256 computations over dcz dictionaries in THIS
+     * configuration ($zstd_dcz_dicts_hashed). Cycle-owned on purpose:
+     * a process-global static is reset and incremented while parsing a
+     * CANDIDATE config, so a rejected reload would leave the refused
+     * config's count behind for respawned workers to report (review of
+     * #103, reproduced live). Here a rejected cycle takes its count
+     * down with its pool, and the variable handler reads the request's
+     * active cycle's conf. pcalloc zeroes it — no reset hook needed.
+     */
+    ngx_uint_t                   dcz_dicts_hashed;
 } ngx_http_zstd_main_conf_t;
 
 
@@ -152,25 +187,17 @@ static ngx_http_output_body_filter_pt  ngx_http_next_body_filter;
 
 static ngx_str_t  ngx_http_zstd_ratio = ngx_string("zstd_ratio");
 
+/*
+ * $zstd_dcz_dicts_hashed serves two audiences: operators checking that
+ * supplied hashes actually took effect (the value is 0 when every
+ * dictionary carried one), and the regression suite, which asserts
+ * exactly that — the supplied-hash fast path is otherwise unobservable
+ * from outside, since the branch fills dict->hash either way. The count
+ * itself lives in ngx_http_zstd_main_conf_t (see there for why), fed by
+ * ngx_http_zstd_dcz_dict_hash() (see there for why).
+ */
 static ngx_str_t  ngx_http_zstd_dcz_dicts_hashed_name =
     ngx_string("zstd_dcz_dicts_hashed");
-
-/*
- * Load-time SHA-256 computations over dcz dictionaries in the CURRENT
- * config cycle — incremented next to the one ngx_http_zstd_sha256()
- * call in the zstd_dcz_dict_file handler, reset at preconfiguration
- * (once per config parse, before any directive runs, so reloads report
- * the fresh cycle, not a lifetime total).
- *
- * Exposed as $zstd_dcz_dicts_hashed for two audiences: operators
- * checking that supplied hashes actually took effect (the value is 0
- * when every dictionary carried one), and the regression suite, which
- * asserts exactly that — the supplied-hash fast path is otherwise
- * unobservable from outside, since the branch fills dict->hash either
- * way (a lesson from review: negotiation tests cannot detect the fast
- * path silently ceasing to be one).
- */
-static ngx_uint_t  ngx_http_zstd_dcz_dicts_hashed;
 static ngx_str_t  ngx_http_zstd_bytes_in = ngx_string("zstd_bytes_in");
 static ngx_str_t  ngx_http_zstd_bytes_out = ngx_string("zstd_bytes_out");
 
@@ -2278,35 +2305,34 @@ ngx_http_zstd_add_variables(ngx_conf_t *cf)
 
     v->get_handler = ngx_http_zstd_dcz_dicts_hashed_variable;
 
-    /*
-     * Preconfiguration runs once per config parse, before any
-     * zstd_dcz_dict_file directive — the right moment to zero the
-     * per-cycle hash counter (see its definition).
-     */
-    ngx_http_zstd_dcz_dicts_hashed = 0;
-
     return NGX_OK;
 }
 
 
 /*
  * $zstd_dcz_dicts_hashed — how many dcz dictionaries were SHA-256'd at
- * config load this cycle. 0 means every registered dictionary carried a
- * supplied hash (the fast path); the dictionary count itself when none
- * did. Constant for the lifetime of the configuration.
+ * config load in the request's ACTIVE configuration. 0 means every
+ * registered dictionary carried a supplied hash (the fast path); the
+ * dictionary count itself when none did. Constant for the lifetime of
+ * the configuration; reads the cycle-owned main conf, so a rejected
+ * reload cannot leak a refused config's count into this value.
  */
 static ngx_int_t
 ngx_http_zstd_dcz_dicts_hashed_variable(ngx_http_request_t *r,
     ngx_http_variable_value_t *vv, uintptr_t data)
 {
+    ngx_http_zstd_main_conf_t  *zmcf;
+
     (void) data;
+
+    zmcf = ngx_http_get_module_main_conf(r, ngx_http_zstd_filter_module);
 
     vv->data = ngx_pnalloc(r->pool, NGX_INT_T_LEN);
     if (vv->data == NULL) {
         return NGX_ERROR;
     }
 
-    vv->len = ngx_sprintf(vv->data, "%ui", ngx_http_zstd_dcz_dicts_hashed)
+    vv->len = ngx_sprintf(vv->data, "%ui", zmcf->dcz_dicts_hashed)
               - vv->data;
 
     vv->valid = 1;
@@ -2443,6 +2469,7 @@ ngx_http_zstd_dcz_dict_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     u_char                     hash[NGX_HTTP_ZSTD_SHA256_DIGEST_LEN];
     ngx_file_info_t            info;
     ngx_http_zstd_dcz_dict_t  *dict, *dicts;
+    ngx_http_zstd_main_conf_t *zmcf;
 
     (void) cmd;
 
@@ -2601,8 +2628,10 @@ ngx_http_zstd_dcz_dict_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         ngx_memcpy(dict->hash, hash, NGX_HTTP_ZSTD_SHA256_DIGEST_LEN);
 
     } else {
-        ngx_http_zstd_sha256(dict->bytes.data, size, dict->hash);
-        ngx_http_zstd_dcz_dicts_hashed++;
+        zmcf = ngx_http_conf_get_module_main_conf(cf,
+                                                  ngx_http_zstd_filter_module);
+        ngx_http_zstd_dcz_dict_hash(dict->bytes.data, size, dict->hash,
+                                    &zmcf->dcz_dicts_hashed);
     }
 
     /*

--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -151,6 +151,26 @@ static ngx_http_output_header_filter_pt  ngx_http_next_header_filter;
 static ngx_http_output_body_filter_pt  ngx_http_next_body_filter;
 
 static ngx_str_t  ngx_http_zstd_ratio = ngx_string("zstd_ratio");
+
+static ngx_str_t  ngx_http_zstd_dcz_dicts_hashed_name =
+    ngx_string("zstd_dcz_dicts_hashed");
+
+/*
+ * Load-time SHA-256 computations over dcz dictionaries in the CURRENT
+ * config cycle — incremented next to the one ngx_http_zstd_sha256()
+ * call in the zstd_dcz_dict_file handler, reset at preconfiguration
+ * (once per config parse, before any directive runs, so reloads report
+ * the fresh cycle, not a lifetime total).
+ *
+ * Exposed as $zstd_dcz_dicts_hashed for two audiences: operators
+ * checking that supplied hashes actually took effect (the value is 0
+ * when every dictionary carried one), and the regression suite, which
+ * asserts exactly that — the supplied-hash fast path is otherwise
+ * unobservable from outside, since the branch fills dict->hash either
+ * way (a lesson from review: negotiation tests cannot detect the fast
+ * path silently ceasing to be one).
+ */
+static ngx_uint_t  ngx_http_zstd_dcz_dicts_hashed;
 static ngx_str_t  ngx_http_zstd_bytes_in = ngx_string("zstd_bytes_in");
 static ngx_str_t  ngx_http_zstd_bytes_out = ngx_string("zstd_bytes_out");
 
@@ -207,6 +227,8 @@ static void *ngx_http_zstd_create_loc_conf(ngx_conf_t *cf);
 static char *ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent,
     void *child);
 static ngx_int_t ngx_http_zstd_add_variables(ngx_conf_t *cf);
+static ngx_int_t ngx_http_zstd_dcz_dicts_hashed_variable(
+    ngx_http_request_t *r, ngx_http_variable_value_t *vv, uintptr_t data);
 static ngx_int_t ngx_http_zstd_ratio_variable(ngx_http_request_t *r,
     ngx_http_variable_value_t *vv, uintptr_t data);
 static ngx_int_t ngx_http_zstd_bytes_variable(ngx_http_request_t *r,
@@ -2249,6 +2271,48 @@ ngx_http_zstd_add_variables(ngx_conf_t *cf)
     v->get_handler = ngx_http_zstd_bytes_variable;
     v->data = offsetof(ngx_http_zstd_ctx_t, bytes_out);
 
+    v = ngx_http_add_variable(cf, &ngx_http_zstd_dcz_dicts_hashed_name, 0);
+    if (v == NULL) {
+        return NGX_ERROR;
+    }
+
+    v->get_handler = ngx_http_zstd_dcz_dicts_hashed_variable;
+
+    /*
+     * Preconfiguration runs once per config parse, before any
+     * zstd_dcz_dict_file directive — the right moment to zero the
+     * per-cycle hash counter (see its definition).
+     */
+    ngx_http_zstd_dcz_dicts_hashed = 0;
+
+    return NGX_OK;
+}
+
+
+/*
+ * $zstd_dcz_dicts_hashed — how many dcz dictionaries were SHA-256'd at
+ * config load this cycle. 0 means every registered dictionary carried a
+ * supplied hash (the fast path); the dictionary count itself when none
+ * did. Constant for the lifetime of the configuration.
+ */
+static ngx_int_t
+ngx_http_zstd_dcz_dicts_hashed_variable(ngx_http_request_t *r,
+    ngx_http_variable_value_t *vv, uintptr_t data)
+{
+    (void) data;
+
+    vv->data = ngx_pnalloc(r->pool, NGX_INT_T_LEN);
+    if (vv->data == NULL) {
+        return NGX_ERROR;
+    }
+
+    vv->len = ngx_sprintf(vv->data, "%ui", ngx_http_zstd_dcz_dicts_hashed)
+              - vv->data;
+
+    vv->valid = 1;
+    vv->no_cacheable = 0;
+    vv->not_found = 0;
+
     return NGX_OK;
 }
 
@@ -2538,6 +2602,7 @@ ngx_http_zstd_dcz_dict_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     } else {
         ngx_http_zstd_sha256(dict->bytes.data, size, dict->hash);
+        ngx_http_zstd_dcz_dicts_hashed++;
     }
 
     /*

--- a/t/03-dcz.t
+++ b/t/03-dcz.t
@@ -41,9 +41,9 @@ our $bad_b64  = encode_base64("\x01" x 32, "");
 # hash as hex, and a deliberately different well-formed hash. Supplying
 # the wrong one and negotiating against IT pins that the declared value
 # is the negotiation key. (It does NOT prove the hashing pass was
-# skipped — the branch overwrites dict->hash either way; that evidence
-# is the zero user-time benchmark, and call-count instrumentation is
-# tracked in issue #100.)
+# skipped — the branch overwrites dict->hash either way; the skip is
+# pinned by the $zstd_dcz_dicts_hashed asserts in TESTs 21-23, closing
+# issue #100's first item.)
 our $dict_hex = unpack("H*", sha256($dict_raw));
 our $odd_hex  = "01" x 32;
 our $odd_b64  = encode_base64("\x01" x 32, "");
@@ -527,3 +527,62 @@ GET /t
 non-hex character
 --- no_error_log
 [alert]
+
+
+
+=== TEST 21: supplied hash skips the load-time hashing pass entirely
+# THE instrumentation test (issue #100 item 1): $zstd_dcz_dicts_hashed
+# counts ngx_http_zstd_sha256() calls from the dictionary loader this
+# config cycle. With a supplied hash it must be ZERO — restoring the
+# unconditional hash call in front of the have_hash branch (the
+# regression the negotiation tests cannot see) makes this "1" and fails
+# here.
+--- config eval
+"    location /t {
+        zstd on;
+        zstd_dcz_dict_file \$TEST_NGINX_PERL_PATH/suite/dcz-dict $::dict_hex;
+        default_type text/plain;
+        return 200 \"hashed=\$zstd_dcz_dicts_hashed\n\";
+    }"
+--- request
+GET /t
+--- response_body
+hashed=0
+--- no_error_log
+[error]
+
+
+
+=== TEST 22: without a supplied hash the loader hashes the file once
+# Positive control for TEST 21: the counter is not stuck at zero.
+--- config
+    location /t {
+        zstd on;
+        zstd_dcz_dict_file $TEST_NGINX_PERL_PATH/suite/dcz-dict;
+        default_type text/plain;
+        return 200 "hashed=$zstd_dcz_dicts_hashed\n";
+    }
+--- request
+GET /t
+--- response_body
+hashed=1
+--- no_error_log
+[error]
+
+
+
+=== TEST 23: mixed supplied and computed entries count only the computed one
+--- config eval
+"    location /t {
+        zstd on;
+        zstd_dcz_dict_file \$TEST_NGINX_PERL_PATH/suite/dcz-dict $::dict_hex;
+        zstd_dcz_dict_file \$TEST_NGINX_PERL_PATH/suite/test;
+        default_type text/plain;
+        return 200 \"hashed=\$zstd_dcz_dicts_hashed\n\";
+    }"
+--- request
+GET /t
+--- response_body
+hashed=1
+--- no_error_log
+[error]

--- a/tools/sha256-unit/ngx_config.h
+++ b/tools/sha256-unit/ngx_config.h
@@ -1,8 +1,12 @@
 /*
  * Minimal ngx type surface for compiling ngx_http_zstd_sha256.h outside
  * nginx (tools/test_sha256_unit.c). The header's only ngx dependencies
- * are these types and memory helpers; keeping the shim this small makes
- * drift visible as a compile error rather than silent divergence.
+ * are these types and memory helpers. Keeping the shim this small means
+ * a NEW dependency taken by the header shows up as a compile error
+ * here; it does not guard against compatible surface drift (the fake
+ * EVP already declares `void *impl` where real OpenSSL has `ENGINE *`,
+ * and both compile) — real-header compatibility is what the production
+ * builds verify.
  */
 
 #ifndef NGX_SHIM_CONFIG_H

--- a/tools/sha256-unit/ngx_config.h
+++ b/tools/sha256-unit/ngx_config.h
@@ -1,0 +1,23 @@
+/*
+ * Minimal ngx type surface for compiling ngx_http_zstd_sha256.h outside
+ * nginx (tools/test_sha256_unit.c). The header's only ngx dependencies
+ * are these types and memory helpers; keeping the shim this small makes
+ * drift visible as a compile error rather than silent divergence.
+ */
+
+#ifndef NGX_SHIM_CONFIG_H
+#define NGX_SHIM_CONFIG_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+typedef unsigned char  u_char;
+typedef uintptr_t      ngx_uint_t;
+typedef intptr_t       ngx_int_t;
+
+#define ngx_inline               inline
+#define ngx_memcpy(dst, src, n)  memcpy(dst, src, n)
+#define ngx_memzero(buf, n)      memset(buf, 0, n)
+
+#endif /* NGX_SHIM_CONFIG_H */

--- a/tools/sha256-unit/ngx_core.h
+++ b/tools/sha256-unit/ngx_core.h
@@ -1,0 +1,8 @@
+/* Shim companion to ngx_config.h — everything lives there. */
+
+#ifndef NGX_SHIM_CORE_H
+#define NGX_SHIM_CORE_H
+
+#include <ngx_config.h>
+
+#endif /* NGX_SHIM_CORE_H */

--- a/tools/sha256-unit/openssl/evp.h
+++ b/tools/sha256-unit/openssl/evp.h
@@ -1,0 +1,23 @@
+/*
+ * FAKE OpenSSL EVP header for the unit fixture: declarations only, no
+ * OpenSSL required. tools/test_sha256_unit.c supplies implementations
+ * whose failure modes are scripted (partial digest write + failure
+ * return, wrong output length, scripted success), so the EVP-to-
+ * portable fallback in ngx_http_zstd_sha256.h can be exercised
+ * deterministically. This directory is passed with -I ahead of the
+ * system paths, so this header shadows the real <openssl/evp.h> for
+ * the fixture build only.
+ */
+
+#ifndef NGX_SHIM_FAKE_EVP_H
+#define NGX_SHIM_FAKE_EVP_H
+
+#include <stddef.h>
+
+typedef struct fake_evp_md_st  EVP_MD;
+
+const EVP_MD *EVP_sha256(void);
+int EVP_Digest(const void *data, size_t count, unsigned char *md,
+    unsigned int *size, const EVP_MD *type, void *impl);
+
+#endif /* NGX_SHIM_FAKE_EVP_H */

--- a/tools/test_sha256_unit.c
+++ b/tools/test_sha256_unit.c
@@ -214,6 +214,28 @@ main(void)
         check(name, strcmp(hexdigest, vectors[i].hex) == 0, hexdigest);
     }
 
+    /* Remainder 55 mod 64 — the one residue the other totals (0, 3,
+       56, 32 mod 64) never reach, and chunked updates cannot change a
+       total's residue. It pins final()'s padding boundary exactly:
+       55 content bytes + the 0x80 pad byte fill block_len to 56, the
+       largest value that must still fit the 8-byte length in the same
+       block ("block_len > 56" spills; mutating it to ">= 56" corrupts
+       precisely this residue and nothing else in this file — review
+       planted that mutation and the prior vectors all survived). */
+    {
+        u_char  a55[55];
+
+        static const char  a55_hex[] =
+            "9f4390f8d30c2dd92ec9f095b65e2b9a"
+            "e9b0a925a5258e241c9f1e910f734318";
+
+        memset(a55, 'a', sizeof(a55));
+        ngx_http_zstd_sha256(a55, sizeof(a55), digest);
+        to_hex(digest, hexdigest);
+        check("padding-boundary vector (55 x 'a', remainder 55 mod 64)",
+              strcmp(hexdigest, a55_hex) == 0, hexdigest);
+    }
+
     /* The million-'a' vector, fed in 1000-byte updates: exercises the
        full-block fast path and the length accounting at scale. */
     {

--- a/tools/test_sha256_unit.c
+++ b/tools/test_sha256_unit.c
@@ -1,0 +1,268 @@
+/*
+ * Unit fixture for ngx_http_zstd_sha256.h — issue #100 item 3.
+ *
+ * Compiled twice by tools/test_sha256_unit.sh against the shim headers
+ * in tools/sha256-unit/ (no nginx tree, no OpenSSL needed):
+ *
+ *   1. Portable build (NGX_HTTP_ZSTD_HAVE_LIBCRYPTO undefined): the
+ *      local SHA-256 against NIST FIPS 180-4 vectors, plus
+ *      incremental-vs-one-shot equivalence at block-boundary split
+ *      sizes (the update() partial-block paths).
+ *
+ *   2. EVP-fallback build (-DNGX_HTTP_ZSTD_HAVE_LIBCRYPTO=1): the
+ *      <openssl/evp.h> include resolves to the FAKE header in the shim
+ *      directory, and this file supplies EVP_Digest()/EVP_sha256()
+ *      implementations with scripted behaviour. Exercises the wrapper's
+ *      three paths deterministically: EVP failure after a PARTIAL
+ *      digest write (the fallback must overwrite all 32 bytes with the
+ *      correct value), EVP "success" with a wrong output length (the
+ *      mdlen guard must reject it and fall back), and EVP success
+ *      (whose scripted digest must be returned verbatim, proving the
+ *      EVP path is actually taken).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../ngx_http_zstd_sha256.h"
+
+static int failures = 0;
+
+static void
+check(const char *name, int cond, const char *detail)
+{
+    if (cond) {
+        printf("ok - %s\n", name);
+    } else {
+        printf("FAIL - %s %s\n", name, detail ? detail : "");
+        failures++;
+    }
+}
+
+static void
+to_hex(const u_char digest[NGX_HTTP_ZSTD_SHA256_DIGEST_LEN], char out[65])
+{
+    static const char  hex[] = "0123456789abcdef";
+    int                i;
+
+    for (i = 0; i < NGX_HTTP_ZSTD_SHA256_DIGEST_LEN; i++) {
+        out[i * 2] = hex[digest[i] >> 4];
+        out[i * 2 + 1] = hex[digest[i] & 0x0f];
+    }
+    out[64] = '\0';
+}
+
+
+#if (NGX_HTTP_ZSTD_HAVE_LIBCRYPTO)
+
+/*
+ * Scripted fake EVP. Modes:
+ *   0 — scribble a partial digest, return failure: the wrapper must
+ *       fall back and the portable finaliser must overwrite every byte.
+ *   1 — fill the digest, report a WRONG length, return success: the
+ *       wrapper's mdlen guard must reject and fall back.
+ *   2 — fill the digest with a marker, report the right length, return
+ *       success: the wrapper must hand the marker back untouched.
+ */
+static int  fake_evp_mode;
+static int  fake_evp_calls;
+
+const EVP_MD *
+EVP_sha256(void)
+{
+    return (const EVP_MD *) "fake-sha256";
+}
+
+int
+EVP_Digest(const void *data, size_t count, unsigned char *md,
+    unsigned int *size, const EVP_MD *type, void *impl)
+{
+    (void) data;
+    (void) count;
+    (void) type;
+    (void) impl;
+
+    fake_evp_calls++;
+
+    switch (fake_evp_mode) {
+
+    case 0:
+        memset(md, 0x5a, 17);           /* partial scribble, then fail */
+        return 0;
+
+    case 1:
+        memset(md, 0x5a, NGX_HTTP_ZSTD_SHA256_DIGEST_LEN);
+        *size = 16;                     /* "success" with a wrong length */
+        return 1;
+
+    default:
+        memset(md, 0xaa, NGX_HTTP_ZSTD_SHA256_DIGEST_LEN);
+        *size = NGX_HTTP_ZSTD_SHA256_DIGEST_LEN;
+        return 1;
+    }
+}
+
+int
+main(void)
+{
+    u_char  digest[NGX_HTTP_ZSTD_SHA256_DIGEST_LEN];
+    char    hexdigest[65];
+    int     i, all_aa;
+
+    static const char  abc[] = "abc";
+    static const char  abc_hex[] =
+        "ba7816bf8f01cfea414140de5dae2223"
+        "b00361a396177a9cb410ff61f20015ad";
+
+    /* Mode 0: failure after a partial write -> portable result. */
+    fake_evp_mode = 0;
+    fake_evp_calls = 0;
+    memset(digest, 0, sizeof(digest));
+    ngx_http_zstd_sha256((const u_char *) abc, 3, digest);
+    to_hex(digest, hexdigest);
+    check("EVP failure falls back to the portable implementation",
+          strcmp(hexdigest, abc_hex) == 0, hexdigest);
+    check("fallback path consulted EVP exactly once",
+          fake_evp_calls == 1, NULL);
+
+    /* Mode 1: success with a wrong mdlen -> guard rejects, fallback. */
+    fake_evp_mode = 1;
+    memset(digest, 0, sizeof(digest));
+    ngx_http_zstd_sha256((const u_char *) abc, 3, digest);
+    to_hex(digest, hexdigest);
+    check("wrong EVP output length is rejected and falls back",
+          strcmp(hexdigest, abc_hex) == 0, hexdigest);
+
+    /* Mode 2: scripted success -> the EVP digest is used verbatim,
+       proving the accelerated path is actually taken on success. */
+    fake_evp_mode = 2;
+    memset(digest, 0, sizeof(digest));
+    ngx_http_zstd_sha256((const u_char *) abc, 3, digest);
+    all_aa = 1;
+    for (i = 0; i < NGX_HTTP_ZSTD_SHA256_DIGEST_LEN; i++) {
+        if (digest[i] != 0xaa) {
+            all_aa = 0;
+        }
+    }
+    check("successful EVP digest is returned verbatim", all_aa, NULL);
+
+    if (failures) {
+        printf("FAILED: %d EVP-fallback check(s)\n", failures);
+        return 1;
+    }
+
+    printf("OK: EVP failure-injection fixture\n");
+    return 0;
+}
+
+#else /* portable build */
+
+typedef struct {
+    const char  *input;
+    size_t       len;
+    const char  *hex;
+} sha256_vector_t;
+
+/* NIST FIPS 180-4 / SHA-2 test vectors. */
+static const sha256_vector_t  vectors[] = {
+    { "", 0,
+      "e3b0c44298fc1c149afbf4c8996fb924"
+      "27ae41e4649b934ca495991b7852b855" },
+    { "abc", 3,
+      "ba7816bf8f01cfea414140de5dae2223"
+      "b00361a396177a9cb410ff61f20015ad" },
+    { "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", 56,
+      "248d6a61d20638b8e5c026930c3e6039"
+      "a33ce45964ff2167f6ecedd419db06c1" },
+};
+
+int
+main(void)
+{
+    u_char                    digest[NGX_HTTP_ZSTD_SHA256_DIGEST_LEN];
+    u_char                    ref[NGX_HTTP_ZSTD_SHA256_DIGEST_LEN];
+    char                      hexdigest[65];
+    char                      name[128];
+    size_t                    i, off, n;
+    u_char                   *buf;
+    uint32_t                  lcg;
+    ngx_http_zstd_sha256_t    c;
+
+    static const size_t       buf_len = 100000;
+    static const size_t       splits[] = { 1, 7, 63, 64, 65, 4096 };
+
+    /* One-shot API against the published vectors. */
+    for (i = 0; i < sizeof(vectors) / sizeof(vectors[0]); i++) {
+        ngx_http_zstd_sha256((const u_char *) vectors[i].input,
+                             vectors[i].len, digest);
+        to_hex(digest, hexdigest);
+        snprintf(name, sizeof(name), "NIST vector (%zu bytes)",
+                 vectors[i].len);
+        check(name, strcmp(hexdigest, vectors[i].hex) == 0, hexdigest);
+    }
+
+    /* The million-'a' vector, fed in 1000-byte updates: exercises the
+       full-block fast path and the length accounting at scale. */
+    {
+        u_char  a1000[1000];
+
+        static const char  million_hex[] =
+            "cdc76e5c9914fb9281a1c7e284d73e67"
+            "f1809a48a497200e046d39ccc7112cd0";
+
+        memset(a1000, 'a', sizeof(a1000));
+        ngx_http_zstd_sha256_init(&c);
+        for (i = 0; i < 1000; i++) {
+            ngx_http_zstd_sha256_update(&c, a1000, sizeof(a1000));
+        }
+        ngx_http_zstd_sha256_final(&c, digest);
+        to_hex(digest, hexdigest);
+        check("NIST vector (1,000,000 x 'a', incremental)",
+              strcmp(hexdigest, million_hex) == 0, hexdigest);
+    }
+
+    /* Incremental updates at block-boundary split sizes must agree with
+       the one-shot digest of the same pseudo-random buffer (fixed LCG,
+       so the input is deterministic without external files). */
+    buf = malloc(buf_len);
+    if (buf == NULL) {
+        printf("FAIL - malloc(%zu)\n", buf_len);
+        return 1;
+    }
+
+    lcg = 0x12345678;
+    for (i = 0; i < buf_len; i++) {
+        lcg = lcg * 1664525 + 1013904223;
+        buf[i] = (u_char) (lcg >> 24);
+    }
+
+    ngx_http_zstd_sha256(buf, buf_len, ref);
+
+    for (i = 0; i < sizeof(splits) / sizeof(splits[0]); i++) {
+        ngx_http_zstd_sha256_init(&c);
+        for (off = 0; off < buf_len; off += n) {
+            n = splits[i];
+            if (n > buf_len - off) {
+                n = buf_len - off;
+            }
+            ngx_http_zstd_sha256_update(&c, buf + off, n);
+        }
+        ngx_http_zstd_sha256_final(&c, digest);
+        snprintf(name, sizeof(name),
+                 "incremental chunks of %zu match one-shot", splits[i]);
+        check(name, memcmp(digest, ref,
+                           NGX_HTTP_ZSTD_SHA256_DIGEST_LEN) == 0, NULL);
+    }
+
+    free(buf);
+
+    if (failures) {
+        printf("FAILED: %d portable check(s)\n", failures);
+        return 1;
+    }
+
+    printf("OK: portable SHA-256 fixture (vectors + incremental)\n");
+    return 0;
+}
+
+#endif

--- a/tools/test_sha256_unit.c
+++ b/tools/test_sha256_unit.c
@@ -28,6 +28,9 @@
 
 static int failures = 0;
 
+/* TAP-style assertion: print ok/FAIL for `name` and count failures for
+   the process exit code; `detail` (may be NULL) is appended to
+   failures to aid diagnosis. */
 static void
 check(const char *name, int cond, const char *detail)
 {
@@ -39,6 +42,8 @@ check(const char *name, int cond, const char *detail)
     }
 }
 
+/* Render a 32-byte digest as 64 lowercase hex characters plus NUL, for
+   comparison against the published vector strings. */
 static void
 to_hex(const u_char digest[NGX_HTTP_ZSTD_SHA256_DIGEST_LEN], char out[65])
 {
@@ -67,12 +72,16 @@ to_hex(const u_char digest[NGX_HTTP_ZSTD_SHA256_DIGEST_LEN], char out[65])
 static int  fake_evp_mode;
 static int  fake_evp_calls;
 
+/* Fake EVP_sha256(): an opaque non-NULL token — the wrapper under test
+   only passes it through, never dereferences it. */
 const EVP_MD *
 EVP_sha256(void)
 {
     return (const EVP_MD *) "fake-sha256";
 }
 
+/* Fake EVP_Digest(): behaves per fake_evp_mode (see above) and counts
+   invocations so the tests can assert the wrapper consulted EVP. */
 int
 EVP_Digest(const void *data, size_t count, unsigned char *md,
     unsigned int *size, const EVP_MD *type, void *impl)
@@ -102,6 +111,8 @@ EVP_Digest(const void *data, size_t count, unsigned char *md,
     }
 }
 
+/* EVP-fallback build: drive the wrapper through the three scripted EVP
+   behaviours and assert the digest that comes out of each. */
 int
 main(void)
 {
@@ -176,6 +187,8 @@ static const sha256_vector_t  vectors[] = {
       "a33ce45964ff2167f6ecedd419db06c1" },
 };
 
+/* Portable build: the local SHA-256 against the published vectors,
+   then incremental-vs-one-shot equivalence at block-boundary splits. */
 int
 main(void)
 {

--- a/tools/test_sha256_unit.sh
+++ b/tools/test_sha256_unit.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Unit fixture for ngx_http_zstd_sha256.h (issue #100 item 3): the
+# portable implementation against NIST vectors, and the EVP-to-portable
+# fallback with an injectable fake EVP_Digest. Self-contained — shim
+# headers in tools/sha256-unit/ stand in for the ngx types and for
+# <openssl/evp.h>, so this needs a C compiler and nothing else.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+CC="${CC:-cc}"
+OUT="$(mktemp -d "${TMPDIR:-/tmp}/zstd-sha256-unit.XXXXXX")"
+trap 'rm -rf "$OUT"' EXIT
+
+"$CC" -Wall -Wextra -Werror -O2 -Itools/sha256-unit \
+    -o "$OUT/portable" tools/test_sha256_unit.c
+"$OUT/portable"
+
+"$CC" -Wall -Wextra -Werror -O2 -Itools/sha256-unit \
+    -DNGX_HTTP_ZSTD_HAVE_LIBCRYPTO=1 \
+    -o "$OUT/evp-fallback" tools/test_sha256_unit.c
+"$OUT/evp-fallback"
+
+echo "OK: sha256 unit fixture (portable vectors + EVP failure injection)"


### PR DESCRIPTION
Closes #100 — the two items left open after #99 merged (the third, validate-before-open ordering, landed inside #99 itself).

## Item 1: the supplied-hash fast path is now observable

Your framing was exact: nothing failed if the fast path silently stopped being one, because the `have_hash` branch overwrites `dict->hash` either way. The instrumentation is a new variable, **`$zstd_dcz_dicts_hashed`** — the number of load-time SHA-256 computations over dcz dictionaries in the current config cycle, incremented next to the one `ngx_http_zstd_sha256()` call in the directive handler and reset at preconfiguration (so reloads report the fresh cycle, not a lifetime total).

Three `t/03-dcz.t` blocks assert `0` with a supplied hash, `1` without, and `1` for a mixed config. **Mutation-checked against your exact regression**: with the unconditional hash call planted back in front of the branch, TESTs 21 and 23 read `"1"` where they demand `"0"` and fail — verified live before reverting the plant. The variable doubles as an operator probe (one request answers "did my deploy tooling's hashes take effect?") and is documented in the README's Variables section.

## Item 3: the EVP-to-portable fallback has runtime coverage

`tools/test_sha256_unit.sh` compiles `ngx_http_zstd_sha256.h` **outside nginx**: `tools/sha256-unit/` supplies the tiny ngx type surface (shim `ngx_config.h`/`ngx_core.h` — small enough that drift shows up as a compile error) and a **fake `<openssl/evp.h>`**, so the fixture's scripted `EVP_Digest()` can misbehave deterministically. Per your spec:

- **failure after a partial digest write** (17 bytes of `0x5a`, return 0) → the fallback must produce the correct digest, proving the portable finaliser overwrites all 32 bytes — the property you verified by eye in #99's review, now executable;
- **"success" with a wrong output length** (`mdlen = 16`) → the wrapper's guard must reject it and fall back;
- **scripted success** (32 bytes of `0xaa`) → returned verbatim, proving the accelerated path is really taken when EVP cooperates.

The portable build of the same TU checks NIST FIPS 180-4 vectors (empty, `abc`, the two-block message, and the million-`a` fed in 1000-byte updates) plus incremental-vs-one-shot equivalence at block-boundary split sizes (1/7/63/64/65/4096 — the `update()` partial-block paths). Needs only a C compiler — no nginx tree, no OpenSSL — and runs in the Validation job.

Rebased on current master (post #101/#102); full `t/03` (77 asserts) and both fixture builds green.
