### PR TITLE
ci: split coverage job TAP run into per-suite servrootis

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1163,6 +1163,8 @@ jobs:
       NGINX_VERSION: ${{ needs.resolve.outputs.nginx_version }}
       # Own Test::Nginx listen port — see the tests job for why.
       TEST_NGINX_SERVER_PORT: "2034"
+      # See ci-deep.yml:117 for why this must be 20, not the ~2s Test::Nginx::Socket default.
+      TEST_NGINX_TIMEOUT: "20"
 
     steps:
       - name: Checkout module
@@ -1233,14 +1235,40 @@ jobs:
           cpanm -l ~/perl5 --notest Test::Nginx::Socket
           echo "PERL5LIB=$HOME/perl5/lib/perl5:$PERL5LIB" >> "$GITHUB_ENV"
 
-      - name: Run TAP suite (drives filter/static/conf-warn paths)
+      - name: Run filter module tests
         run: |
           export PERL5LIB="$HOME/perl5/lib/perl5:${PERL5LIB:-}"
+          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-filter"
+          mkdir -p "$TEST_NGINX_SERVROOT"
           cd "$GITHUB_WORKSPACE"
-          # 01-static.t asserts on a fixed ETag derived from fixture mtime;
-          # pin it or every run gets a fresh checkout mtime and fails.
+          prove t/00-filter.t
+
+      - name: Run config-load warning tests
+        run: |
+          export PERL5LIB="$HOME/perl5/lib/perl5:${PERL5LIB:-}"
+          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-confwarn"
+          rm -rf "$TEST_NGINX_SERVROOT"
+          mkdir -p "$TEST_NGINX_SERVROOT"
+          cd "$GITHUB_WORKSPACE"
+          prove t/02-conf-warn.t
+
+      - name: Run static module tests
+        run: |
+          export PERL5LIB="$HOME/perl5/lib/perl5:${PERL5LIB:-}"
+          export TEST_NGINX_SERVROOT="$GITHUB_WORKSPACE/t/servroot-static"
+          mkdir -p "$TEST_NGINX_SERVROOT"
           touch -d @1541504307 "$GITHUB_WORKSPACE/t/suite/test" "$GITHUB_WORKSPACE/t/suite/test.zst"
