### PR TITLE
ci: bound apt mirror failover so a dead mirror can't eat the job cap

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -108,8 +108,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y \
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y \
             build-essential \
             libpcre2-dev \
             zlib1g-dev \
@@ -298,8 +298,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y \
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y \
             build-essential \
             pkg-config \
             libzstd-dev \
@@ -459,8 +459,8 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y build-essential pkg-config \
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y build-essential pkg-config \
             libpcre2-dev zlib1g-dev wget cmake python3 \
             python3-requests zstd
 
@@ -617,8 +617,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y build-essential pkg-config libzstd-dev \
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y build-essential pkg-config libzstd-dev \
             libpcre2-dev zlib1g-dev wget binutils
 
       - name: Cache nginx source tarball
@@ -857,8 +857,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y build-essential libzstd-dev \
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y build-essential libzstd-dev \
             libpcre2-dev zlib1g-dev wget curl
 
       - name: Cache nginx source tarball
@@ -1005,8 +1005,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y build-essential pkg-config libzstd-dev \
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y build-essential pkg-config libzstd-dev \
             libpcre2-dev zlib1g-dev wget
 
       - name: Cache nginx source tarball
@@ -1107,8 +1107,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y \
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y \
             libperl-dev \
             cpanminus \
             libzstd1 \
@@ -1363,8 +1363,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y python3 python3-requests zstd libzstd1 \
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y python3 python3-requests zstd libzstd1 \
             libperl-dev cpanminus
 
       - name: Download ASAN nginx binary
@@ -1538,8 +1538,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y build-essential pkg-config libzstd-dev \
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y build-essential pkg-config libzstd-dev \
             libpcre2-dev zlib1g-dev libssl-dev libperl-dev cpanminus \
             python3 python3-requests zstd lcov wget
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -108,8 +108,19 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y \
+          # apt tuning lives in a conf file rather than per-invocation -o
+          # flags, so apt-get calls from nested scripts inherit it too.
+          # builder02 shares the box across jobs and never talks to the
+          # Azure mirror: keep timeouts loose enough that a loaded runner
+          # idling a connection isn't a step failure.
+          printf '%s\n' \
+            'DPkg::Lock::Timeout "120";' \
+            'Acquire::Retries "3";' \
+            'Acquire::http::Timeout "20";' \
+            'Acquire::https::Timeout "20";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y \
             build-essential \
             libpcre2-dev \
             zlib1g-dev \
@@ -298,8 +309,19 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y \
+          # apt tuning lives in a conf file rather than per-invocation -o
+          # flags, so apt-get calls from nested scripts inherit it too.
+          # builder02 shares the box across jobs and never talks to the
+          # Azure mirror: keep timeouts loose enough that a loaded runner
+          # idling a connection isn't a step failure.
+          printf '%s\n' \
+            'DPkg::Lock::Timeout "120";' \
+            'Acquire::Retries "3";' \
+            'Acquire::http::Timeout "20";' \
+            'Acquire::https::Timeout "20";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y \
             build-essential \
             pkg-config \
             libzstd-dev \
@@ -459,8 +481,19 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y build-essential pkg-config \
+          # apt tuning lives in a conf file rather than per-invocation -o
+          # flags, so apt-get calls from nested scripts inherit it too.
+          # builder02 shares the box across jobs and never talks to the
+          # Azure mirror: keep timeouts loose enough that a loaded runner
+          # idling a connection isn't a step failure.
+          printf '%s\n' \
+            'DPkg::Lock::Timeout "120";' \
+            'Acquire::Retries "3";' \
+            'Acquire::http::Timeout "20";' \
+            'Acquire::https::Timeout "20";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config \
             libpcre2-dev zlib1g-dev wget cmake python3 \
             python3-requests zstd
 
@@ -617,8 +650,19 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y build-essential pkg-config libzstd-dev \
+          # apt tuning lives in a conf file rather than per-invocation -o
+          # flags, so apt-get calls from nested scripts inherit it too.
+          # builder02 shares the box across jobs and never talks to the
+          # Azure mirror: keep timeouts loose enough that a loaded runner
+          # idling a connection isn't a step failure.
+          printf '%s\n' \
+            'DPkg::Lock::Timeout "120";' \
+            'Acquire::Retries "3";' \
+            'Acquire::http::Timeout "20";' \
+            'Acquire::https::Timeout "20";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config libzstd-dev \
             libpcre2-dev zlib1g-dev wget binutils
 
       - name: Cache nginx source tarball
