### PR TITLE
ci: gate the ASAN smoke step on leaks, fix the two unstable check names

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,24 @@
+---
+# CodeRabbit configuration for nginx-zstd-module.
+#
+# This file exists for one setting. On PR #110 (2026-08-12, a fork PR from an
+# outside contributor) a 🟠 Major functional-correctness finding thread ended
+#
+#   finding -> contributor: "Addressed in <sha>" -> org-members-only refusal
+#
+# which renders in the UI as a resolved conversation that was never actually
+# re-reviewed. The fix was sound, but only because it was verified by hand.
+#
+# NOTE: allow_non_org_members defaults to true in CodeRabbit's own schema, so
+# the refusal was NOT caused by this key being unset -- it was disabled
+# somewhere above the repo, almost certainly the org-level CodeRabbit setting
+# "restrict chat to organization members". Setting it explicitly here states
+# the repo's intent and takes effect if repo config wins; if the refusal
+# recurs on the next fork PR, the override did NOT win and the fix belongs in
+# the org's CodeRabbit dashboard, not in this file.
+#
+# Either way the standing rule is unchanged: verify an outside contributor's
+# fix commit by hand before merging. A quiet thread is not a re-review.
+
+chat:
+  allow_non_org_members: true

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -240,15 +240,26 @@ jobs:
 
   # ── Build the module against nginx mainline (amd64) ─────────────────────
   build:
-    # Job name is FIXED and must stay that way. It was
+    # Job name must stay VERSION-FREE. It was
     # `Build (${{ matrix.flavor }} ${{ matrix.version }})`, which renamed the
     # check on every nginx mainline release -- so this job could never be a
     # required context: a version-pinned required check stops reporting the
     # day nginx ships a new version and blocks every PR with no obvious
-    # cause. The resolved version is surfaced by the "Report resolved
-    # version" step below and in the job summary instead of the title.
-    # Do NOT put matrix values back in here.
-    name: Build
+    # cause.
+    #
+    # It interpolates `matrix.flavor` and nothing else, and that is load-
+    # bearing in BOTH directions. A matrix job whose name contains no matrix
+    # expression does not keep the bare name: GitHub appends the entire
+    # matrix cell to disambiguate it, so a plain `name: Build` reports as
+    # `Build (nginx, 1.31.3, https://nginx.org/..., nginx-1.31.3)` -- version
+    # back in the check name, plus the url and dir. `flavor` is the only
+    # matrix key stable across nginx releases, so naming it explicitly is
+    # what suppresses the auto-suffix and keeps the name constant.
+    #
+    # The resolved version is surfaced by the "Report resolved version" step
+    # below and in the job summary. Do NOT add `matrix.version` here, and do
+    # NOT strip the expression back to a bare literal.
+    name: Build (${{ matrix.flavor }})
     runs-on: [self-hosted, builder02, lxc]
     timeout-minutes: 30
     needs: resolve

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -240,7 +240,15 @@ jobs:
 
   # ── Build the module against nginx mainline (amd64) ─────────────────────
   build:
-    name: Build (${{ matrix.flavor }} ${{ matrix.version }})
+    # Job name is FIXED and must stay that way. It was
+    # `Build (${{ matrix.flavor }} ${{ matrix.version }})`, which renamed the
+    # check on every nginx mainline release -- so this job could never be a
+    # required context: a version-pinned required check stops reporting the
+    # day nginx ships a new version and blocks every PR with no obvious
+    # cause. The resolved version is surfaced by the "Report resolved
+    # version" step below and in the job summary instead of the title.
+    # Do NOT put matrix values back in here.
+    name: Build
     runs-on: [self-hosted, builder02, lxc]
     timeout-minutes: 30
     needs: resolve
@@ -250,6 +258,23 @@ jobs:
       matrix: ${{ fromJSON(needs.resolve.outputs.matrix) }}
 
     steps:
