### PR TITLE
fix: guard zero-delta input-buffer pointer update; unique test temp files

### DIFF
--- a/filter/ngx_http_zstd_filter_module.c
+++ b/filter/ngx_http_zstd_filter_module.c
@@ -1135,7 +1135,18 @@ ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
                    ctx->buffer_out.dst, ctx->buffer_out.pos,
                    ctx->buffer_out.size);
 
-    ctx->in_buf->pos   += ctx->buffer_in.pos  - pos_in;
+    /*
+     * Guard the zero-delta case instead of unconditionally adding: when the
+     * dequeued link is a data-less carrier (last_buf/flush, pos == NULL —
+     * see add_data), buffer_in still describes the previous, fully-drained
+     * buffer, so the delta is provably 0 — but `NULL + 0` is still undefined
+     * pointer arithmetic. gcc's UBSan lets it pass; clang's aborts with
+     * "applying zero offset to null pointer".
+     */
+    if (ctx->buffer_in.pos != pos_in) {
+        ctx->in_buf->pos += ctx->buffer_in.pos - pos_in;
+    }
+
     ctx->out_buf->last += ctx->buffer_out.pos - pos_out;
     ctx->redo = 0;
 

--- a/t/00-filter.t
+++ b/t/00-filter.t
@@ -1084,10 +1084,14 @@ Content-Encoding: zstd
 --- response_body_filters eval
 sub {
     my $zstd = $_[0];
-    open(my $fh, "|-", "zstd -dq -c >/tmp/zstd_t43.out 2>/dev/null") or return "ERR";
+    require File::Temp;
+    my ($tfh, $tmp) = File::Temp::tempfile("zstd_t43_XXXXXX",
+                                           TMPDIR => 1, UNLINK => 1);
+    close($tfh);
+    open(my $fh, "|-", "zstd -dq -c >$tmp 2>/dev/null") or return "ERR";
     print $fh $zstd; close($fh);
-    open(my $r, "<", "/tmp/zstd_t43.out") or return "ERR";
-    local $/; my $d = <$r>; close($r); unlink "/tmp/zstd_t43.out";
+    open(my $r, "<", $tmp) or return "ERR";
+    local $/; my $d = <$r>; close($r); unlink $tmp;
     return $d;
 }
 --- response_body
