### PR TITLE
ci: wait for the dpkg lock instead of dying on it (third flake class)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -108,8 +108,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y \
             build-essential \
             libpcre2-dev \
             zlib1g-dev \
@@ -298,8 +298,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y \
             build-essential \
             pkg-config \
             libzstd-dev \
@@ -459,8 +459,8 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config \
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y build-essential pkg-config \
             libpcre2-dev zlib1g-dev wget cmake python3 \
             python3-requests zstd
 
@@ -617,8 +617,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config libzstd-dev \
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y build-essential pkg-config libzstd-dev \
             libpcre2-dev zlib1g-dev wget binutils
 
       - name: Cache nginx source tarball
@@ -857,8 +857,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential libzstd-dev \
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y build-essential libzstd-dev \
             libpcre2-dev zlib1g-dev wget curl
 
       - name: Cache nginx source tarball
@@ -1005,8 +1005,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config libzstd-dev \
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y build-essential pkg-config libzstd-dev \
             libpcre2-dev zlib1g-dev wget
 
       - name: Cache nginx source tarball
@@ -1107,8 +1107,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y \
             libperl-dev \
             cpanminus \
             libzstd1 \
@@ -1363,8 +1363,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y python3 python3-requests zstd libzstd1 \
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y python3 python3-requests zstd libzstd1 \
             libperl-dev cpanminus
 
       - name: Download ASAN nginx binary
@@ -1538,8 +1538,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config libzstd-dev \
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y build-essential pkg-config libzstd-dev \
             libpcre2-dev zlib1g-dev libssl-dev libperl-dev cpanminus \
             python3 python3-requests zstd lcov wget
 

--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -83,8 +83,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y \
             build-essential curl libpcre2-dev libzstd-dev pkg-config \
             wget zstd libperl-dev cpanminus
 
@@ -144,8 +144,8 @@ jobs:
 
       - name: Install clang + libFuzzer
         run: |
-          sudo apt-get update
-          sudo apt-get install -y clang
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y clang
 
       - name: Select fuzz duration
         env:
@@ -238,8 +238,8 @@ jobs:
           echo "NGINX_VERSION=$ver" >> "$GITHUB_ENV"
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y \
             build-essential curl libpcre2-dev libzstd-dev pkg-config \
             valgrind wget zlib1g-dev zstd
       - name: Build debug nginx + zstd module
@@ -290,8 +290,8 @@ jobs:
           echo "NGINX_VERSION=$ver" >> "$GITHUB_ENV"
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y \
             build-essential curl libpcre2-dev libzstd-dev pkg-config \
             valgrind wget zlib1g-dev zstd
       - name: Build debug nginx + zstd module
@@ -335,8 +335,8 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y flawfinder clang-tidy python3 python3-pip pipx nginx-dev
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y flawfinder clang-tidy python3 python3-pip pipx nginx-dev
           # semgrep: isolate via pipx (PEP 668 blocks a bare pip3 install into the
           # system Python on the Ubuntu 24.04 self-hosted runner). Fall back to a
           # user pip install with --break-system-packages if pipx is unavailable.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,8 +54,8 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config libzstd-dev \
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y build-essential pkg-config libzstd-dev \
             libpcre2-dev zlib1g-dev wget
 
       - name: Cache nginx source tarball

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Install clang + libFuzzer
         run: |
-          sudo apt-get update
-          sudo apt-get install -y clang
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y clang
 
       - name: Build fuzz target
         run: bash fuzz/build.sh "$GITHUB_WORKSPACE/fuzz/fuzz_accept_encoding"

--- a/.github/workflows/security-scanners.yml
+++ b/.github/workflows/security-scanners.yml
@@ -33,8 +33,8 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y flawfinder clang-tidy python3 python3-pip pipx nginx-dev
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y flawfinder clang-tidy python3 python3-pip pipx nginx-dev
           # semgrep: isolate via pipx (PEP 668 blocks a bare pip3 install into the
           # system Python on the Ubuntu 24.04 self-hosted runner). Fall back to a
           # user pip install with --break-system-packages if pipx is unavailable.

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -43,8 +43,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get -o DPkg::Lock::Timeout=120 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 install -y \
             build-essential curl libpcre2-dev libzstd-dev pkg-config \
             valgrind wget zlib1g-dev zstd
 


### PR DESCRIPTION
A phase0-branch run failed its Build job in **Install dependencies** with:

```
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 900 (apt-get)
```

— a background provisioning `apt-get` racing the step on the runner, unrelated to the diff. Same disease as the ptrace (#111) and teardown-reap (#114/#115) classes: a tight infrastructure assumption (*the lock is always free*) failing on shared runners with the verdict nowhere in sight.

apt has the built-in cure: `-o DPkg::Lock::Timeout=120` makes every `apt-get` **wait** up to two minutes for the lock instead of failing instantly (supported since apt 1.9.11, so every runner in the fleet). Applied to all 36 invocations across the six workflows, on `update` and `install` both — the race hits whichever runs first. Shape-swept afterward: zero unconverted `apt-get` calls remain (the shape-not-literal-value lesson from #115 applied).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated build, testing, fuzzing, security scanning, and analysis workflows.
  * Package installation steps now wait up to 120 seconds for the system package manager lock, reducing failures caused by concurrent package operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->