### PR TITLE
fix(filter): mid-stream CCtx re-init silently truncates sub_filter'd streams

### DIFF
--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -175,10 +175,26 @@ typedef struct {
     unsigned                     nomem:1;
 
     /* the 40-byte dcz frame header has been queued on the out chain.
-     * Guarded separately from CCtx init because the init block can run
-     * more than once (a data-less flush call arrives before the first
-     * input sets buffer_in.src) and the prefix must never be duplicated. */
+     * Kept even though cctx_ready below now makes init single-shot: the
+     * prefix must never be duplicated regardless of init bookkeeping. */
     unsigned                     dcz_header_sent:1;
+
+    /*
+     * First-body-data latch for init_cctx. This used to be inferred from
+     * `ctx->buffer_in.src == NULL`, but buffer_in.src is data state, not
+     * lifecycle state: add_data reloads it from every incoming buffer, and
+     * a data-less carrier buffer (ngx_buf_special() — e.g. the sync bufs
+     * the sub filter emits while a match candidate spans input buffers)
+     * has pos == NULL, which re-armed the check. The next invocation then
+     * re-ran ZSTD_CCtx_reset() mid-stream, silently discarding everything
+     * libzstd had buffered but not yet flushed: the response still ended
+     * in ONE well-formed frame (200 + valid zstd), just with the reset-
+     * window content missing. Observed in production as truncated HTML on
+     * sub_filter-rewritten pages fed by a small-buffer upstream (the
+     * dcz_header_sent guard above was an earlier symptom of the same
+     * re-run, without the data-loss diagnosis).
+     */
+    unsigned                     cctx_ready:1;
 
     /* PR #49: Action state machine (COMPRESS, FLUSH, or END) */
     ngx_http_zstd_action_t       action;
@@ -894,24 +910,30 @@ ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "http zstd filter");
 
-    if (!ctx->last && ctx->buffer_in.src == NULL) {
-        /* First call: configure the reused CCtx for this request. */
+    if (!ctx->cctx_ready) {
+        /*
+         * First call: configure the CCtx for this request. Latched by an
+         * explicit flag — do NOT infer this from buffer_in.src == NULL;
+         * see the cctx_ready comment in ngx_http_zstd_ctx_t.
+         */
         if (ngx_http_zstd_filter_init_cctx(r, ctx) != NGX_OK) {
             goto failed;
         }
 
         /*
          * dcz responses start with the fixed 40-byte frame header (RFC
-         * 9842 §2.2). Queue it ahead of any compressed output; the
-         * dcz_header_sent guard (not the init condition above) makes it
-         * once-only, because this block re-runs if a data-less flush
-         * arrives before the first input sets buffer_in.src.
+         * 9842 §2.2). Queue it ahead of any compressed output. The
+         * dcz_header_sent guard predates cctx_ready (this block used to
+         * re-run when a data-less buffer cleared buffer_in.src); it stays
+         * as an independent invariant on the wire prefix.
          */
         if (ctx->dcz_dict != NULL && !ctx->dcz_header_sent) {
             if (ngx_http_zstd_filter_emit_dcz_header(r, ctx) != NGX_OK) {
                 goto failed;
             }
         }
+
+        ctx->cctx_ready = 1;
     }
 
     if (in) {
@@ -1327,18 +1349,25 @@ ngx_http_zstd_filter_add_data(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
         ctx->flush = 1;
     }
 
+    if (ngx_buf_size(ctx->in_buf) == 0) {
+        /*
+         * Data-less buffer (flush/sync/last carrier, or an empty data
+         * buf). Its signal flags were captured above; never load it into
+         * buffer_in. These bufs can carry pos == NULL (ngx_buf_special()),
+         * and installing that as buffer_in.src both hands libzstd a NULL
+         * src and clobbers the pointer other code may treat as state (the
+         * old init_cctx first-call check did — see cctx_ready). If last or
+         * flush was just set, return OK so the compress step runs the
+         * end/flush immediately; otherwise skip to the next link.
+         */
+        return (ctx->last || ctx->flush) ? NGX_OK : NGX_AGAIN;
+    }
+
     ctx->buffer_in.src = ctx->in_buf->pos;
     ctx->buffer_in.pos = 0;
     ctx->buffer_in.size = ngx_buf_size(ctx->in_buf);
 
     ctx->bytes_in += ngx_buf_size(ctx->in_buf);
-
-    if (ctx->buffer_in.size == 0) {
-        /* Empty buffer: only skip to next if there is no pending signal.
-         * If last or flush was just set above, return OK so the compress
-         * step runs the end/flush immediately without a wasted iteration. */
-        return (ctx->last || ctx->flush) ? NGX_OK : NGX_AGAIN;
-    }
 
     return NGX_OK;
 }

--- a/t/00-filter.t
+++ b/t/00-filter.t
@@ -2351,3 +2351,76 @@ zstd: skip, client did not accept zstd encoding
 --- no_error_log
 zstd: compressing response
 [error]
+
+
+=== TEST 92: sub_filter partial-match sync bufs must not reset the CCtx mid-stream
+# Regression for the silent-truncation bug: the body filter inferred
+# "first body data" from ctx->buffer_in.src == NULL, while add_data
+# reloaded buffer_in.src from every incoming buffer. The sub filter
+# emits a data-less sync carrier (pos == NULL, ngx_http_sub_filter
+# line ~516) whenever an in-memory input buffer is entirely absorbed
+# into a cross-buffer match candidate ("looked") and produces no
+# output. Loading that carrier re-armed the first-call check, the next
+# invocation re-ran ZSTD_CCtx_reset(), and everything libzstd had
+# buffered but not yet flushed was silently discarded -- the response
+# still ended as ONE well-formed frame (200 + valid zstd), just with
+# the pre-reset content missing. Seen in production as truncated HTML
+# on sub_filter-rewritten pages fed by a slow chunked upstream.
+#
+# The mock backend streams three chunks with pauses; chunk 2 lies
+# strictly inside the sub_filter FROM pattern, so it is fully absorbed
+# into the match state and triggers the sync carrier. A pre-fix module
+# loses chunk 1 ("EARLY-CONTENT ..."); the fixed module round-trips
+# the whole rewritten body.
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        sub_filter 'http://upstream.example' 'https://very-long-replacement-host.example';
+        sub_filter_once off;
+        sub_filter_types text/plain;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/up;
+    }
+    location /up {
+        proxy_http_version 1.1;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_RAND_PORT_1/;
+    }
+--- tcp_listen: $TEST_NGINX_RAND_PORT_1
+--- tcp_no_close
+--- tcp_reply_delay: 100ms
+--- tcp_reply eval
+my $hdr  = "HTTP/1.1 200 OK\r\n"
+         . "Content-Type: text/plain\r\n"
+         . "Transfer-Encoding: chunked\r\n"
+         . "Connection: close\r\n\r\n";
+my $seg1 = "EARLY-CONTENT that must survive the match holdback http://up";
+my $seg2 = "stream.exa";     # entirely inside the FROM pattern: absorbed, no output
+my $seg3 = "mple/path LATE-CONTENT after the match completes\n";
+my $chunk = sub { sprintf("%x\r\n%s\r\n", length($_[0]), $_[0]) };
+[
+    $hdr . $chunk->($seg1),
+    $chunk->($seg2),
+    $chunk->($seg3) . "0\r\n\r\n",
+]
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+Content-Encoding: zstd
+--- response_body_filters eval
+sub {
+    my $zstd = $_[0];
+    open(my $fh, "|-", "zstd -dq -c >/tmp/zstd_t92.out 2>/dev/null") or return "ERR";
+    print $fh $zstd; close($fh);
+    open(my $r, "<", "/tmp/zstd_t92.out") or return "ERR";
+    local $/; my $d = <$r>; close($r); unlink "/tmp/zstd_t92.out";
+    return $d;
+}
+--- response_body
+EARLY-CONTENT that must survive the match holdback https://very-long-replacement-host.example/path LATE-CONTENT after the match completes
+--- no_error_log
+[error]


