### PR TITLE
fix(static): opt in to byte ranges like gzip_static (reverses f7e2ef3)

### DIFF
--- a/static/ngx_http_zstd_static_module.c
+++ b/static/ngx_http_zstd_static_module.c
@@ -565,6 +565,14 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
     b->last_buf = (r == r->main) ? 1 : 0;
     b->last_in_chain = 1;
 
+    /* gzip_static parity: a zero-length file served in a subrequest
+     * yields a buf with neither in_file nor last_buf — sync marks it
+     * so the output chain doesn't reject it as a zero-size buf. Only
+     * reachable when the frame-header probe is compiled out (no
+     * pread(2) / NGX_WIN32); with the probe active, sub-4-byte files
+     * never get this far. */
+    b->sync = (b->last_buf || b->in_file) ? 0 : 1;
+
     b->file->fd = of.fd;
     b->file->name = path;
     b->file->log = log;

--- a/static/ngx_http_zstd_static_module.c
+++ b/static/ngx_http_zstd_static_module.c
@@ -531,11 +531,16 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, log, 0,
                    "zstd static: serving precompressed \"%s\"", path.data);
 
-    /* Byte ranges are meaningless on a compressed body: offsets in the
-     * .zst file do not correspond to positions in the original content.
-     * RFC 9110 §14.2 — clear Accept-Ranges so clients do not request
-     * ranges that would yield undecipherable fragments. */
-    ngx_http_clear_accept_ranges(r);
+    /* gzip_static parity: byte ranges address the SELECTED
+     * REPRESENTATION (RFC 9110 §14.2) — here the .zst bytes on disk,
+     * which a client can fetch, resume and concatenate coherently
+     * because the validator is strong and the bytes are stable. That
+     * is why gzip_static has always set r->allow_ranges, and ranges
+     * only work by opting in: the range filter bails without the
+     * flag. The FILTER module's clear_accept_ranges remains correct
+     * for the opposite reason — a stream generated on the fly has
+     * nothing stable to seek into. */
+    r->allow_ranges = 1;
 
     b = ngx_calloc_buf(r->pool);
     if (b == NULL) {

--- a/t/01-static.t
+++ b/t/01-static.t
@@ -28,19 +28,21 @@ run_tests();
 # COVERAGE NOTES on gaps found by the git-history CI audit
 # (kept above __DATA__ so they are not parsed into any test block):
 #
-# Gap 2 — f7e2ef3 ("clear Accept-Ranges in static module"):
-# deliberately NOT covered by a black-box test here. The static
-# handler serves a local file and never sets r->allow_ranges (in this
-# nginx, only the upstream/proxy path sets it — see
-# ngx_http_upstream.c, and ngx_http_range_filter_module.c bails unless
-# r->allow_ranges). ngx_http_clear_accept_ranges() in the static
-# module is therefore purely defensive: no request reachable through
-# zstd_static alone makes the pre-fix and fixed builds differ
-# (empirically verified — identical 200, no Accept-Ranges, no
-# Content-Range, on both a pre-f7e2ef3 and a fixed .so). A Perl test
-# asserting !Accept-Ranges would PASS on the buggy build too, i.e. be
-# blind. Per the project's fail-first discipline we do not add a test
-# that cannot fail on the unfixed code.
+# Gap 2 — f7e2ef3 ("clear Accept-Ranges in static module"), since
+# REVERSED: the handler now opts IN via r->allow_ranges = 1, covered
+# fail-first by TESTS 36–37. The history, for the record: f7e2ef3's
+# clear was a no-op (the handler never set r->allow_ranges, and
+# ngx_http_range_filter_module.c bails without it — empirically
+# verified at the time: identical responses on pre-fix and fixed
+# builds), and its rationale misread the RFC it cited. RFC 9110 §14.2
+# has ranges address the SELECTED REPRESENTATION — under
+# Content-Encoding: zstd, the .zst bytes — which is not an
+# "undecipherable fragment" hazard but exactly the coherent,
+# resumable-download semantics gzip_static has always provided by
+# setting r->allow_ranges = 1 (strong validator, byte-identical
+# representation on disk). The filter module's clear remains correct
+# for the opposite reason: a stream generated on the fly has nothing
+# stable to seek into.
 #
 # Gap 3 — HTTP/2 transport axis (8281baa bug-B class):
 # the build enables --with-http_v2_module but nothing tests the h2
@@ -897,3 +899,57 @@ Content-Encoding: zstd
 --- error_code: 200
 --- no_error_log
 decompression window
+
+
+
+=== TEST 36: a served sidecar advertises Accept-Ranges: bytes
+# gzip_static parity (see gzip_static's r->allow_ranges = 1): the
+# representation is the .zst bytes and the validator is strong, so
+# static-side ranges are coherent — resumable downloads included.
+# Fails on builds without the opt-in: no allow_ranges, no header.
+--- config
+    location /test {
+        zstd_static on;
+        root ../../t/suite;
+    }
+--- request
+GET /test
+--- more_headers
+Accept-Encoding: gzip, zstd
+--- response_headers
+Content-Encoding: zstd
+Accept-Ranges: bytes
+--- no_error_log
+[error]
+
+
+
+=== TEST 37: byte ranges slice the sidecar's bytes (206 + Content-Range)
+# RFC 9110 §14.2: ranges address the SELECTED REPRESENTATION — under
+# Content-Encoding: zstd that is the .zst bytes themselves, which a
+# client can fetch, resume and concatenate before decompressing. The
+# fixture is TEST 35's crafted 12-byte frame (magic + 1 KB window +
+# raw "hi\n" block), so the slice is byte-pinned: the first four bytes
+# are the frame magic. Unfixed code ignores Range and answers 200.
+--- config
+    location /rg/ {
+        zstd_static on;
+        root html;
+    }
+--- user_files eval
+">>> rg/tiny.js\ntiny origin body\n>>> rg/tiny.js.zst\n"
+. pack("C*", 0x28, 0xB5, 0x2F, 0xFD, 0x00, 0x00, 0x19, 0x00, 0x00)
+. "hi\n"
+--- request
+GET /rg/tiny.js
+--- more_headers
+Accept-Encoding: zstd
+Range: bytes=0-3
+--- error_code: 206
+--- response_headers
+Content-Encoding: zstd
+Content-Range: bytes 0-3/12
+--- response_body eval
+pack("C*", 0x28, 0xB5, 0x2F, 0xFD)
+--- no_error_log
+[error]


### PR DESCRIPTION
While auditing the unified static handler on #117 against gzip_static, we found zstd_static has never served range requests — and that the commit ostensibly governing this (f7e2ef3, "clear Accept-Ranges in static module") doesn't hold up on either half:

- **The bug it fixed didn't exist.** The range filter bails unless a handler sets `r->allow_ranges`, which this handler never did — so nginx neither advertised nor honoured ranges before or after the clear. The suite's own Gap 2 coverage note recorded the empirical verification (identical responses on pre-fix and fixed builds), which is why no test ever covered it.

- **Its own RFC citation argues the other way.** RFC 9110 §14.2 has ranges address the *selected representation* — under `Content-Encoding: zstd`, the `.zst` bytes on disk. That's not an "undecipherable fragment" hazard: a client fetches bytes 0–999, resumes at 1000–, concatenates and decompresses, coherently, because the validator is strong and the bytes are stable. It's exactly the semantics gzip_static has always provided with `r->allow_ranges = 1` (resumable downloads of precompressed assets), and no client that can't handle CE-plus-ranges sends `Range` at all. The *filter* module's clear remains correct for the opposite reason — a stream generated on the fly has nothing stable to seek into.

The fix is the gzip_static line: `r->allow_ranges = 1`. TEST 36 pins `Accept-Ranges: bytes` on a 200; TEST 37 pins a 206 + `Content-Range` slice byte-compared against a crafted 12-byte frame (TEST 35's fixture — the first four bytes are the frame magic). Both verified fail-first against the unfixed module: the 206 comes back 200 with no range headers. The Gap 2 note is rewritten to record the reversal with this archaeology. Full local battery: 1,654 assertions across the four Perl suites green.

Related: the unified compression module on #117 had inherited the same clear through the port and got the identical fix in 7a34356, plus a `b->sync` gzip_static-parity line. This PR originally skipped that line as unreachable (the frame-header probe rejects sub-4-byte files), but review pointed out the probe sits behind `#if !(NGX_WIN32)` / `#if (NGX_HAVE_PREAD)` — on a build where it compiles out, a zero-length `.zst` in a subrequest reaches exactly the case the line exists for. fb7ed9b takes the one-line parity instead of the platform-qualified footnote. ngx_brotli's static module has the same gap (no `allow_ranges`, no defensive clear either); that's being handled in its own tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Static `.zst` files now support byte-range requests.
  * Partial responses return the appropriate status, range metadata, and requested content.

* **Bug Fixes**
  * Static compressed responses now correctly advertise range support.
  * Empty compressed responses in subrequests are handled correctly.

* **Tests**
  * Added coverage for range headers, partial responses, content ranges, and returned bytes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
