### PR TITLE
ci: drop redundant push trigger now that PRs must be up to date

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,8 +23,6 @@ env:
   # drops an old tarball.
 
 on:
-  push:
-    branches: [master, main, dev]
   pull_request:
     branches: [master, main]
   schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,8 +12,6 @@ env:
   NGINX_VERSION: ""
 
 on:
-  push:
-    branches: [master, main, dev]
   pull_request:
     branches: [master, main]
   schedule:

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -13,8 +13,6 @@ env:
   NGINX_VERSION: ""
 
 on:
-  push:
-    branches: [master, main, dev]
   pull_request:
     branches: [master, main]
   workflow_dispatch: {}

--- a/.github/workflows/security-scanners.yml
+++ b/.github/workflows/security-scanners.yml
@@ -12,8 +12,6 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 on:
-  push:
-    branches: [master, main, dev]
   pull_request:
     branches: [master, main]
   workflow_dispatch: {}

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -12,8 +12,6 @@ env:
   NGINX_VERSION: ""
 
 on:
-  push:
-    branches: [master, main, dev]
   pull_request:
     branches: [master, main]
   workflow_dispatch: {}


### PR DESCRIPTION
> Closes the long-standing "CI fires twice per change" row. The row was gated on a repo-settings precondition that did not exist; that precondition is now in place, which is what makes this diff safe.

## TL;DR

`build-test`, `codeql`, `fuzzing`, `security-scanners` and `valgrind` each ran on `push` to `master`/`main`/`dev` *and* on `pull_request`, so merging a PR re-ran all five on the resulting merge commit. This drops the `push` trigger from those five workflows.

## Why the push trigger existed

It was not redundant before now. A squash base often differs from the tested PR head — when PR B merges onto a tree PR A never saw, the post-merge `push` run is the only test that combination ever gets. Dropping `push` without closing that gap loses merge-commit coverage silently, which is why the row sat open rather than being taken as an easy CI-cost win.

## What closes the gap

Repo ruleset `lock master` (id 16557047) gained a `required_status_checks` rule with `strict_required_status_checks_policy: true`. A PR cannot merge unless its head branch is current with `master`, so the tested head *is* the merge result and the post-merge run has nothing new to cover.

Required contexts:

`Validation` · `CodeQL` · `Security scanners` · `Coverage (gcov/lcov)` · `Build ASAN+UBSAN` · `Tests ASAN+UBSAN` · `Dynamic-module linkage isolation` · `Fuzz regression (120s)`

The nginx build/test jobs are deliberately **not** required. Their check names are templated from the resolved version (`Build (${{ matrix.flavor }} ${{ matrix.version }})` → `Build (nginx 1.31.3)`), so the name changes on every nginx mainline release. A version-pinned required check stops reporting the day nginx ships 1.31.4 and blocks every PR with no obvious cause. The sanitizer and coverage jobs cover build and test execution without carrying a version in their names.

The rule went in the **repo-level** ruleset, not the org-level `PR-ONLY` (18391658). `PR-ONLY` matches `nginx-*` across `myguard-labs` — 11 repos — and these check names are specific to this module.

## Not changed

`schedule` and `workflow_dispatch` are untouched. `build-test` keeps its weekly Monday cron, which catches nginx API drift against new releases with no push involved.

## Testing

- `tools/test_docs_ci_drift.sh` passes — the F7 regression guarding README/SECURITY/CONTRIBUTING against live workflow contents. No doc referenced the push trigger.
- `actionlint` clean on all seven workflow files, plus the pre-commit `check yaml` and `actionlint` hooks on commit.
- `master` verified fully green before the ruleset change: all 13 check-runs succeeded on `957d5b3`.

One caveat worth recording: `Tests (nginx 1.31.3 mainline)` was failing on `957d5b3` at the "Run zstd_long (LDM) directive regression" step. A `gh run rerun --failed` turned it green on the same SHA with no code change, so it is a flake, not a real failure — and it is not a required context here.