### PR TITLE
ci: unflake the reload-leak check — triage sanitizer output instead of stat-ing it

### DIFF
--- a/tools/test_reload_leak.sh
+++ b/tools/test_reload_leak.sh
@@ -9,9 +9,23 @@
 #
 # Strategy: start nginx (built with -fsanitize=address) using a dictionary,
 # SIGHUP it several times so the old cycle's dict cleanup runs repeatedly,
-# then stop nginx cleanly. ASAN's leak detector reports on exit; if the
-# CDict (or its cleanup registration) leaks per reload, the run aborts and
-# this script exits non-zero.
+# then stop nginx cleanly. ASAN's leak detector reports on exit; a leak
+# report in the log fails this script.
+#
+# Environment caveat this script must survive: LeakSanitizer's exit-time
+# check ptrace-attaches a stop-the-world tracer, and runners whose
+# seccomp/yama policy blocks ptrace kill that tracer ("WARNING: ptrace
+# appears to be blocked", "Child exited with signal ..."), after which
+# LSan reports NOTHING. Two failure modes follow: the warning lands in
+# log_path and a file-existence check misreads it as a leak (the CI
+# flake that motivated this script's triage), and a genuinely quiet run
+# is a VACUOUS pass because the detector never ran. Hence the positive
+# control below, verdicts read from log content rather than log
+# existence, and a watchdog on shutdown ("LeakSanitizer may hang" is
+# real). Indeterminate environments exit 0 with a ::warning:: GitHub
+# annotation naming the runner fix — they are infrastructure findings,
+# not leaks, and a real leak still fails every time because it produces
+# an actual "ERROR: LeakSanitizer" report.
 #
 # Usage: tools/test_reload_leak.sh <nginx-binary> [reloads]
 
@@ -25,6 +39,32 @@ cleanup() { rm -rf "$WORK"; }
 trap cleanup EXIT
 
 mkdir -p "$WORK/conf" "$WORK/logs" "$WORK/html"
+
+# ── Positive control ─────────────────────────────────────────────────
+# Prove LSan can detect a DELIBERATE leak in this environment before
+# trusting any verdict below; a broken detector must read as
+# indeterminate, never as "no leak".
+if command -v cc >/dev/null 2>&1; then
+    cat >"$WORK/canary.c" <<'EOF'
+#include <stdlib.h>
+int main(void) { malloc(1234); return 0; }
+EOF
+    if cc -fsanitize=address -o "$WORK/canary" "$WORK/canary.c" 2>/dev/null; then
+        set +e
+        ASAN_OPTIONS="detect_leaks=1:exitcode=23" \
+            timeout 30 "$WORK/canary" >/dev/null 2>&1
+        crc=$?
+        set -e
+        if [ "$crc" -ne 23 ]; then
+            echo "::warning::LeakSanitizer failed its positive control" \
+                 "(deliberate leak exited $crc, want 23) — ptrace is likely" \
+                 "blocked on this runner (LXC seccomp / yama). Leak check" \
+                 "INDETERMINATE, not failed; fix the runner profile to" \
+                 "restore coverage."
+            exit 0
+        fi
+    fi
+fi
 
 # A non-trivial dictionary so ZSTD_createCDict() actually allocates.
 head -c 8192 /dev/urandom | base64 >"$WORK/html/zstd.dict"
@@ -59,11 +99,23 @@ export ASAN_OPTIONS="${ASAN_OPTIONS:-}:detect_leaks=1:exitcode=23:log_path=$WORK
 "$NGINX" -p "$WORK" -c "$WORK/conf/nginx.conf" &
 NGINX_PID=$!
 
-# Wait for the listener.
-for _ in $(seq 1 50); do
-    if curl -fsS -o /dev/null "http://127.0.0.1:18099/"; then break; fi
+# Wait for the listener — quietly (the old loop let the first refused
+# curl print to stderr, a red herring that muddied flake diagnosis) and
+# with an explicit verdict when startup never completes: ASAN startup
+# on a loaded shared runner is exactly when this fires.
+ready=0
+for _ in $(seq 1 100); do
+    if curl -fsS -o /dev/null "http://127.0.0.1:18099/" 2>/dev/null; then
+        ready=1
+        break
+    fi
     sleep 0.1
 done
+if [ "$ready" -ne 1 ]; then
+    echo "❌ nginx under ASAN did not accept connections within 10s"
+    kill -9 "$NGINX_PID" 2>/dev/null || true
+    exit 1
+fi
 
 for i in $(seq 1 "$RELOADS"); do
     curl -fsS -o /dev/null -H 'Accept-Encoding: zstd' "http://127.0.0.1:18099/"
@@ -74,15 +126,58 @@ done
 
 # One final request against the latest cycle, then a clean shutdown so
 # every cycle's pool cleanup (including the dict cleanup handler) runs.
+# The watchdog bounds the wait: a ptrace-blocked LSan can hang at exit,
+# which would otherwise eat the job timeout instead of yielding a
+# verdict. And wait must not run under set -e: a leak makes nginx exit
+# 23 (exitcode above), which used to abort the script right here,
+# skipping the report that says WHY.
 curl -fsS -o /dev/null -H 'Accept-Encoding: zstd' "http://127.0.0.1:18099/"
 kill -QUIT "$NGINX_PID"
