### PR TITLE
tools: close the last two tight teardown reaps in the coverage suite

### DIFF
--- a/tools/test_dcz.py
+++ b/tools/test_dcz.py
@@ -412,7 +412,7 @@ def main() -> int:
                 ),
             ]
             for name, case_headers in fallback_cases:
-                headers, body = fetch(args.port, case_headers)
+                headers, _body = fetch(args.port, case_headers)
                 check(
                     f"fallback: {name} -> zstd",
                     content_encoding(headers) == "zstd",
@@ -434,7 +434,15 @@ def main() -> int:
 
         finally:
             nginx.terminate()
-            nginx.wait(timeout=10)
+            try:
+                # 30s, not 10: gcov-instrumented nginx flushing .gcda
+                # at exit on a loaded runner can outlive a tight reap
+                # budget; teardown runs after the verdict, so patience
+                # costs nothing when healthy.
+                nginx.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                nginx.kill()
+                nginx.wait(timeout=30)
 
     if failures:
         print(f"FAILED: {len(failures)} dcz check(s): {', '.join(failures)}")

--- a/tools/test_window_cap.py
+++ b/tools/test_window_cap.py
@@ -276,9 +276,14 @@ http {{
         finally:
             proc.terminate()
             try:
-                proc.wait(timeout=10)
+                # 30s, not 10: gcov-instrumented nginx flushing .gcda
+                # at exit on a loaded runner can outlive a tight reap
+                # budget; teardown runs after the verdict, so patience
+                # costs nothing when healthy.
+                proc.wait(timeout=30)
             except subprocess.TimeoutExpired:
                 proc.kill()
+                proc.wait(timeout=30)
             backend.shutdown()
             err = (logs / "error.log")
             if err.exists():


### PR DESCRIPTION
> Follow-up to #112 (landing as #114), which raised the teardown reap budget in seven of the nine tools the coverage job drives. Independent of #114; the two PRs touch disjoint files.

## TL;DR

Two test tools could still fail, or quietly leave an nginx process running, when a coverage-instrumented server was slow to shut down. They now get the same patient shutdown handling as the other seven tools.

`test_dcz.py` and `test_window_cap.py` move to the 30s reap budget; `test_dcz.py` gains the missing `TimeoutExpired` guard (a slow exit propagated out of the `finally` and leaked the process), and `test_window_cap.py` gains the missing `wait()` after `kill()` (zombie until interpreter exit).

**Severity:** `Low` (`test infrastructure — CI flake removal`)

## Testing

`py_compile` on both tools; lint pre-pass over the diff (ruff/mypy/bandit/semgrep/ast-grep). The teardown shape now matches the seven tools #112 fixed. Includes a one-line RUF059 fix in `test_dcz.py` (`body` → `_body`) required by the pre-commit ruff gate on the touched file.