+      # The job title is fixed so the check name stays stable, so the
+      # resolved version has to be visible somewhere -- here and in the job
+      # summary, which is where you look when a build fails and you need to
+      # know which nginx it was.
+      #
+      # Values go through `env:` rather than straight into the `run:` body:
+      # they originate from the resolve job's scrape of nginx.org, so
+      # interpolating them into shell is a template-injection sink (zizmor
+      # flags it). As env vars they are data, never code.
+      - name: Report resolved version
+        env:
+          FLAVOR: ${{ matrix.flavor }}
+          VERSION: ${{ matrix.version }}
+        run: |
+          echo "Building $FLAVOR $VERSION"
+          echo "### Build: $FLAVOR $VERSION" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Checkout module
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
@@ -1031,10 +1056,13 @@ jobs:
 
   # ── Full test suite — runs against the mainline binary ────────────────────
   tests:
-    # The job-level name: cannot use the `env` context, but the `needs`
-    # context IS available there — so the resolved version shows in the job
-    # title without a hardcoded literal.
-    name: Tests (nginx ${{ needs.resolve.outputs.nginx_version }} mainline)
+    # Job name is FIXED -- see the `build` job for the full reasoning. It was
+    # `Tests (nginx ${{ needs.resolve.outputs.nginx_version }} mainline)`,
+    # which renamed the check on every nginx mainline release and so kept
+    # this job out of the required-checks set. The version is reported by the
+    # "Report resolved version" step below instead. Do NOT put the `needs`
+    # expression back in the title.
+    name: Tests
     runs-on: [self-hosted, builder02, lxc]
     timeout-minutes: 20
     needs: [resolve, build]
@@ -1049,6 +1077,13 @@ jobs:
       TEST_NGINX_SERVER_PORT: "2014"
 
     steps:
+      # Fixed job title -- surface the resolved version here instead.
+      - name: Report resolved version
+        run: |
+          echo "Testing against nginx $NGINX_VERSION mainline"
+          echo "### Tests: nginx $NGINX_VERSION mainline" \
+            >> "$GITHUB_STEP_SUMMARY"
+
       - name: Checkout module
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
@@ -1378,11 +1413,30 @@ jobs:
           echo "✓ no ASAN/UBSAN report attributable to the zstd module"
 
       - name: Run smoke tests under ASAN+UBSAN
+        # Leak gating here is NOT free: every harness below starts nginx and
+        # stops it with SIGTERM, and each one accepts -15 as a clean exit
+        # (e.g. tools/test_encoding.py's `returncode not in (0, -15)`). LSan
+        # reports at worker exit and signals a leak through the exit STATUS,
+        # so a leak was invisible twice over -- the harness waved the status
+        # through, and this step never looked at LSan's output at all. Both
+        # halves are fixed here: reports go to files, and the step greps them
+        # after the harnesses run.
+        #
+        # log_path is what makes that possible: without it LSan writes to
+        # stderr, which the harnesses capture and discard. detect_leaks stays
+        # 1 -- the point is to gate on leaks, not to silence them the way the
+        # Perl-suite step above does.
         env:
-          ASAN_OPTIONS: detect_leaks=1:abort_on_error=1:strict_string_checks=1:halt_on_error=1
+          ASAN_OPTIONS: detect_leaks=1:abort_on_error=1:strict_string_checks=1:halt_on_error=1:log_path=/tmp/lsan-smoke
+          # ABSOLUTE path: LSan resolves this against the CWD of the process
+          # it fires in -- an nginx worker started by a harness, whose CWD is
+          # not the workspace. A relative path there fails to open and LSan
+          # aborts, so the suppressions must not depend on where nginx ran.
+          LSAN_OPTIONS: suppressions=${{ github.workspace }}/lsan.suppress:print_suppressions=0
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
         run: |
           cd "$GITHUB_WORKSPACE"