+( sleep 90; kill -9 "$NGINX_PID" 2>/dev/null ) &
+WATCHDOG=$!
+set +e
 wait "$NGINX_PID"
 rc=$?
+set -e
+kill "$WATCHDOG" 2>/dev/null || true
 
-if [ -n "$(ls "$WORK"/logs/asan* 2>/dev/null || true)" ]; then
-    echo "❌ ASAN reported a leak across $RELOADS reloads:"
+# ── Verdict triage: read the sanitizer output, never just stat it ────
+# log_path receives EVERYTHING the sanitizer prints, warnings included.
+if ls "$WORK"/logs/asan* >/dev/null 2>&1; then
+
+    # Real sanitizer findings fail unconditionally — even if the
+    # watchdog had to kill a hung exit, a written report stands.
+    if grep -q -E 'ERROR: (Leak|Address)Sanitizer|SUMMARY: (Leak|Address)Sanitizer' \
+        "$WORK"/logs/asan*
+    then
+        echo "❌ sanitizer reported errors across $RELOADS reloads:"
+        cat "$WORK"/logs/asan*
+        exit 1
+    fi
+
+    # The known lockdown signature: LSan's tracer was killed before it
+    # could inspect anything. No verdict exists in either direction.
+    if grep -q -E 'ptrace.*blocked|LeakSanitizer may hang|Child exited with signal' \
+        "$WORK"/logs/asan*
+    then
+        echo "::warning::LeakSanitizer could not run its exit-time check" \
+             "(ptrace blocked on this runner — LXC seccomp / yama). Leak" \
+             "check INDETERMINATE, not failed; fix the runner profile to" \
+             "restore coverage."
+        cat "$WORK"/logs/asan*
+        exit 0
+    fi
+
+    echo "❌ unexpected sanitizer output (treating as failure):"
     cat "$WORK"/logs/asan*
     exit 1
+fi
+
+if [ "$rc" -eq 137 ]; then
+    echo "::warning::nginx under ASAN had to be killed by the shutdown" \
+         "watchdog (LeakSanitizer hang?). Leak check INDETERMINATE, not" \
+         "failed."
+    exit 0
 fi
 
 if [ "$rc" -ne 0 ]; then


### PR DESCRIPTION
## What

Unflakes the `zstd_dict_file reload leak check (CDict lifecycle)` step, which has twice failed CI with no leak in sight — most recently on #110's `9c94798` (a workflow-script-only diff over a tree that had passed this exact job an hour earlier), requiring a force-push to retrigger.

## Root cause

Both failures carry the same signature:

```
==1589==WARNING: ptrace appears to be blocked (is seccomp enabled?). LeakSanitizer may hang.
==1589==Child exited with signal 112.
```

LeakSanitizer's exit-time check ptrace-attaches a stop-the-world tracer. On runners whose LXC seccomp/yama policy blocks ptrace, the tracer dies, LSan writes that *warning* (not a leak report) into `log_path` — and the script's verdict was **"any `asan*` file exists = leak"**, so the warning banner alone flipped the check red. The same lockdown can also produce *no* file, which the old check read as a clean pass: a vacuous verdict from a detector that never ran — the worse half of the bug, and previously invisible. (The stray `curl: (7)` line long recorded as part of the flake signature was a red herring: the readiness poll's first refused attempt printing to stderr while the loop retried.)

## Fix

- **Positive control first**: a four-line deliberately-leaky canary compiled with `-fsanitize=address` must be flagged by LSan (`exitcode=23`, timeout-bounded since a ptrace-blocked LSan can hang). If the detector can't see a *deliberate* leak, the environment can't do leak detection: `::warning::` annotation naming the runner fix, exit 0 — an infrastructure finding, not a leak, and no longer a silent vacuous pass.
- **Verdict triage reads log content, never just existence**: `ERROR:/SUMMARY: (Leak|Address)Sanitizer` fails unconditionally (a written report stands even if the watchdog had to kill a hung exit); the ptrace-blocked signature without an error report is indeterminate (`::warning::`, exit 0); any other unexpected output still fails loudly.
- **Shutdown watchdog** (90 s + SIGKILL) so "LeakSanitizer may hang" yields a verdict instead of eating the job timeout — and `wait` moved out from under `set -e`, fixing a latent bug: a *real* leak makes nginx exit 23, which previously aborted the script on the `wait` line before the report was printed.
- Readiness poll silenced and given an explicit failure when nginx never accepts.

A real leak still fails every time — it produces an actual `ERROR: LeakSanitizer` report, which triage always treats as red.

For the runner itself: allowing ptrace in the LXC container's seccomp profile (or relaxing `kernel.yama.ptrace_scope` inside it) would restore full leak coverage on the affected machine; until then the annotation makes indeterminate runs visible instead of red or silently green.

## Verification

Locally against an ASAN+UBSAN build using the CI job's exact configure recipe: positive control passes and the run ends green. Triage patterns checked against the failing CI run's literal warning lines (must **not** match the error pattern, must match the lockdown pattern) and a synthetic LSan leak report (must match the error pattern). Shellcheck clean.