@@ -1154,11 +1158,15 @@ Content-Encoding: zstd
 --- response_body_filters eval
 sub {
     my $zstd = $_[0];
-    open(my $fh, "|-", "zstd -dq -c >/tmp/zstd_t44.out 2>/dev/null") or return "ERR-OPEN";
+    require File::Temp;
+    my ($tfh, $tmp) = File::Temp::tempfile("zstd_t44_XXXXXX",
+                                           TMPDIR => 1, UNLINK => 1);
+    close($tfh);
+    open(my $fh, "|-", "zstd -dq -c >$tmp 2>/dev/null") or return "ERR-OPEN";
     print $fh $zstd; close($fh);
     my $rc = $?;
-    open(my $r, "<", "/tmp/zstd_t44.out") or return "ERR-READ";
-    local $/; my $d = <$r>; close($r); unlink "/tmp/zstd_t44.out";
+    open(my $r, "<", $tmp) or return "ERR-READ";
+    local $/; my $d = <$r>; close($r); unlink $tmp;
     return "ERR-DECODE rc=$rc" if $rc != 0;          # premature end -> non-zero
     require Digest::MD5;
     return length($d) . ":" . Digest::MD5::md5_hex($d);
@@ -2414,10 +2422,16 @@ Content-Encoding: zstd
 --- response_body_filters eval
 sub {
     my $zstd = $_[0];
-    open(my $fh, "|-", "zstd -dq -c >/tmp/zstd_t92.out 2>/dev/null") or return "ERR";
+    require File::Temp;
+    my ($tfh, $tmp) = File::Temp::tempfile("zstd_t92_XXXXXX",
+                                           TMPDIR => 1, UNLINK => 1);
+    close($tfh);
+    open(my $fh, "|-", "zstd -dq -c >$tmp 2>/dev/null") or return "ERR";
     print $fh $zstd; close($fh);
-    open(my $r, "<", "/tmp/zstd_t92.out") or return "ERR";
-    local $/; my $d = <$r>; close($r); unlink "/tmp/zstd_t92.out";
+    my $rc = $?;
+    return "ERR-DECODE rc=$rc" if $rc != 0;
+    open(my $r, "<", $tmp) or return "ERR";
+    local $/; my $d = <$r>; close($r); unlink $tmp;
     return $d;
 }
 --- response_body

--- a/t/00-filter.t
+++ b/t/00-filter.t
@@ -1087,10 +1087,9 @@ sub {
     require File::Temp;
     my ($tfh, $tmp) = File::Temp::tempfile("zstd_t43_XXXXXX",
                                            TMPDIR => 1, UNLINK => 1);
-    close($tfh);
-    open(my $fh, "|-", "zstd -dq -c >$tmp 2>/dev/null") or return "ERR";
-    print $fh $zstd; close($fh);
-    open(my $r, "<", $tmp) or return "ERR";
+    binmode($tfh); print $tfh $zstd; close($tfh);
+    # List-form pipe open: no shell, so the temp path is never re-parsed.
+    open(my $r, "-|", "zstd", "-dqc", $tmp) or do { unlink $tmp; return "ERR" };
     local $/; my $d = <$r>; close($r); unlink $tmp;
     return $d;
 }
@@ -1161,12 +1160,10 @@ sub {
     require File::Temp;
     my ($tfh, $tmp) = File::Temp::tempfile("zstd_t44_XXXXXX",
                                            TMPDIR => 1, UNLINK => 1);
-    close($tfh);
-    open(my $fh, "|-", "zstd -dq -c >$tmp 2>/dev/null") or return "ERR-OPEN";
-    print $fh $zstd; close($fh);
-    my $rc = $?;
-    open(my $r, "<", $tmp) or return "ERR-READ";
-    local $/; my $d = <$r>; close($r); unlink $tmp;
+    binmode($tfh); print $tfh $zstd; close($tfh);
+    # List-form pipe open: no shell, so the temp path is never re-parsed.
+    open(my $r, "-|", "zstd", "-dqc", $tmp) or do { unlink $tmp; return "ERR-OPEN" };
+    local $/; my $d = <$r>; close($r); my $rc = $?; unlink $tmp;
     return "ERR-DECODE rc=$rc" if $rc != 0;          # premature end -> non-zero
     require Digest::MD5;
     return length($d) . ":" . Digest::MD5::md5_hex($d);
@@ -2425,13 +2422,11 @@ sub {
     require File::Temp;
     my ($tfh, $tmp) = File::Temp::tempfile("zstd_t92_XXXXXX",
                                            TMPDIR => 1, UNLINK => 1);
-    close($tfh);
-    open(my $fh, "|-", "zstd -dq -c >$tmp 2>/dev/null") or return "ERR";
-    print $fh $zstd; close($fh);
-    my $rc = $?;
+    binmode($tfh); print $tfh $zstd; close($tfh);
+    # List-form pipe open: no shell, so the temp path is never re-parsed.
+    open(my $r, "-|", "zstd", "-dqc", $tmp) or do { unlink $tmp; return "ERR" };
+    local $/; my $d = <$r>; close($r); my $rc = $?; unlink $tmp;
     return "ERR-DECODE rc=$rc" if $rc != 0;
-    open(my $r, "<", $tmp) or return "ERR";
-    local $/; my $d = <$r>; close($r); unlink $tmp;
     return $d;
 }
 --- response_body


### PR DESCRIPTION
> Follow-ups from the #116 review; independent of the truncation fix itself, which landed unchanged.

## TL;DR

The compressor's bookkeeping did pointer arithmetic on a null pointer in one corner case, and three tests shared fixed temp-file names that concurrent checkouts could clobber. Neither produced wrong output today; both are latent failures waiting on an environment change.

`ngx_http_zstd_filter_compress()` now guards the `ctx->in_buf->pos` update on a non-zero delta, and tests 43/44/92 decode through `File::Temp::tempfile` instead of `/tmp/zstd_tNN.out`.

**Severity:** `Low` (`latent UB + test hygiene — no behaviour change on current builds`)

## Mechanism

When `add_data()` dequeues a data-less carrier (`last_buf`/`flush`, `pos == NULL`), `buffer_in` still describes the previous, fully-drained buffer, so `ctx->buffer_in.pos - pos_in` is provably 0 — but `NULL + 0` is undefined pointer arithmetic. Verified divergence: gcc 14.2 UBSan accepts it; clang 19 UBSan aborts with `applying zero offset to null pointer`. The ASan+UBSAN CI job runs `t/00-filter.t` with the distro default `cc` (gcc), so this becomes a hard CI failure the day that job builds with clang. The guard skips the update when the delta is zero; a terminal carrier at end-of-response reaches this path on every request.

TEST 92 also gains the decoder exit-status assertion TEST 44 already had, so a truncated frame now reports `ERR-DECODE rc=N` instead of a less specific body mismatch.

## Testing

`prove t/00-filter.t` against nginx 1.31.2: 1074 tests, all pass. Lint roster (cppcheck, clang-tidy, flawfinder, semgrep, ast-grep, perlcritic) clean on the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response compression handling for empty data buffers, preventing potential processing errors.
  * Enhanced reliability when processing compressed response bodies.

* **Tests**
  * Improved decompression test isolation by using unique temporary files.
  * Temporary test files are now cleaned up automatically, reducing interference between test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->