@@ -856,9 +900,26 @@ jobs:
           persist-credentials: false
 
       - name: Install dependencies
+        # A slow-rather-than-dead mirror can still crawl past every
+        # Acquire timeout; cap the step so a stall fails HERE, named,
+        # with the log intact — instead of the 15-minute job cap
+        # swallowing it (the #117 failure shape).
+        timeout-minutes: 5
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y build-essential libzstd-dev \
+          # ubuntu-latest resolves apt through azure.archive.ubuntu.com,
+          # whose outage shape is ~2 minutes of default Acquire timeout per
+          # index file before the runner's mirror list falls back (the #117
+          # cancellations). Short idle timeouts and a single retry make
+          # that failover cheap; a conf file rather than -o flags also
+          # covers apt-get calls from nested scripts.
+          printf '%s\n' \
+            'DPkg::Lock::Timeout "120";' \
+            'Acquire::Retries "1";' \
+            'Acquire::http::Timeout "10";' \
+            'Acquire::https::Timeout "10";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y build-essential libzstd-dev \
             libpcre2-dev zlib1g-dev wget curl
 
       - name: Cache nginx source tarball
@@ -1005,8 +1066,19 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y build-essential pkg-config libzstd-dev \
+          # apt tuning lives in a conf file rather than per-invocation -o
+          # flags, so apt-get calls from nested scripts inherit it too.
+          # builder02 shares the box across jobs and never talks to the
+          # Azure mirror: keep timeouts loose enough that a loaded runner
+          # idling a connection isn't a step failure.
+          printf '%s\n' \
+            'DPkg::Lock::Timeout "120";' \
+            'Acquire::Retries "3";' \
+            'Acquire::http::Timeout "20";' \
+            'Acquire::https::Timeout "20";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config libzstd-dev \
             libpcre2-dev zlib1g-dev wget
 
       - name: Cache nginx source tarball
@@ -1107,8 +1179,19 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y \
+          # apt tuning lives in a conf file rather than per-invocation -o
+          # flags, so apt-get calls from nested scripts inherit it too.
+          # builder02 shares the box across jobs and never talks to the
+          # Azure mirror: keep timeouts loose enough that a loaded runner
+          # idling a connection isn't a step failure.
+          printf '%s\n' \
+            'DPkg::Lock::Timeout "120";' \
+            'Acquire::Retries "3";' \
+            'Acquire::http::Timeout "20";' \
+            'Acquire::https::Timeout "20";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y \
             libperl-dev \
             cpanminus \
             libzstd1 \
@@ -1363,8 +1446,19 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y python3 python3-requests zstd libzstd1 \
+          # apt tuning lives in a conf file rather than per-invocation -o
+          # flags, so apt-get calls from nested scripts inherit it too.
+          # builder02 shares the box across jobs and never talks to the
+          # Azure mirror: keep timeouts loose enough that a loaded runner
+          # idling a connection isn't a step failure.
+          printf '%s\n' \
+            'DPkg::Lock::Timeout "120";' \
+            'Acquire::Retries "3";' \
+            'Acquire::http::Timeout "20";' \
+            'Acquire::https::Timeout "20";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y python3 python3-requests zstd libzstd1 \
             libperl-dev cpanminus
 
       - name: Download ASAN nginx binary
@@ -1538,8 +1632,19 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y build-essential pkg-config libzstd-dev \
+          # apt tuning lives in a conf file rather than per-invocation -o
+          # flags, so apt-get calls from nested scripts inherit it too.
+          # builder02 shares the box across jobs and never talks to the
+          # Azure mirror: keep timeouts loose enough that a loaded runner
+          # idling a connection isn't a step failure.
+          printf '%s\n' \
+            'DPkg::Lock::Timeout "120";' \
+            'Acquire::Retries "3";' \
+            'Acquire::http::Timeout "20";' \
+            'Acquire::https::Timeout "20";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config libzstd-dev \
             libpcre2-dev zlib1g-dev libssl-dev libperl-dev cpanminus \
             python3 python3-requests zstd lcov wget
 

--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -83,8 +83,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y \
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y \
             build-essential curl libpcre2-dev libzstd-dev pkg-config \
             wget zstd libperl-dev cpanminus
 
@@ -144,8 +144,8 @@ jobs:
 
       - name: Install clang + libFuzzer
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y clang
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y clang
 
       - name: Select fuzz duration
         env:
@@ -238,8 +238,8 @@ jobs:
           echo "NGINX_VERSION=$ver" >> "$GITHUB_ENV"
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y \
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y \
             build-essential curl libpcre2-dev libzstd-dev pkg-config \
             valgrind wget zlib1g-dev zstd
       - name: Build debug nginx + zstd module
@@ -290,8 +290,8 @@ jobs:
           echo "NGINX_VERSION=$ver" >> "$GITHUB_ENV"
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y \
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y \
             build-essential curl libpcre2-dev libzstd-dev pkg-config \
             valgrind wget zlib1g-dev zstd
       - name: Build debug nginx + zstd module
@@ -335,8 +335,8 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y flawfinder clang-tidy python3 python3-pip pipx nginx-dev
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y flawfinder clang-tidy python3 python3-pip pipx nginx-dev
           # semgrep: isolate via pipx (PEP 668 blocks a bare pip3 install into the
           # system Python on the Ubuntu 24.04 self-hosted runner). Fall back to a
           # user pip install with --break-system-packages if pipx is unavailable.

--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -83,8 +83,19 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y \
+          # apt tuning lives in a conf file rather than per-invocation -o
+          # flags, so apt-get calls from nested scripts inherit it too.
+          # builder02 shares the box across jobs and never talks to the
+          # Azure mirror: keep timeouts loose enough that a loaded runner
+          # idling a connection isn't a step failure.
+          printf '%s\n' \
+            'DPkg::Lock::Timeout "120";' \
+            'Acquire::Retries "3";' \
+            'Acquire::http::Timeout "20";' \
+            'Acquire::https::Timeout "20";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y \
             build-essential curl libpcre2-dev libzstd-dev pkg-config \
             wget zstd libperl-dev cpanminus
 
@@ -144,8 +155,19 @@ jobs:
 
       - name: Install clang + libFuzzer
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y clang
+          # apt tuning lives in a conf file rather than per-invocation -o
+          # flags, so apt-get calls from nested scripts inherit it too.
+          # builder02 shares the box across jobs and never talks to the
+          # Azure mirror: keep timeouts loose enough that a loaded runner
+          # idling a connection isn't a step failure.
+          printf '%s\n' \
+            'DPkg::Lock::Timeout "120";' \
+            'Acquire::Retries "3";' \
+            'Acquire::http::Timeout "20";' \
+            'Acquire::https::Timeout "20";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y clang
 
       - name: Select fuzz duration
         env:
@@ -238,8 +260,19 @@ jobs:
           echo "NGINX_VERSION=$ver" >> "$GITHUB_ENV"
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y \
+          # apt tuning lives in a conf file rather than per-invocation -o
+          # flags, so apt-get calls from nested scripts inherit it too.
+          # builder02 shares the box across jobs and never talks to the
+          # Azure mirror: keep timeouts loose enough that a loaded runner
+          # idling a connection isn't a step failure.
+          printf '%s\n' \
+            'DPkg::Lock::Timeout "120";' \
+            'Acquire::Retries "3";' \
+            'Acquire::http::Timeout "20";' \
+            'Acquire::https::Timeout "20";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y \
             build-essential curl libpcre2-dev libzstd-dev pkg-config \
             valgrind wget zlib1g-dev zstd
       - name: Build debug nginx + zstd module
@@ -290,8 +323,19 @@ jobs:
           echo "NGINX_VERSION=$ver" >> "$GITHUB_ENV"
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y \
+          # apt tuning lives in a conf file rather than per-invocation -o
+          # flags, so apt-get calls from nested scripts inherit it too.
+          # builder02 shares the box across jobs and never talks to the
+          # Azure mirror: keep timeouts loose enough that a loaded runner
+          # idling a connection isn't a step failure.
+          printf '%s\n' \
+            'DPkg::Lock::Timeout "120";' \
+            'Acquire::Retries "3";' \
+            'Acquire::http::Timeout "20";' \
+            'Acquire::https::Timeout "20";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y \
             build-essential curl libpcre2-dev libzstd-dev pkg-config \
             valgrind wget zlib1g-dev zstd
       - name: Build debug nginx + zstd module