### PR DESCRIPTION
## Symptom

A proxied response streamed through `sub_filter` + `zstd` can come back as a **well-formed zstd frame that decodes to a fraction of the body** — HTTP 200, valid `Content-Encoding: zstd`, clean frame end, no error log. The client has no way to tell the payload was truncated. Seen in production on a CDN edge: a 35 KB HTML page deterministically decoded to 262 bytes (the document head + closing tail, middle missing).

## Root cause

The body filter infers "first body data" from `ctx->buffer_in.src == NULL`, and `add_data()` reloads `buffer_in.src` from **every** incoming buffer:

- When a `sub_filter` match candidate spans input buffers, an input buffer that is *entirely* absorbed into the match state produces no output, and the sub filter emits a **data-less sync carrier** with `pos == NULL` (`ngx_http_sub_filter_module.c`, the `b->sync = 1` branch in the output stage). This happens with any slow / small-buffer upstream (chunked streaming, `proxy_buffering off`, long RTT relays...).
- `add_data()` loads that carrier: `ctx->buffer_in.src = ctx->in_buf->pos` → `NULL`.
- The **next** body-filter invocation sees `buffer_in.src == NULL`, believes it is the first call, and re-runs `init_cctx` → `ZSTD_CCtx_reset(ZSTD_reset_session_and_parameters)`.
- Everything libzstd had buffered internally but not yet flushed (with `ZSTD_e_continue`, potentially the whole response so far) is **silently discarded**. The eventual `ZSTD_e_end` still seals one perfectly valid frame containing only the bytes fed after the last reset.

In the production capture, a single request re-ran `init_cctx` **416 times** (debug log: 416 × "zstd cctx ready", one final emit). The struct even carried a hint: `dcz_header_sent` exists *because* "the init block can run more than once" — the re-run was known, but its data-loss consequence was not.

## Fix

Two changes, both required:

1. **`cctx_ready` latch** — `init_cctx` now runs exactly once per request, keyed on explicit lifecycle state instead of `buffer_in.src` data state.
2. **`add_data()` never loads a zero-size buffer into `buffer_in`** — signal flags (`last_buf`/`flush`) are captured first and the buffer is otherwise skipped, so a `NULL` `pos` can neither clobber `buffer_in.src` nor reach `ZSTD_compressStream2()` as the `src` pointer.

## Test

TEST 92 reproduces the exact shape with the embedded TCP server: a chunked upstream streamed in three delayed segments where the middle segment lies strictly inside the `sub_filter` FROM pattern (fully absorbed into the match state → sync carrier), `proxy_buffering off`. It asserts the decoded body round-trips byte-for-byte. Pre-fix, the first segment's content vanishes; post-fix, the full rewritten body arrives.

Verified end-to-end on a debug build (nginx 1.31.3, libzstd 1.5.7): the failing shape goes from 262/41290 bytes decoded with 416 CCtx inits to 41290/41290 with exactly 1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming compression behavior that could reset state mid-response and produce duplicate headers.
  * Improved handling of empty and special input buffers during flushing.
  * Preserved content correctly when text replacements span multiple upstream data chunks.

* **Tests**
  * Added regression coverage for compressed responses involving delayed, chunked content and cross-buffer replacements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->