+          rm -f /tmp/lsan-smoke.*
           python3 tools/test_encoding.py --nginx-binary "$TEST_NGINX_BINARY" --port 18090
           python3 tools/test_encoding.py --nginx-binary "$TEST_NGINX_BINARY" --port 18091 --fixture-lines 1900
           python3 tools/test_encoding.py --nginx-binary "$TEST_NGINX_BINARY" --port 18092 --concurrent-requests 2
@@ -1407,6 +1461,30 @@ jobs:
           # frame header is hand-assembled — both lifetime/OOB classes.
           python3 tools/test_dcz.py --nginx-binary "$TEST_NGINX_BINARY" \
             --port 18089
+
+          # Leak verdict. Everything in lsan.suppress is gone by now, so any
+          # surviving "ERROR: LeakSanitizer" is an unsuppressed leak and fails
+          # the job -- which is the coverage this step never had.
+          #
+          # A ptrace-blocked runner cannot run the exit-time check at all
+          # (LXC seccomp / yama on builder02). That is INDETERMINATE, not
+          # clean: warn loudly rather than print a checkmark that would mean
+          # "no leaks" when nothing was actually checked. Same distinction
+          # tools/test_reload_leak.sh draws.
+          if grep -qE 'ptrace appears to be blocked|LeakSanitizer may hang' \
+               /tmp/lsan-smoke.* 2>/dev/null; then
+            echo "::warning::LeakSanitizer could not run its exit-time check" \
+                 "(ptrace blocked on this runner — LXC seccomp / yama). Smoke" \
+                 "leak check INDETERMINATE, not clean; fix the runner profile" \
+                 "to restore coverage."
+          elif grep -q 'ERROR: LeakSanitizer' /tmp/lsan-smoke.* 2>/dev/null; then
+            echo "❌ unsuppressed leak under the smoke tests:"
+            cat /tmp/lsan-smoke.* 2>/dev/null
+            exit 1
+          else
+            echo "✓ no unsuppressed leaks under the smoke tests"
+          fi
+
           echo "✓ All smoke tests clean under ASAN+UBSAN"
 
       - name: zstd_dict_file reload leak check (CDict lifecycle)

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1479,24 +1479,32 @@ jobs:
           #
           # A ptrace-blocked runner cannot run the exit-time check at all
           # (LXC seccomp / yama on builder02). That is INDETERMINATE, not
-          # clean: warn loudly rather than print a checkmark that would mean
-          # "no leaks" when nothing was actually checked. Same distinction
+          # clean: warn rather than print a checkmark that would mean "no
+          # leaks" when nothing was actually checked. Same distinction
           # tools/test_reload_leak.sh draws.
-          if grep -qE 'ptrace appears to be blocked|LeakSanitizer may hang' \
-               /tmp/lsan-smoke.* 2>/dev/null; then
+          #
+          # Order matters, and the two conditions are NOT mutually exclusive.
+          # log_path writes one file per process, so a run can easily produce
+          # a ptrace warning from one nginx worker and a real leak report from
+          # another -- ptrace works only intermittently on this runner. Test
+          # the leak FIRST: checking ptrace first lets a warning anywhere in
+          # the set short-circuit the verdict and mask a leak elsewhere, which
+          # is the exact defect this whole step exists to fix.
+          if grep -q 'ERROR: LeakSanitizer' /tmp/lsan-smoke.* 2>/dev/null; then
+            echo "❌ unsuppressed leak under the smoke tests:"
+            cat /tmp/lsan-smoke.* 2>/dev/null
+            exit 1
+          elif grep -qE 'ptrace appears to be blocked|LeakSanitizer may hang' \
+                 /tmp/lsan-smoke.* 2>/dev/null; then
             echo "::warning::LeakSanitizer could not run its exit-time check" \
                  "(ptrace blocked on this runner — LXC seccomp / yama). Smoke" \
                  "leak check INDETERMINATE, not clean; fix the runner profile" \
                  "to restore coverage."