-          prove t/*.t
+          cd "$GITHUB_WORKSPACE"
+          prove t/01-static.t
+
+      - name: Run dcz negotiation tests
+        run: |
+          export PERL5LIB="$HOME/perl5/lib/perl5:${PERL5LIB:-}"
+          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-dcz"
+          rm -rf "$TEST_NGINX_SERVROOT"
+          mkdir -p "$TEST_NGINX_SERVROOT"
+          cd "$GITHUB_WORKSPACE"
+          prove t/03-dcz.t
 
       - name: Run correctness/regression tool suite (drives filter edge cases)
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -829,7 +829,7 @@ jobs:
       - name: Run filter module tests
         run: |
           export PERL5LIB="$HOME/perl5/lib/perl5:${PERL5LIB:-}"
-          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-filter"
+          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-filter-${{ github.run_id }}-${{ github.job }}"
           mkdir -p "$TEST_NGINX_SERVROOT"
           cd "$GITHUB_WORKSPACE"
           perl t/00-filter.t 2>&1 | sed 's/^Error:/Err:/' | tee t/filter-tests.log
@@ -839,7 +839,7 @@ jobs:
       - name: Run config-load warning tests
         run: |
           export PERL5LIB="$HOME/perl5/lib/perl5:${PERL5LIB:-}"
-          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-confwarn"
+          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-confwarn-${{ github.run_id }}-${{ github.job }}"
           rm -rf "$TEST_NGINX_SERVROOT"
           mkdir -p "$TEST_NGINX_SERVROOT"
           cd "$GITHUB_WORKSPACE"
@@ -853,7 +853,7 @@ jobs:
       - name: Run static module tests
         run: |
           export PERL5LIB="$HOME/perl5/lib/perl5:${PERL5LIB:-}"
-          export TEST_NGINX_SERVROOT="$GITHUB_WORKSPACE/t/servroot-static"
+          export TEST_NGINX_SERVROOT="$GITHUB_WORKSPACE/t/servroot-static-${{ github.run_id }}-${{ github.job }}"
           mkdir -p "$TEST_NGINX_SERVROOT"
           touch -d @1541504307 "$GITHUB_WORKSPACE/t/suite/test" "$GITHUB_WORKSPACE/t/suite/test.zst"
           cd "$GITHUB_WORKSPACE"
@@ -864,7 +864,7 @@ jobs:
       - name: Run dcz negotiation tests
         run: |
           export PERL5LIB="$HOME/perl5/lib/perl5:${PERL5LIB:-}"
-          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-dcz"
+          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-dcz-${{ github.run_id }}-${{ github.job }}"
           rm -rf "$TEST_NGINX_SERVROOT"
           mkdir -p "$TEST_NGINX_SERVROOT"
           cd "$GITHUB_WORKSPACE"
@@ -1091,11 +1091,11 @@ jobs:
           export PERL5LIB="$HOME/perl5/lib/perl5:${PERL5LIB:-}"
           rm -f /tmp/asan-zstd.*
           cd "$GITHUB_WORKSPACE"
-          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-asan"
+          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-asan-${{ github.run_id }}-${{ github.job }}"
           mkdir -p "$TEST_NGINX_SERVROOT"
           perl t/00-filter.t > t/filter-asan.log 2>&1 || true
           touch -d @1541504307 "$GITHUB_WORKSPACE/t/suite/test" "$GITHUB_WORKSPACE/t/suite/test.zst"
-          export TEST_NGINX_SERVROOT="$GITHUB_WORKSPACE/t/servroot-static"
+          export TEST_NGINX_SERVROOT="$GITHUB_WORKSPACE/t/servroot-static-${{ github.run_id }}-${{ github.job }}"
           mkdir -p "$TEST_NGINX_SERVROOT"
           perl t/01-static.t > t/static-asan.log 2>&1 || true
           # Gate strictly on sanitizer reports attributable to this module.
@@ -1238,7 +1238,7 @@ jobs:
       - name: Run filter module tests
         run: |
           export PERL5LIB="$HOME/perl5/lib/perl5:${PERL5LIB:-}"
-          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-filter"
+          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-filter-${{ github.run_id }}-${{ github.job }}"
           mkdir -p "$TEST_NGINX_SERVROOT"
           cd "$GITHUB_WORKSPACE"
           prove t/00-filter.t
@@ -1246,7 +1246,7 @@ jobs:
       - name: Run config-load warning tests
         run: |
           export PERL5LIB="$HOME/perl5/lib/perl5:${PERL5LIB:-}"
-          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-confwarn"
+          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-confwarn-${{ github.run_id }}-${{ github.job }}"
           rm -rf "$TEST_NGINX_SERVROOT"
           mkdir -p "$TEST_NGINX_SERVROOT"
           cd "$GITHUB_WORKSPACE"
@@ -1255,7 +1255,7 @@ jobs:
       - name: Run static module tests
         run: |
           export PERL5LIB="$HOME/perl5/lib/perl5:${PERL5LIB:-}"
-          export TEST_NGINX_SERVROOT="$GITHUB_WORKSPACE/t/servroot-static"
+          export TEST_NGINX_SERVROOT="$GITHUB_WORKSPACE/t/servroot-static-${{ github.run_id }}-${{ github.job }}"
           mkdir -p "$TEST_NGINX_SERVROOT"
           touch -d @1541504307 "$GITHUB_WORKSPACE/t/suite/test" "$GITHUB_WORKSPACE/t/suite/test.zst"
           cd "$GITHUB_WORKSPACE"
@@ -1264,7 +1264,7 @@ jobs:
       - name: Run dcz negotiation tests
         run: |
           export PERL5LIB="$HOME/perl5/lib/perl5:${PERL5LIB:-}"
-          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-dcz"
+          export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-dcz-${{ github.run_id }}-${{ github.job }}"
           rm -rf "$TEST_NGINX_SERVROOT"
           mkdir -p "$TEST_NGINX_SERVROOT"
           cd "$GITHUB_WORKSPACE"


### PR DESCRIPTION
The coverage job's TAP suite currently runs all tests under a single implicit
servroot, which works only by accident of the default Test::Nginx location.
The `t/01-static.t` suite serves fixtures via `root ../../t/suite`, which
only resolves when the servroot sits two levels under the checkout. A `/tmp`
servroot makes every static case 404 while the suite still reports green —
testing behavior that would silently break if Test::Nginx defaults changed.

This PR splits the TAP run to match the pattern already established in the
`tests` and `tests-asan` jobs: filter and conf-warn suites use `/tmp` servrootis,
while `t/01-static.t` explicitly uses `$GITHUB_WORKSPACE/t/servroot-static`.

Also adds `TEST_NGINX_TIMEOUT: "20"` to the coverage job's env block,
consistent with ci-deep.yml:117. The ~2s Test::Nginx::Socket default is too
short for these suites and would cause spurious timeouts.

## Testing

* `actionlint` passes on the modified workflow
* TAP steps are now split into four separate steps matching tests job structure
* Explicit servroot pinning makes test behavior deterministic