### PR TITLE
build: test Windows toolchains

### DIFF
--- a/.github/scripts/configure-msvc.sh
+++ b/.github/scripts/configure-msvc.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Configure the Windows/MSVC CI build after vcvars64.bat has initialized the
+# parent cmd process. Kept in a real bash file because a GitHub custom `cmd`
+# shell wraps inline run blocks in a .cmd file, which bash cannot parse.
+
+set -euo pipefail
+
+module_dir=$(cygpath -m "$GITHUB_WORKSPACE")
+zstd_root=$(cygpath -m \
+    "$VCPKG_INSTALLATION_ROOT/installed/x64-windows-static")
+
+ZSTD_INC="$zstd_root/include" ZSTD_LIB="$zstd_root/lib" \
+    ./configure \
+        --crossbuild=win32 \
+        --with-cc=cl \
+        --with-cc-opt='-MT -DFD_SETSIZE=1024' \
+        --with-pcre="$module_dir/pcre2-$PCRE2_VERSION" \
+        --with-zlib="$module_dir/zlib-$ZLIB_VERSION" \
+        --add-module="$module_dir"

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,219 @@
+---
+# yamllint disable rule:line-length rule:truthy
+name: Windows build
+
+# MSVC and MinGW exercise different nginx win32 build paths. MSVC supports
+# static addons only; MinGW's GNU linker also supports dynamic PE modules.
+
+on:
+  pull_request:
+    branches: [master, main]
+    paths:
+      - 'auto/**'
+      - 'filter/**'
+      - 'static/**'
+      - '*.h'
+      - 'config'
+      - 'tools/build-windows.sh'
+      - '.github/workflows/windows-build.yml'
+  push:
+    branches: [master]
+  workflow_dispatch: {}
+
+concurrency:
+  group: windows-build-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  NGINX_VERSION: 1.31.3
+  NGINX_SHA256: a7657c50811c2d92d9895395e8b873ef60398142c4db21eb647811c38f6dd525
+  PCRE2_VERSION: 10.44
+  PCRE2_SHA256: 86b9cb0aa3bcb7994faa88018292bc704cdbb708e785f7c74352ff6ea7d3175b
+  ZLIB_VERSION: 1.3.1
+  ZLIB_SHA256: 9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+
+jobs:
+  msvc:
+    name: MSVC x64 static
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout module
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          persist-credentials: false
+
+      - name: Install static libzstd
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install zstd:x64-windows-static
+          if ($LASTEXITCODE -ne 0) { throw "vcpkg failed with $LASTEXITCODE" }
+          $lib = "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows-static\lib"
+          if (-not (Test-Path "$lib\zstd_static.lib")) {
+            if (-not (Test-Path "$lib\zstd.lib")) { throw "vcpkg zstd archive not found" }
+            Copy-Item "$lib\zstd.lib" "$lib\zstd_static.lib"
+          }
+
+      - name: Fetch and verify sources
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $sources = @(
+            @{ file = "nginx-$env:NGINX_VERSION.tar.gz"; url = "https://nginx.org/download/nginx-$env:NGINX_VERSION.tar.gz"; sha = $env:NGINX_SHA256 },
+            @{ file = "pcre2-$env:PCRE2_VERSION.tar.gz"; url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-$env:PCRE2_VERSION/pcre2-$env:PCRE2_VERSION.tar.gz"; sha = $env:PCRE2_SHA256 },
+            @{ file = "zlib-$env:ZLIB_VERSION.tar.gz"; url = "https://zlib.net/zlib-$env:ZLIB_VERSION.tar.gz"; sha = $env:ZLIB_SHA256 }
+          )
+          foreach ($s in $sources) {
+            Invoke-WebRequest -Uri $s.url -OutFile $s.file -ConnectionTimeoutSeconds 30 -OperationTimeoutSeconds 60
+            $actual = (Get-FileHash $s.file -Algorithm SHA256).Hash.ToLower()
+            if ($actual -ne $s.sha) { throw "sha256 mismatch for $($s.file): $actual" }
+            tar -xzf $s.file
+            if ($LASTEXITCODE -ne 0) { throw "tar failed for $($s.file)" }
+          }
+
+      - name: Configure
+        shell: bash
+        working-directory: nginx-${{ env.NGINX_VERSION }}
+        run: |
+          set -euo pipefail
+          module_dir=$(cygpath -m "$GITHUB_WORKSPACE")
+          deps_dir=$module_dir
+          zstd_root=$(cygpath -m "$VCPKG_INSTALLATION_ROOT/installed/x64-windows-static")
+          ZSTD_INC="$zstd_root/include" ZSTD_LIB="$zstd_root/lib" \
+            ./configure \
+              --crossbuild=win32 \
+              --with-cc=cl \
+              --with-cc-opt='-MT -DFD_SETSIZE=1024' \
+              --with-pcre="$deps_dir/pcre2-$PCRE2_VERSION" \
+              --with-zlib="$deps_dir/zlib-$ZLIB_VERSION" \
+              --add-module="$module_dir"
+
+      - name: Locate MSVC
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $root = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          $vcvars = "$root\VC\Auxiliary\Build\vcvars64.bat"
+          if (-not (Test-Path $vcvars)) { throw "vcvars64.bat not found" }
+          "VCVARS=$vcvars" >> $env:GITHUB_ENV
+
+      - name: Pre-build PCRE2 and zlib
+        shell: cmd  # zizmor: ignore[misfeature]
+        run: |
+          call "%VCVARS%" || exit /b 1
+          cd pcre2-%PCRE2_VERSION% || exit /b 1
+          copy /y src\config.h.generic src\config.h || exit /b 1
+          copy /y src\pcre2.h.generic src\pcre2.h || exit /b 1
+          copy /y src\pcre2_chartables.c.dist src\pcre2_chartables.c || exit /b 1
+          cl -c -O2 -MT -DHAVE_CONFIG_H -DPCRE2_CODE_UNIT_WIDTH=8 -DPCRE2_STATIC -Isrc ^
+            src\pcre2_auto_possess.c src\pcre2_chartables.c src\pcre2_compile.c ^
+            src\pcre2_config.c src\pcre2_context.c src\pcre2_convert.c ^
+            src\pcre2_dfa_match.c src\pcre2_error.c src\pcre2_extuni.c ^
+            src\pcre2_find_bracket.c src\pcre2_maketables.c src\pcre2_match.c ^
+            src\pcre2_match_data.c src\pcre2_newline.c src\pcre2_ord2utf.c ^
+            src\pcre2_pattern_info.c src\pcre2_script_run.c src\pcre2_serialize.c ^
+            src\pcre2_string_utils.c src\pcre2_study.c src\pcre2_substitute.c ^
+            src\pcre2_substring.c src\pcre2_tables.c src\pcre2_ucd.c ^
+            src\pcre2_valid_utf.c src\pcre2_xclass.c || exit /b 1
+          link -lib -out:pcre2-8.lib *.obj || exit /b 1
+          cd ..\zlib-%ZLIB_VERSION% || exit /b 1
+          cl -c -O2 -MT adler32.c crc32.c deflate.c infback.c inffast.c inflate.c inftrees.c trees.c zutil.c compress.c uncompr.c gzclose.c gzlib.c gzread.c gzwrite.c || exit /b 1
+          link -lib -out:zlib.lib *.obj || exit /b 1
+
+      - name: Build
+        shell: cmd  # zizmor: ignore[misfeature]
+        working-directory: nginx-${{ env.NGINX_VERSION }}
+        run: |
+          call "%VCVARS%" || exit /b 1
+          nmake -f objs/Makefile || exit /b 1
+
+      - name: Verify static modules and directives
+        shell: pwsh
+        working-directory: nginx-${{ env.NGINX_VERSION }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $table = Get-Content objs\ngx_modules.c -Raw
+          foreach ($name in 'ngx_http_zstd_filter_module', 'ngx_http_zstd_static_module') {
+            if ($table -notmatch $name) { throw "$name absent from ngx_modules.c" }
+          }
+          New-Item -ItemType Directory -Force conf, logs | Out-Null
+          function Test-Directive([string]$directive, [bool]$valid) {
+            @('events {}', 'http {', "server { listen 8080; $directive }", '}') | Set-Content -Encoding ascii conf/nginx.conf
+            & .\objs\nginx.exe -t -p . -c conf/nginx.conf 2>$null
+            if (($LASTEXITCODE -eq 0) -ne $valid) { throw "unexpected verdict for: $directive" }
+          }
+          Test-Directive 'zstd on; zstd_static on;' $true
+          Test-Directive 'zstd_not_a_directive on;' $false
+          exit 0
+
+  mingw:
+    name: MinGW-w64 x64 dynamic
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout module
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          persist-credentials: false
+
+      - name: Set up MSYS2
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884  # v2.32.0
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            base-devel
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-pcre2
+            mingw-w64-x86_64-zlib
+            mingw-w64-x86_64-zstd
+
+      - name: Fetch, configure and build
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+          fetch() {
+            local url=$1 sha=$2 file=${1##*/}
+            curl -fsSLO --connect-timeout 30 --max-time 120 "$url"
+            printf '%s  %s\n' "$sha" "$file" | sha256sum -c -
+            tar -xzf "$file"
+          }
+          fetch "https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz" "$NGINX_SHA256"
+          fetch "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-$PCRE2_VERSION/pcre2-$PCRE2_VERSION.tar.gz" "$PCRE2_SHA256"
+          fetch "https://zlib.net/zlib-$ZLIB_VERSION.tar.gz" "$ZLIB_SHA256"
+          module_dir=$(cygpath -m "$GITHUB_WORKSPACE")
+          cd "nginx-$NGINX_VERSION"
+          ZSTD_INC=/mingw64/include ZSTD_LIB=/mingw64/lib \
+            ./configure \
+              --with-cc=gcc \
+              --with-pcre="../pcre2-$PCRE2_VERSION" \
+              --with-zlib="../zlib-$ZLIB_VERSION" \
+              --add-dynamic-module="$module_dir"
+          make -j2
+
+      - name: Verify dynamic modules and directives
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+          cd "nginx-$NGINX_VERSION"
+          test -f objs/ngx_http_zstd_filter_module.so
+          test -f objs/ngx_http_zstd_static_module.so
+          mkdir -p conf logs
+          cat > conf/nginx.conf <<'EOF'
+          load_module objs/ngx_http_zstd_filter_module.so;
+          load_module objs/ngx_http_zstd_static_module.so;
+          events {}
+          http { server { listen 8080; zstd on; zstd_static on; } }
+          EOF
+          ./objs/nginx.exe -t -p . -c conf/nginx.conf
+          sed -i 's/zstd on/zstd_not_a_directive on/' conf/nginx.conf
+          if ./objs/nginx.exe -t -p . -c conf/nginx.conf; then
+            echo 'bogus directive was accepted' >&2
+            exit 1
+          fi

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -66,7 +66,7 @@ jobs:
           $sources = @(
             @{ file = "nginx-$env:NGINX_VERSION.tar.gz"; url = "https://nginx.org/download/nginx-$env:NGINX_VERSION.tar.gz"; sha = $env:NGINX_SHA256 },
             @{ file = "pcre2-$env:PCRE2_VERSION.tar.gz"; url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-$env:PCRE2_VERSION/pcre2-$env:PCRE2_VERSION.tar.gz"; sha = $env:PCRE2_SHA256 },
-            @{ file = "zlib-$env:ZLIB_VERSION.tar.gz"; url = "https://zlib.net/zlib-$env:ZLIB_VERSION.tar.gz"; sha = $env:ZLIB_SHA256 }
+            @{ file = "zlib-$env:ZLIB_VERSION.tar.gz"; url = "https://github.com/madler/zlib/releases/download/v$env:ZLIB_VERSION/zlib-$env:ZLIB_VERSION.tar.gz"; sha = $env:ZLIB_SHA256 }
           )
           foreach ($s in $sources) {
             Invoke-WebRequest -Uri $s.url -OutFile $s.file -ConnectionTimeoutSeconds 30 -OperationTimeoutSeconds 60
@@ -186,7 +186,7 @@ jobs:
           }
           fetch "https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz" "$NGINX_SHA256"
           fetch "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-$PCRE2_VERSION/pcre2-$PCRE2_VERSION.tar.gz" "$PCRE2_SHA256"
-          fetch "https://zlib.net/zlib-$ZLIB_VERSION.tar.gz" "$ZLIB_SHA256"
+          fetch "https://github.com/madler/zlib/releases/download/v$ZLIB_VERSION/zlib-$ZLIB_VERSION.tar.gz" "$ZLIB_SHA256"
           module_dir=$(cygpath -m "$GITHUB_WORKSPACE")
           cd "nginx-$NGINX_VERSION"
           ZSTD_INC=/mingw64/include ZSTD_LIB=/mingw64/lib \

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -15,6 +15,7 @@ on:
       - '*.h'
       - 'config'
       - 'tools/build-windows.sh'
+      - '.github/scripts/configure-msvc.sh'
       - '.github/workflows/windows-build.yml'
   push:
     branches: [master]
@@ -89,20 +90,11 @@ jobs:
       - name: Configure
         # Configure is a bash script, but every compiler probe needs the
         # environment installed by vcvars64.bat in this same cmd process.
-        shell: cmd /d /s /c "call "%VCVARS%" && bash --noprofile --norc -e -o pipefail {0}"  # zizmor: ignore[misfeature]
+        shell: cmd  # zizmor: ignore[misfeature]
         working-directory: nginx-${{ env.NGINX_VERSION }}
         run: |
-          module_dir=$(cygpath -m "$GITHUB_WORKSPACE")
-          deps_dir=$module_dir
-          zstd_root=$(cygpath -m "$VCPKG_INSTALLATION_ROOT/installed/x64-windows-static")
-          ZSTD_INC="$zstd_root/include" ZSTD_LIB="$zstd_root/lib" \
-            ./configure \
-              --crossbuild=win32 \
-              --with-cc=cl \
-              --with-cc-opt='-MT -DFD_SETSIZE=1024' \
-              --with-pcre="$deps_dir/pcre2-$PCRE2_VERSION" \
-              --with-zlib="$deps_dir/zlib-$ZLIB_VERSION" \
-              --add-module="$module_dir"
+          call "%VCVARS%" || exit /b 1
+          bash "%GITHUB_WORKSPACE:\=/%/.github/scripts/configure-msvc.sh" || exit /b 1
 
       - name: Pre-build PCRE2 and zlib
         shell: cmd  # zizmor: ignore[misfeature]
@@ -196,11 +188,10 @@ jobs:
               --with-pcre="../pcre2-$PCRE2_VERSION" \
               --with-zlib="../zlib-$ZLIB_VERSION" \
               --add-dynamic-module="$module_dir"
-          # A parallel all-target build can start the dynamic-module link
-          # before nginx's MinGW import library exists. Build that dependency
-          # explicitly, then parallelize the remaining targets.
-          make -j2 objs/libnginx.a
-          make -j2
+          # A parallel build can start the dynamic-module link before nginx's
+          # MinGW import library exists. The generated makefile does not expose
+          # that library as a separate target, so preserve its declared order.
+          make -j1
 
       - name: Verify dynamic modules and directives
         shell: msys2 {0}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -76,11 +76,22 @@ jobs:
             if ($LASTEXITCODE -ne 0) { throw "tar failed for $($s.file)" }
           }
 
+      - name: Locate MSVC
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $root = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          $vcvars = "$root\VC\Auxiliary\Build\vcvars64.bat"
+          if (-not (Test-Path $vcvars)) { throw "vcvars64.bat not found" }
+          "VCVARS=$vcvars" >> $env:GITHUB_ENV
+
       - name: Configure
-        shell: bash
+        # Configure is a bash script, but every compiler probe needs the
+        # environment installed by vcvars64.bat in this same cmd process.
+        shell: cmd /d /s /c "call "%VCVARS%" && bash --noprofile --norc -e -o pipefail {0}"  # zizmor: ignore[misfeature]
         working-directory: nginx-${{ env.NGINX_VERSION }}
         run: |
-          set -euo pipefail
           module_dir=$(cygpath -m "$GITHUB_WORKSPACE")
           deps_dir=$module_dir
           zstd_root=$(cygpath -m "$VCPKG_INSTALLATION_ROOT/installed/x64-windows-static")
@@ -92,16 +103,6 @@ jobs:
               --with-pcre="$deps_dir/pcre2-$PCRE2_VERSION" \
               --with-zlib="$deps_dir/zlib-$ZLIB_VERSION" \
               --add-module="$module_dir"
-
-      - name: Locate MSVC
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          $root = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
-          $vcvars = "$root\VC\Auxiliary\Build\vcvars64.bat"
-          if (-not (Test-Path $vcvars)) { throw "vcvars64.bat not found" }
-          "VCVARS=$vcvars" >> $env:GITHUB_ENV
 
       - name: Pre-build PCRE2 and zlib
         shell: cmd  # zizmor: ignore[misfeature]
@@ -195,6 +196,10 @@ jobs:
               --with-pcre="../pcre2-$PCRE2_VERSION" \
               --with-zlib="../zlib-$ZLIB_VERSION" \
               --add-dynamic-module="$module_dir"
+          # A parallel all-target build can start the dynamic-module link
+          # before nginx's MinGW import library exists. Build that dependency
+          # explicitly, then parallelize the remaining targets.
+          make -j2 objs/libnginx.a
           make -j2
 
       - name: Verify dynamic modules and directives

--- a/README.md
+++ b/README.md
@@ -168,9 +168,17 @@ load_module modules/ngx_http_zstd_static_module.so;
 
 * Both `ngx_http_zstd_filter_module` and `ngx_http_zstd_static_module` are compiled together.
 * If you are using a custom zstd installation, set `ZSTD_INC` (path to `zstd.h`) and `ZSTD_LIB` (path to the library) before running `configure`. If unset, the system-installed zstd is used.
-* **Windows (MSVC):** a complete, SHA-pinned build script that assembles nginx + this module (and optionally ngx_brotli and headers-more) as a static `nginx.exe` lives at [`tools/build-windows.sh`](tools/build-windows.sh) — including the VS-prompt/MSYS2 launch incantation and the native-perl requirement that older guides get wrong. The usual Windows-nginx caveats apply (effectively single-worker via `select()`, no HTTP/3 — local dev use, not production), and the `zstd_static` frame probes (magic number and declared-window checks) are `pread`-based and compiled out under `NGX_WIN32`.
+* **Windows:** MSVC builds the modules statically into `nginx.exe`; MinGW-w64
+  can also build them as dynamic `.so`-named PE DLLs. The SHA-pinned
+  [`tools/build-windows.sh`](tools/build-windows.sh) assembles the MSVC build
+  (and optionally ngx_brotli and headers-more). The usual Windows-nginx caveats
+  apply (effectively single-worker via `select()`, no HTTP/3 — local dev use,
+  not production), and the `zstd_static` frame probes (magic number and
+  declared-window checks) are `pread`-based and compiled out under
+  `NGX_WIN32`. [`.github/workflows/windows-build.yml`](.github/workflows/windows-build.yml)
+  is the executable MinGW recipe and verifies both toolchains.
 * Dynamic modules (`.so`) require dynamic linking against `libzstd.so`. The build scripts auto-detect and prefer this. Ensure the zstd shared library is installed and available at runtime (`libzstd-dev` on Debian/Ubuntu, `libzstd-devel` on RHEL/Fedora).
-* When `ZSTD_LIB` is set to a non-standard path, the build embeds an RPATH pointing to that directory in the module `.so`. This means the module will load `libzstd.so` from that exact path at runtime. If the library is later moved (e.g. by a package upgrade), the module will fail to load. Use the system package and leave `ZSTD_LIB` unset to avoid this.
+* On POSIX, when `ZSTD_LIB` is set to a non-standard path, the build embeds an RPATH pointing to that directory in the module `.so`. This means the module will load `libzstd.so` from that exact path at runtime. If the library is later moved (e.g. by a package upgrade), the module will fail to load. Use the system package and leave `ZSTD_LIB` unset to avoid this.
 
 # Compatibility
 

--- a/auto/zstd
+++ b/auto/zstd
@@ -101,7 +101,16 @@ if [ -n "$ZSTD_INC" -o -n "$ZSTD_LIB" ]; then
     if [ $ngx_found = no ]; then
         # then try the dynamic shared library
         ngx_feature="ZStandard dynamic library in $ZSTD_INC and $ZSTD_LIB"
-        ngx_zstd_opt_L="-L$ZSTD_LIB -lzstd -Wl,-rpath,$ZSTD_LIB"
+        if [ "${NGX_PLATFORM:-}" = win32 ]; then
+            # MinGW produces PE/COFF modules. Its linker has no ELF runtime
+            # search path to encode, and --enable-new-dtags/-rpath are either
+            # rejected or ignored depending on the binutils version. The DLL
+            # must be beside nginx.exe or otherwise on Windows' DLL search
+            # path at runtime.
+            ngx_zstd_opt_L="-L$ZSTD_LIB -lzstd"
+        else
+            ngx_zstd_opt_L="-L$ZSTD_LIB -lzstd -Wl,-rpath,$ZSTD_LIB"
+        fi
 
         SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
         CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"


### PR DESCRIPTION
## TL;DR

Windows builds had one tested route for Microsoft's compiler and no automated guard for either Windows toolchain. This adds a Windows runner that builds both supported forms and proves nginx actually recognizes the modules' configuration.

In code terms: `.github/workflows/windows-build.yml` builds static MSVC and dynamic MinGW-w64 variants, while `auto/zstd` omits ELF `rpath` flags for PE/COFF links.

**Severity:** `Medium` (`platform compatibility - MinGW builds were unsupported and MSVC regressions had no remote gate`)

## Build contract

- MSVC links both modules into `nginx.exe` and checks `objs/ngx_modules.c`.
- MinGW-w64 produces and loads both `.so`-named PE DLLs.
- Each lane accepts `zstd on; zstd_static on;` and rejects `zstd_not_a_directive`, so a stock nginx build cannot pass by silently dropping the addon.
- Source archives and third-party actions are pinned; downloaded archives are SHA-256 verified before extraction.

## Compatibility

POSIX keeps the existing explicit-library `rpath`. MinGW uses Windows' DLL search path instead. MSVC remains a static-addon build because nginx does not set `MODULE_LINK` for that compiler; MinGW follows nginx's GNU-linker dynamic-module path.

## Testing

- `bash tools/ci-build.sh nginx 1.31.3` (Linux control build; both modules produced)
- `actionlint .github/workflows/windows-build.yml`
- `yamllint .github/workflows/windows-build.yml`
- `zizmor .github/workflows/windows-build.yml` (no findings; two documented `cmd` uses ignored)
- `bash tools/test_docs_ci_drift.sh`
- branch-wide review-lint: workflow/security/SAST checks clean; README retains its pre-existing markdownlint baseline
- [Windows build run 32080738492](https://github.com/myguard-labs/nginx-zstd-module/actions/runs/32080738492): MSVC x64 static and MinGW-w64 x64 dynamic passed, including both directive controls


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows build support for both MSVC static modules and MinGW-w64 dynamic modules.
  * Added automated Windows CI validation for builds, generated modules, and directive handling.
  * Added platform-specific zstd linking for Windows.

* **Documentation**
  * Expanded installation guidance with Windows build options, scripts, workflow details, and platform considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->