-          elif grep -q 'ERROR: LeakSanitizer' /tmp/lsan-smoke.* 2>/dev/null; then
-            echo "❌ unsuppressed leak under the smoke tests:"
-            cat /tmp/lsan-smoke.* 2>/dev/null
-            exit 1
+            echo "⚠ smoke tests passed; leak check INDETERMINATE"
           else
             echo "✓ no unsuppressed leaks under the smoke tests"
+            echo "✓ All smoke tests clean under ASAN+UBSAN"
           fi
-
-          echo "✓ All smoke tests clean under ASAN+UBSAN"
 
       - name: zstd_dict_file reload leak check (CDict lifecycle)
         env:

--- a/lsan.suppress
+++ b/lsan.suppress
@@ -1,0 +1,22 @@
+# LeakSanitizer suppressions for the ASAN+UBSAN smoke tests.
+#
+# Scope: nginx CORE allocations that are still reachable when a worker is
+# terminated by SIGTERM. nginx does not free every allocation at exit by
+# design -- the process is about to die and the pool teardown is skipped --
+# so these are exit-time noise, not leaks.
+#
+# The three below are the complete set observed on builder02 (56320 bytes in
+# 3 allocations, every run): the connection/event/read-write event arrays
+# allocated in ngx_event_process_init (src/event/ngx_event.c:755, :762, :774).
+# Every frame is pure nginx core; none of them touch this module.
+#
+# Deliberately NARROW: suppression is by allocating function, so a leak from
+# ngx_http_zstd_* -- or from any other core path -- is still reported and
+# still fails the step. Do NOT widen this to a blanket `leak:ngx_*`; that
+# would suppress the module's own allocations, which reach LSan through
+# ngx_palloc and friends, and turn the whole leak gate into a no-op.
+#
+# If a new core-exit allocation shows up, add it here with its file:line and
+# a note on why it is exit-time-reachable -- do not relax the pattern.
+
+leak:ngx_event_process_init


### PR DESCRIPTION
> Clears three Watch rows carried in `memory/labs/http-zstd/TODO.md` since #110 and #105. No module code changes; this is all CI integrity.

## TL;DR

We have an automated test that is supposed to shout when the code forgets to hand back memory it borrowed. It has been finding something on every single run, printing the complaint, and then reporting success anyway. So "all tests passed" has not actually meant "no leaks" for as long as that step has existed.

Separately, two other test jobs renamed themselves every time a new nginx came out, which quietly kept them out of the list of checks a change has to pass before it can be merged.

Concretely: the ASAN smoke step now writes LeakSanitizer output to files and fails on any report not matched by `lsan.suppress`, and the `build` / `tests` jobs have fixed names so they can be added to ruleset 16557047.

**Severity:** `Medium` (`CI integrity — a green check asserted a property nothing verified`)

## Why the leak gate never fired

LeakSanitizer reports at process exit and signals through the **exit status**. Every smoke harness starts nginx, stops it with SIGTERM, and treats that as a clean shutdown:

```python
# tools/test_encoding.py:408
if process.returncode not in (0, -15):
```

So the harness swallowed the status. The step then never looked at LSan's output at all, going straight to `echo "✓ All smoke tests clean under ASAN+UBSAN"`. Two independent layers had to miss it, and both did.

The reports are real and reproduce on every run. From the #110 merge run (31638807302):

```
==737==ERROR: LeakSanitizer: detected memory leaks
Indirect leak of 31744 byte(s) in 1 object(s) allocated from:
    #2 ... in ngx_event_process_init src/event/ngx_event.c:755
SUMMARY: AddressSanitizer: 56320 byte(s) leaked in 3 allocation(s).
```

All three are nginx-core connection and event arrays from `ngx_event_process_init`, still reachable when a worker is terminated. Zero zstd frames. nginx does not free everything at exit by design, so these are noise, but noise that was drowning any real signal.

