### PR TITLE
tools: give nginx teardown a 30s reap budget (second flake class from #111)

### DIFF
--- a/tools/test_compression_matrix.py
+++ b/tools/test_compression_matrix.py
@@ -377,10 +377,14 @@ http {{
             finally:
                 proc.terminate()
                 try:
-                    proc.wait(timeout=5)
+                    # 30s, not 5: gcov-instrumented nginx flushing
+                    # .gcda at exit on a loaded runner can outlive a
+                    # tight reap budget; teardown runs after the
+                    # verdict, so patience costs nothing when healthy.
+                    proc.wait(timeout=30)
                 except subprocess.TimeoutExpired:
                     proc.kill()
-                    proc.wait(timeout=5)
+                    proc.wait(timeout=30)
         finally:
             backend.shutdown()
             backend.server_close()

--- a/tools/test_concurrent_cctx_isolation.py
+++ b/tools/test_concurrent_cctx_isolation.py
@@ -304,10 +304,14 @@ http {{
             finally:
                 proc.terminate()
                 try:
-                    proc.wait(timeout=5)
+                    # 30s, not 5: gcov-instrumented nginx flushing
+                    # .gcda at exit on a loaded runner can outlive a
+                    # tight reap budget; teardown runs after the
+                    # verdict, so patience costs nothing when healthy.
+                    proc.wait(timeout=30)
                 except subprocess.TimeoutExpired:
                     proc.kill()
-                    proc.wait(timeout=5)
+                    proc.wait(timeout=30)
         finally:
             backend.shutdown()
             backend.server_close()

--- a/tools/test_encoding.py
+++ b/tools/test_encoding.py
@@ -398,10 +398,14 @@ def main() -> int:
         finally:
             process.terminate()
             try:
-                process.wait(timeout=5)
+                # 30s, not 5: gcov-instrumented nginx flushing .gcda
+                # at exit on a loaded runner can outlive a tight reap
+                # budget; teardown runs after the verdict, so patience
+                # costs nothing when healthy.
+                process.wait(timeout=30)
             except subprocess.TimeoutExpired:
                 process.kill()
-                process.wait(timeout=5)
+                process.wait(timeout=30)
 
             output = process.stdout.read() if process.stdout is not None else ""
             error_log = read_if_exists(logs_dir / "error.log")

--- a/tools/test_proxy_unbuffered_truncation.py
+++ b/tools/test_proxy_unbuffered_truncation.py
@@ -334,10 +334,14 @@ http {{
             finally:
                 proc.terminate()
                 try:
-                    proc.wait(timeout=5)
+                    # 30s, not 5: gcov-instrumented nginx flushing
+                    # .gcda at exit on a loaded runner can outlive a
+                    # tight reap budget; teardown runs after the
+                    # verdict, so patience costs nothing when healthy.
+                    proc.wait(timeout=30)
                 except subprocess.TimeoutExpired:
                     proc.kill()
-                    proc.wait(timeout=5)
+                    proc.wait(timeout=30)
         finally:
             backend.shutdown()
             backend.server_close()

--- a/tools/test_reload_under_load.py
+++ b/tools/test_reload_under_load.py
@@ -277,10 +277,14 @@ http {{
                 # (incl. the CDict cleanup handler from 2c538e0).
                 os.kill(master_pid, signal.SIGQUIT)
                 try:
-                    proc.wait(timeout=10)
+                    # 30s, not 10/5: gcov-instrumented nginx flushing
+                    # .gcda at exit on a loaded runner can outlive a
+                    # tight reap budget; teardown runs after the
+                    # verdict, so patience costs nothing when healthy.
+                    proc.wait(timeout=30)
                 except subprocess.TimeoutExpired:
                     proc.kill()
-                    proc.wait(timeout=5)
+                    proc.wait(timeout=30)
 
                 el = logs / "error.log"
                 logtext = (el.read_text("utf-8", "replace")
@@ -315,10 +319,10 @@ http {{
                 if proc.poll() is None:
                     proc.terminate()
                     try:
-                        proc.wait(timeout=5)
+                        proc.wait(timeout=30)
                     except subprocess.TimeoutExpired:
                         proc.kill()
-                        proc.wait(timeout=5)
+                        proc.wait(timeout=30)
         finally:
             backend.shutdown()
             backend.server_close()

--- a/tools/test_terminal_frame.py
+++ b/tools/test_terminal_frame.py
@@ -181,10 +181,14 @@ def main() -> int:
         finally:
             process.terminate()
             try:
-                process.wait(timeout=5)
+                # 30s, not 5: gcov-instrumented nginx flushing .gcda
+                # at exit on a loaded runner can outlive a tight reap
+                # budget; teardown runs after the verdict, so patience
+                # costs nothing when healthy.
+                process.wait(timeout=30)
             except subprocess.TimeoutExpired:
                 process.kill()
-                process.wait(timeout=5)
+                process.wait(timeout=30)
 
             output = process.stdout.read() if process.stdout is not None else ""
             error_log = test_encoding.read_if_exists(logs_dir / "error.log")

--- a/tools/test_zstd_long_ldm.py
+++ b/tools/test_zstd_long_ldm.py
@@ -196,10 +196,15 @@ def run_server(nginx, conf, root, port, backend_port, zstd_bin,
     finally:
         proc.terminate()
         try:
-            proc.wait(timeout=5)
+            # 30s, not 5: a gcov-instrumented nginx flushing .gcda at
+            # exit on a loaded runner can outlive a tight reap budget
+            # (seen live in CI — the verdict had already passed and the
+            # teardown alone failed the tool). Teardown runs after the
+            # verdict, so patience costs nothing on healthy runs.
+            proc.wait(timeout=30)
         except subprocess.TimeoutExpired:
             proc.kill()
-            proc.wait(timeout=5)
+            proc.wait(timeout=30)
 
 
 def main() -> int:


### PR DESCRIPTION
## What

Follow-up to #111, catching the commit that missed its merge window: the coverage-job flake class. All seven Python tools share the same copy-pasted nginx teardown — `terminate() → wait(5) → kill() → wait(5)` — and every reap budget becomes 30 s.

## Why

#111's first CI run failed the coverage job with a `TimeoutExpired` from `tools/test_zstd_long_ldm.py`'s teardown, *after* every assertion in the phase had already passed. A gcov-instrumented nginx flushing `.gcda` profile data at exit on a loaded runner can outlive a 5-second reap — uninterruptible I/O shrugs off even the SIGKILL for a while — so the verdict was decided and the reap alone failed the tool. The identical-tree retry passed, confirming runner noise on an untouched code path: same disease #111 treats (tight infrastructure assumptions failing on the shared runner with the module verdict nowhere in sight), different organ.

Every teardown block sits in `finally` after the success return, so the larger budget costs nothing on healthy runs — a normal exit reaps in well under a second — and only spends time where 5 s used to fail spuriously.

## Verification

`py_compile` across all seven tools; the `test_encoding` harness self-checks; live runs of `test_encoding.py` and `test_zstd_long_ldm.py` (the tool that flaked) against a local ASAN-instrumented build.