@@ -335,8 +379,19 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y flawfinder clang-tidy python3 python3-pip pipx nginx-dev
+          # apt tuning lives in a conf file rather than per-invocation -o
+          # flags, so apt-get calls from nested scripts inherit it too.
+          # builder02 shares the box across jobs and never talks to the
+          # Azure mirror: keep timeouts loose enough that a loaded runner
+          # idling a connection isn't a step failure.
+          printf '%s\n' \
+            'DPkg::Lock::Timeout "120";' \
+            'Acquire::Retries "3";' \
+            'Acquire::http::Timeout "20";' \
+            'Acquire::https::Timeout "20";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y flawfinder clang-tidy python3 python3-pip pipx nginx-dev
           # semgrep: isolate via pipx (PEP 668 blocks a bare pip3 install into the
           # system Python on the Ubuntu 24.04 self-hosted runner). Fall back to a
           # user pip install with --break-system-packages if pipx is unavailable.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,8 +54,8 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y build-essential pkg-config libzstd-dev \
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y build-essential pkg-config libzstd-dev \
             libpcre2-dev zlib1g-dev wget
 
       - name: Cache nginx source tarball

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,9 +53,25 @@ jobs:
           echo "NGINX_VERSION=$ver" >> "$GITHUB_ENV"
 
       - name: Install build dependencies
+        # A slow-rather-than-dead mirror can still crawl past every
+        # Acquire timeout; cap the step so a stall fails HERE, named,
+        # with the log intact, instead of eating the job cap.
+        timeout-minutes: 5
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y build-essential pkg-config libzstd-dev \
+          # ubuntu-latest resolves apt through azure.archive.ubuntu.com,
+          # whose outage shape is ~2 minutes of default Acquire timeout per
+          # index file before the runner's mirror list falls back (the #117
+          # cancellations). Short idle timeouts and a single retry make
+          # that failover cheap; a conf file rather than -o flags also
+          # covers apt-get calls from nested scripts.
+          printf '%s\n' \
+            'DPkg::Lock::Timeout "120";' \
+            'Acquire::Retries "1";' \
+            'Acquire::http::Timeout "10";' \
+            'Acquire::https::Timeout "10";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config libzstd-dev \
             libpcre2-dev zlib1g-dev wget
 
       - name: Cache nginx source tarball

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Install clang + libFuzzer
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y clang
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y clang
 
       - name: Build fuzz target
         run: bash fuzz/build.sh "$GITHUB_WORKSPACE/fuzz/fuzz_accept_encoding"

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -35,8 +35,19 @@ jobs:
 
       - name: Install clang + libFuzzer
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y clang
+          # apt tuning lives in a conf file rather than per-invocation -o
+          # flags, so apt-get calls from nested scripts inherit it too.
+          # builder02 shares the box across jobs and never talks to the
+          # Azure mirror: keep timeouts loose enough that a loaded runner
+          # idling a connection isn't a step failure.
+          printf '%s\n' \
+            'DPkg::Lock::Timeout "120";' \
+            'Acquire::Retries "3";' \
+            'Acquire::http::Timeout "20";' \
+            'Acquire::https::Timeout "20";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y clang
 
       - name: Build fuzz target
         run: bash fuzz/build.sh "$GITHUB_WORKSPACE/fuzz/fuzz_accept_encoding"

--- a/.github/workflows/security-scanners.yml
+++ b/.github/workflows/security-scanners.yml
@@ -33,8 +33,19 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y flawfinder clang-tidy python3 python3-pip pipx nginx-dev
+          # apt tuning lives in a conf file rather than per-invocation -o
+          # flags, so apt-get calls from nested scripts inherit it too.
+          # builder02 shares the box across jobs and never talks to the
+          # Azure mirror: keep timeouts loose enough that a loaded runner
+          # idling a connection isn't a step failure.
+          printf '%s\n' \
+            'DPkg::Lock::Timeout "120";' \
+            'Acquire::Retries "3";' \
+            'Acquire::http::Timeout "20";' \
+            'Acquire::https::Timeout "20";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y flawfinder clang-tidy python3 python3-pip pipx nginx-dev
           # semgrep: isolate via pipx (PEP 668 blocks a bare pip3 install into the
           # system Python on the Ubuntu 24.04 self-hosted runner). Fall back to a
           # user pip install with --break-system-packages if pipx is unavailable.