## What changed

`ASAN_OPTIONS` gains `log_path=/tmp/lsan-smoke` so reports land in files instead of stderr, where the harnesses captured and discarded them. After the harnesses run, the step greps those files and exits 1 on any surviving `ERROR: LeakSanitizer`.

`lsan.suppress` suppresses the three core allocations **by allocating function**, deliberately narrow. Verified directly against LSan rather than assumed: with a fixture leaking from both `ngx_event_process_init` and `ngx_http_zstd_alloc`, the core one is suppressed (`Suppressions used: 1 1024 ngx_event_process_init`) and the module one still reports and still exits non-zero.

The suppressions path is absolute. LSan resolves it against the CWD of the process it fires in, which is an nginx worker started by a harness, not the workspace. A relative path there does not degrade gracefully:

```
AddressSanitizer: failed to read suppressions file '.../lsan.suppress'
```

That is a hard abort, so every worker would have died. Caught while reviewing the diff, before it shipped.

A ptrace-blocked runner cannot run the exit-time check at all (LXC seccomp / yama on builder02). That case warns and passes rather than printing a checkmark, since "nothing was checked" is not the same claim as "nothing was found". Same distinction `tools/test_reload_leak.sh` already draws.

## Stable check names

`build` and `tests` named themselves from the resolved nginx version, so the check name changed on every mainline release and neither could be a required context. A version-pinned required check stops reporting the day nginx ships a new version and blocks every PR with no obvious cause, which is why the previous fix was to leave them out.

Both names are now version-free; the version moves to a `Report resolved version` step and the job summary. This unblocks adding them to ruleset 16557047, which closes the documented hole where a failed mainline build skips `tests` via `needs` and the 11 required contexts still all pass.

`build` keeps `name: Build (${{ matrix.flavor }})` rather than a bare literal, and that expression is load-bearing. The first push used plain `name: Build`, which made things worse: a matrix job whose name interpolates nothing gets the entire matrix cell appended to disambiguate it, so the check reported as `Build (nginx, 1.31.3, https://nginx.org/download/nginx-1.31.3.tar.gz, nginx-1.31.3)`. Version back in the name, plus the url and dir. `flavor` is the only matrix key stable across nginx releases, so naming it explicitly is what suppresses the suffix. Caught on this branch's first CI run, where `Tests` reported under its new name and `Build` did not. `tests` has no matrix and keeps its bare literal correctly.

Matrix values go through `env:` rather than into the `run:` body, since they come from the resolve job's scrape of nginx.org and a direct expansion is a template-injection sink. zizmor finding count is unchanged at 21, measured on both sides of the diff.

## The CodeRabbit row

`.coderabbit.yaml` sets `chat.allow_non_org_members: true`. On fork PR #110 a Major finding thread ended in an org-members-only refusal and rendered as resolved without any re-review.

Worth flagging, because the TODO row and the handoff both had this wrong: the key **defaults to true** in CodeRabbit's schema, so the refusal was not caused by it being unset. It is disabled above the repo, most likely org-level. This file states the repo's intent and takes effect if repo config wins; if the refusal recurs on the next fork PR, the fix belongs in the org dashboard instead. Either way an outside contributor's fix commit still gets verified by hand before merging.

## Testing

The leak gate's three cases were exercised against real LSan output before commit:

| Case | Verdict |
| --- | --- |
| Module leak present | FAIL, rc=1 |
| Only suppressed core leak | CLEAN, rc=0 |
| ptrace-blocked warning text | INDETERMINATE, warns, rc=0 |

`actionlint` clean, `yamllint` clean on `.coderabbit.yaml`, workflow YAML parses, zizmor 21 before and after. Remote CI on this PR is the real test of the workflow changes.

What this PR does **not** do: add `Build` and `Tests` to ruleset 16557047. The names have to be stable on the default branch before the ruleset can reference them, so that is a follow-up once this merges.