--- a/.github/workflows/security-scanners.yml
+++ b/.github/workflows/security-scanners.yml
@@ -33,8 +33,8 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y flawfinder clang-tidy python3 python3-pip pipx nginx-dev
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y flawfinder clang-tidy python3 python3-pip pipx nginx-dev
           # semgrep: isolate via pipx (PEP 668 blocks a bare pip3 install into the
           # system Python on the Ubuntu 24.04 self-hosted runner). Fall back to a
           # user pip install with --break-system-packages if pipx is unavailable.

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -43,8 +43,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y \
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y \
             build-essential curl libpcre2-dev libzstd-dev pkg-config \
             valgrind wget zlib1g-dev zstd
 

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -43,8 +43,19 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 -o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y \
+          # apt tuning lives in a conf file rather than per-invocation -o
+          # flags, so apt-get calls from nested scripts inherit it too.
+          # builder02 shares the box across jobs and never talks to the
+          # Azure mirror: keep timeouts loose enough that a loaded runner
+          # idling a connection isn't a step failure.
+          printf '%s\n' \
+            'DPkg::Lock::Timeout "120";' \
+            'Acquire::Retries "3";' \
+            'Acquire::http::Timeout "20";' \
+            'Acquire::https::Timeout "20";' \
+            | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y \
             build-essential curl libpcre2-dev libzstd-dev pkg-config \
             valgrind wget zlib1g-dev zstd
 


### PR DESCRIPTION
The `compression_vary interop` job on #117's last two runs sat in **Install dependencies** until the 15-minute job cap cancelled it. The recovered log shows the known `azure.archive.ubuntu.com` outage shape — every index fetch cycles through `Ign:` retries against the dead mirror before the runner's mirror list falls back to `archive.ubuntu.com`:

```
Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
Ign:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease
...   (three retry cycles per index)
Hit:2 https://archive.ubuntu.com/ubuntu noble InRelease
Get:3 https://archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
...
##[error]The operation was canceled.
```

The fallback works — it's just gated behind roughly two minutes of default Acquire timeout per attempt across ~30 index files, which is more accumulated timeout than the job budget allows. `DPkg::Lock::Timeout` (#119) bounds lock waits only and can't touch a network-side stall — this is the other flake in the same family.

**Reworked after review** (8be16b8) — the first cut added `-o Acquire::Retries=1 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10` to all 36 `apt-get` sites uniformly; review caught that the tight values were written for the Azure mirror but would land on builder02 too, where they'd be a new failure cliff rather than a fix. Now:

- **Two runner profiles, one conf file per job.** Each job writes `/etc/apt/apt.conf.d/99-ci-net` at the top of its apt step and the `apt-get` lines drop their flags entirely (`DPkg::Lock::Timeout=120` from #119 folded in). The two `ubuntu-latest` jobs (`cvary-interop`, CodeQL) — the only ones that resolve through `azure.archive.ubuntu.com` — get the tight profile (10s idle timeout, 1 retry). The self-hosted builder02 jobs, which share a box across concurrent jobs and never touch the Azure mirror, get 20s/3. The conf-file shape over `$APT_OPTS` interpolation: no `SC2086` exemption, and `apt-get` calls from nested scripts inherit the tuning, which per-invocation `-o` flags never covered.
- **`timeout-minutes: 5` on the two `ubuntu-latest` apt steps.** `Acquire::*::Timeout` bounds one connection's idle time, never step wall-clock — a slow-rather-than-dead mirror could still crawl into the 15-minute job cap and reproduce the same unreadable cancellation. The step cap makes that failure fast, named, and with its log intact.

The timeouts are per-connection inactivity limits, not total-transfer limits, so slow large downloads are unaffected. How much of the crawl the failover actually skips depends on whether apt's mirror method marks a failed mirror dead for the rest of the run or re-pays retries×timeout per index file — unmeasured until the next real outage, so this PR no longer claims "seconds" anywhere.

One clarification for the review thread: `azure.archive.ubuntu.com` isn't *persistently* bad — it was down during the #117 incident window (the "known outage shape" above) and is healthy again; it's the default and nearest mirror for Azure-hosted runners. That's why this PR tunes failover rather than dropping the mirror: an unconditional drop would trade an occasional outage for always using the farther mirror. The deterministic follow-up would be probe-then-drop before `update` (the `mirror+file:/etc/apt/apt-mirrors.txt` mechanism makes the edit straightforward), which only pays the cost when the probe actually fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of automated builds, testing, fuzzing, security scans, and memory checks when downloading system packages.
  * Added retry handling and network timeouts to reduce failures caused by temporary package repository or network issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
