### PR TITLE
ci: depth pass, docs, adoption stamp (steps 30-42)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -481,7 +481,18 @@ jobs:
     name: Build (libzstd 1.4.x — fallback paths)
     runs-on: ${{ fromJSON(vars.POOL || '["ubuntu-latest"]') }}
     timeout-minutes: 25
-    needs: resolve
+    # Lane D: takes validation's slot rather than starting a new one. The pool
+    # has 6 real slots and this workflow's own fan-out after `resolve` was 7
+    # jobs wide, so one of them had to queue. validation(216s) ->
+    # build-old-libzstd(135s) = 351s, still under the 370s
+    # resolve(6s)->build(212s)->tests(145s) critical path measured on run
+    # 32547163515, so this costs no wall-clock while dropping this
+    # workflow's peak from 7 to 6. `!cancelled()` keeps it running when
+    # validation FAILS -- it depends on validation only for the slot, never
+    # for an artifact, and a validation failure must not silently skip a
+    # build-matrix leg.
+    needs: [resolve, validation]
+    if: ${{ !cancelled() }}
 
     env:
       # Resolved mainline nginx (used by the cache keys + download/build steps

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -487,12 +487,16 @@ jobs:
     # build-old-libzstd(135s) = 351s, still under the 370s
     # resolve(6s)->build(212s)->tests(145s) critical path measured on run
     # 32547163515, so this costs no wall-clock while dropping this
-    # workflow's peak from 7 to 6. `!cancelled()` keeps it running when
-    # validation FAILS -- it depends on validation only for the slot, never
-    # for an artifact, and a validation failure must not silently skip a
-    # build-matrix leg.
+    # workflow's peak from 7 to 6. The `if:` keeps it running when validation
+    # FAILS -- it depends on validation only for the slot, never for an
+    # artifact, and a validation failure must not silently skip a build-matrix
+    # leg. It must still SKIP when `resolve` fails: every step below builds
+    # against `needs.resolve.outputs.nginx_version`, which is empty in that
+    # case, so a bare `!cancelled()` would download a bogus tarball instead of
+    # skipping. Hence the explicit resolve success test rather than relying on
+    # default `needs` semantics, which the `if:` overrides for BOTH deps.
     needs: [resolve, validation]
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.resolve.result == 'success' }}
 
     env:
       # Resolved mainline nginx (used by the cache keys + download/build steps

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,18 @@
 Changes with http-zstd
 
+    *) Change: the repository adopted the myguard nginx-module skeleton
+       standard. CI material moved under ci/ (t/, tests/unit/, tools/,
+       fuzz/, linter/), the module sources moved to src/, and .github/
+       workflows/ci.yml became the single pull-request entry point that
+       calls Lint, Build&Test, Security Scanners, Fuzzing, Valgrind,
+       CodeQL, A/UBSan and Windows build as reusable workflows. Long
+       runners moved to the scheduled ci-deep.yml lane. Adds a unit-test
+       layer over the real Accept-Encoding decision function, a fuzz
+       dictionary derived from live call sites with a drift gate, a
+       coverage report scoped to src/, and a tracked pre-commit hook.
+       No module behaviour changed; directives, defaults and the module
+       binary are unaffected.
+
     *) Feature: RFC 9842 dcz dictionary compression. New repeatable
        zstd_dcz_dict_file directive (http/server/location) loads
        dictionaries hashed at config load; a request whose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,45 @@ this code started by not knowing nginx internals either.
 - [ ] All CI checks green. No skipping, no "it works on my machine".
 - [ ] Commit messages: imperative subject, body explains *why*.
       No AI co-author trailers.
+- [ ] The local hook is enabled (see below) — it runs the same checks the
+      Lint job runs, so you find them in a second instead of a CI round-trip.
+
+## Enable the local hook
+
+The repository ships its own pre-commit hook. It is **not** active in a fresh
+clone — git never enables hooks automatically — so turn it on once:
+
+```sh
+git config core.hooksPath .githooks
+```
+
+That is the whole setup. `.githooks/pre-commit` drives the same
+`ci/linter/` checkers the **Lint** workflow runs, so a finding shows up before
+the push rather than on the PR.
+
+Install the tools it calls with:
+
+```sh
+ci/linter/install-linters.sh          # apt + pipx + cpan + upstream binaries
+ci/linter/install-linters.sh --check  # report what is present; non-zero if any
+                                      # required tool is missing
+```
+
+`--check` exits non-zero when a tool is missing, so it is safe to use as a gate
+in your own scripts — a tool that is absent is never reported as clean.
+
+Timing: the hook takes ~0.5s for a docs-only change and ~3.6s when a C file is
+staged (semgrep is most of that). To run the full set by hand without
+committing:
+
+```sh
+ci/linter/run-all.sh                  # every checker over the tracked tree
+LINT_ONLY="sh python" ci/linter/run-all.sh   # narrow to named checkers
+```
+
+One trap worth knowing: `run-all.sh` enumerates files with `git ls-files`, so a
+**new untracked file is invisible to it** and the run reads green while checking
+nothing. `git add -N` the file first.
 
 ## How CI works here
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,11 +36,25 @@ clone — git never enables hooks automatically — so turn it on once:
 git config core.hooksPath .githooks
 ```
 
-That is the whole setup. `.githooks/pre-commit` drives the same
-`ci/linter/` checkers the **Lint** workflow runs, so a finding shows up before
-the push rather than on the PR.
+`.githooks/pre-commit` then runs **two** gates on every commit, and fails on
+either:
 
-Install the tools it calls with:
+1. `ci/linter/run-all.sh --staged` — the same `ci/linter/` checkers the **Lint**
+   workflow runs (nginx-convention, shell, Python, Perl, YAML, spelling, and the
+   CI-policy checkers).
+2. the `.pre-commit-config.yaml` hooks — secret detection (gitleaks,
+   detect-private-key), the C SAST gates (flawfinder, semgrep, cppcheck),
+   ast-grep, ruff, actionlint and shellcheck.
+
+Neither list is a superset of the other, which is why the hook runs both.
+
+**`pre-commit` itself is a hard prerequisite.** When `.pre-commit-config.yaml`
+is present and the `pre-commit` binary is missing, the hook exits 2 and blocks
+the commit rather than warning — a gate that skips itself when its tool is
+absent reports green while checking nothing. The same applies to a missing
+linter: `run-all.sh` exits 2 and the commit is blocked.
+
+Install everything the hook calls — `pre-commit` included — with:
 
 ```sh
 ci/linter/install-linters.sh          # apt + pipx + cpan + upstream binaries
@@ -50,6 +64,20 @@ ci/linter/install-linters.sh --check  # report what is present; non-zero if any
 
 `--check` exits non-zero when a tool is missing, so it is safe to use as a gate
 in your own scripts — a tool that is absent is never reported as clean.
+
+Verify the hook is actually live before trusting it — this gate was green and
+inert for days once, because `core.hooksPath` makes the copy
+`pre-commit install` writes into `.git/hooks/` unreachable while every surface
+a human checks still looks installed:
+
+```sh
+printf 'probe   \n\nno newline at eof' > _p.txt
+git add _p.txt && git commit -m probe -- _p.txt   # expect BLOCKED
+git reset -q HEAD _p.txt; rm -f _p.txt
+```
+
+Both `trim trailing whitespace` and `fix end of files` must report Failed. If
+the commit lands, `.pre-commit-config.yaml` is not being consulted.
 
 Timing: the hook takes ~0.5s for a docs-only change and ~3.6s when a C file is
 staged (semgrep is most of that). To run the full set by hand without

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ load_module modules/ngx_http_zstd_static_module.so;
 * If you are using a custom zstd installation, set `ZSTD_INC` (path to `zstd.h`) and `ZSTD_LIB` (path to the library) before running `configure`. If unset, the system-installed zstd is used.
 * **Windows:** MSVC builds the modules statically into `nginx.exe`; MinGW-w64
   can also build them as dynamic `.so`-named PE DLLs. The SHA-pinned
-  [`tools/build-windows.sh`](tools/build-windows.sh) assembles the MSVC build
+  [`ci/tools/build-windows.sh`](ci/tools/build-windows.sh) assembles the MSVC build
   (and optionally ngx_brotli and headers-more). The usual Windows-nginx caveats
   apply (effectively single-worker via `select()`, no HTTP/3 — local dev use,
   not production), and the `zstd_static` frame probes (magic number and
@@ -985,18 +985,63 @@ Run the suites locally:
 
 ```bash
 # Perl suites (needs Test::Nginx::Socket and a built nginx)
-TEST_NGINX_BINARY=/path/to/nginx prove t/00-filter.t t/01-static.t
+TEST_NGINX_BINARY=/path/to/nginx prove ci/t/00-filter.t ci/t/01-static.t
+
+# Unit tests over the Accept-Encoding decision function
+ci/tests/unit/run.sh
 
 # End-to-end smoke tests
-python3 tools/test_encoding.py --nginx-binary /path/to/nginx
+python3 ci/tools/test_encoding.py --nginx-binary /path/to/nginx
 
 # Build and run the fuzzer (needs clang)
-bash fuzz/build.sh && ./fuzz/fuzz_accept_encoding -max_total_time=60 fuzz/corpus/
+bash ci/fuzz/build.sh && ./ci/fuzz/fuzz_accept_encoding -max_total_time=60 ci/fuzz/corpus/
 ```
+
+## Repository layout
+
+Everything CI needs lives under `ci/`, so the repository root stays the
+module: sources, docs and packaging.
+
+```text
+src/                     the module itself
+  ngx_http_zstd_filter_module.c    the compression filter
+  ngx_http_zstd_static_module.c    the .zst static handler
+  ngx_http_zstd_common.h           shared helpers + the Accept-Encoding parser
+ci/
+  t/                     Test::Nginx::Socket suites (00-filter, 01-static, …)
+  tests/unit/            unit tests over the real decision TU
+  tools/                 soak.sh, test_encoding.py, benchmark.py, ci-build.sh, …
+  fuzz/                  libFuzzer target, corpus, dictionary, regressions
+  linter/                the checker set run by the hook and the Lint workflow
+  ast-grep/              structural rules
+.github/workflows/       ci.yml (the only pull_request entry point) + members
+.githooks/pre-commit     the tracked local gate
+```
+
+The `Accept-Encoding` parser is sliced out of `src/ngx_http_zstd_common.h`
+into the fuzz and unit builds at build time by `ci/fuzz/extract_parser.sh`,
+so those targets always compile production code — there is no second copy to
+drift.
+
+## Linting
+
+The same checkers run in three places: your commit (via `.githooks/pre-commit`),
+`ci/linter/run-all.sh` by hand, and the **Lint** workflow on every PR.
+
+```sh
+git config core.hooksPath .githooks    # enable the hook, once per clone
+ci/linter/install-linters.sh           # install what the checkers need
+ci/linter/install-linters.sh --check   # report presence; non-zero if any missing
+ci/linter/run-all.sh                   # run every checker over the tracked tree
+```
+
+Full description of each checker, what it is blind to, and how to narrow a run
+with `LINT_ONLY`: [`ci/linter/README.md`](ci/linter/README.md). Contributor
+setup and the `git ls-files` trap: [CONTRIBUTING.md](CONTRIBUTING.md).
 
 # Benchmarks
 
-Reproduce with `python3 tools/benchmark.py` (drives the `zstd`/`gzip`
+Reproduce with `python3 ci/tools/benchmark.py` (drives the `zstd`/`gzip`
 CLIs linked against the same libzstd/zlib, so ratio is machine-stable;
 throughput scales with CPU). Figures below: **libzstd 1.5.5**, single
 core, `--repeat 3`, best wall-time.
@@ -1070,7 +1115,7 @@ context; new requests use new workers. There is no shared compression
 state to corrupt across a reload. The `zstd_dict_file` `ZSTD_CDict` is
 loaded once per cycle and freed on the old cycle's cleanup; a
 reload-leak regression for exactly this runs under ASAN in CI
-(`tools/test_reload_leak.sh`).
+(`ci/tools/test_reload_leak.sh`).
 
 **`zstd_dict_file`.** Loaded at config load in the `http` context, into
 a `ZSTD_CDict` shared read-only by all workers (dictionary size capped
@@ -1095,7 +1140,7 @@ purely "load the previous `.so` / previous nginx binary and reload":
 No data migration, no irreversible step. A bad deploy is a one-line
 config change or a binary swap away from rolled back.
 
-**Pre-deploy soak.** `tools/soak.sh <nginx> <seconds> <concurrency>`
+**Pre-deploy soak.** `ci/tools/soak.sh <nginx> <seconds> <concurrency>`
 drives sustained mixed load (tiny/medium/large/compressible payloads,
 zstd and non-zstd clients, the bypass path, a chunked upstream) and
 fails on any sanitizer report, leak, crash, `[alert]`/`[emerg]`, or

--- a/ci/.adopted
+++ b/ci/.adopted
@@ -1,0 +1,12 @@
+prompt_version: 241a7ac6f664bf98324f085489ed41a7f67eae56bf0ff500507ec84bb9f2f4eb
+skeleton_sha:   537f28ea996e6e540cebff486a9e8fff824b6918
+adopted_date:   2026-08-22
+steps_degraded: 30
+
+# step 30: the memcheck subject cannot be answered honestly from configuration.
+# valgrind.suppress is the generic circulated nginx file (28 unfilled
+# <insert_a_suppression_name_here> blocks naming ngx_http_lua_* and
+# drizzle_state_connect, symbols this module never links) and can mask this
+# module's own errors. Deriving a real set needs a memcheck soak = phase 7 work.
+# Tracked: memory/labs/http-zstd/issues.md, and upstream in skeleton PR #41.
+# Every other subject and step is fully satisfied.

--- a/ci/adoption-findings.md
+++ b/ci/adoption-findings.md
@@ -362,3 +362,194 @@ Also re-verified after all of the cycle's workflow edits: `ci.yml` is still the
 only workflow carrying a `pull_request:` trigger. Checked by parsing each
 workflow's `on:` key with a YAML loader, not by grepping for the string --
 `on:` parses as the boolean True in YAML, so a naive grep is not the same test.
+
+## Step 30 — the depth audit: does each gate reach the module? (2026-08-22)
+
+Five subjects, each answered from configuration plus step 26's coverage report.
+No long run started by this step.
+
+### 1. The seam — VERIFIED, with a positive control
+
+`UNIT_ENTRY` = `ci/tests/unit/run.sh`; fuzz entry = `ci/fuzz/build.sh`. Neither
+compiles `src/*.c` directly: both `#include` `ci/fuzz/generated_parser.inc`,
+which `ci/fuzz/extract_parser.sh` slices verbatim out of the shipped
+`src/ngx_http_zstd_common.h`. Both entry points regenerate it at build time
+(`ci/tests/unit/run.sh:60`, `ci/fuzz/build.sh:19`), so there is no
+hand-maintained copy to drift.
+
+Proven, not assumed:
+
+- regenerating in a clean tree reproduces the committed `.inc` byte for byte
+  (no drift);
+- renaming `ngx_http_zstd_eval_qvalue()` in `src/ngx_http_zstd_common.h` and
+  re-running the extractor propagates the change into the generated TU
+  (`PROBE` present) — so an edit to production code really does reach the unit
+  and fuzz builds. Source restored, regeneration re-diffed clean.
+
+**What it now catches that it did not before:** a parser change that compiles in
+`src/` but was never exercised — previously possible only if someone remembered
+to re-copy the parser by hand.
+
+### 2. ASan/UBSan — the soak config reaches the module
+
+`ci/tools/soak.sh` enables the module's own directives in more than one
+location: `zstd on`, `zstd_min_length`, `zstd_max_length`, `zstd_types`,
+`zstd_bypass $arg_nozstd`, `zstd_window_log 21`, and drives `/bypass` and
+`/bypass?nozstd=1` plus clients that do not advertise zstd. Step 26's coverage
+over `src/` reports 60.0% — the handler's lines execute, and the figure is not
+~1%, so nginx core is not padding the denominator.
+
+**Catches now:** a use-after-free or overflow on the bypass and
+Vary/no-zstd-client paths, not only on the happy compress path.
+
+### 3. Fuzzing — surface and dictionary match the parse surface
+
+`fuzz.dict` is derived from real call sites and gated against drift by
+`gen_dict.sh --check`, which passes: coding tokens `"dcz"` and `"zstd"` match
+`src/*.c`. The parser's table literals are `"*"`, `"identity"`, `"q"` and
+`"zstd"`; all are reachable — the qvalue surface has 5 dedicated dict entries
+(`";q="`, `"q=0"`, `"q=1"`, `"q=0.0"`, `"q=1.0"`) and 597 of the 9280 corpus
+inputs carry a `q=`. Two regression inputs replay before each fresh run.
+
+**Catches now:** qvalue arithmetic and precedence defects, which the mutation
+pass in step 24 confirmed the target detects.
+
+### 4. Coverage — measured over the module only
+
+`ci/tools/coverage.sh` reports with gcovr filtered to `src/`; unfiltered gcovr
+walks the whole configured nginx tree. Measured 60.0%, so the filter is real —
+a ~1% figure would have meant nginx core was in the denominator.
+
+### 5. Valgrind / helgrind
+
+**Memcheck: NOT trustworthy as a gate — see `issues.md`.** `valgrind.suppress`
+is the generic circulated nginx file: all 28 blocks are unedited
+`<insert_a_suppression_name_here>` placeholders and the set names
+`ngx_http_lua_*` and `drizzle_state_connect`, symbols this module never links.
+Several blocks suppress bare `fun:malloc` / `fun:memcpy` under short stacks, so
+it can mask this module's own errors. It is live config, not dead:
+`ci/tools/soak.sh:71,79` passes it to both tools. Deliberately NOT fixed here —
+deriving a real set needs a genuine memcheck soak, which is phase-7 work.
+Ledgered OPEN with two acceptable fixes, and sent upstream (skeleton PR #41)
+because the skeleton ships the same file to every adopter.
+
+**Helgrind: NOT applicable, settled with evidence.** The module has no shared
+cross-worker state. Counted over `src/*.c` and `src/*.h`: `ngx_shared_memory_add`
+0, `shm_zone` 0, `ngx_slab` 0, `ngx_atomic` 0, `ngx_thread` 0, `pthread` 0. The
+only file-scope mutable state is the two filter-chain pointers at
+`src/ngx_http_zstd_filter_module.c:215-216`, assigned once in
+`ngx_http_zstd_filter_init()` (`:2358` and `:2361`) — the `postconfiguration`
+hook, which runs in the master process before fork. All other state is
+per-request `ctx` off the request pool. There is no cross-thread sharing for
+helgrind to reason about.
+
+## Step 31 — re-audit the gates that drift (2026-08-22)
+
+Six explicit answers. `/proc/loadavg` was 1.4-2.5 (1-min) on a 6-slot box for
+every timing below.
+
+**Caching.** `ci/tools/ci-build.sh` is the single chokepoint; no workflow
+duplicates cache logic. Measured in PR2: `NO_CACHE=1` cold build of nginx 1.31.2
+-> ccache 0/146 (0.00%); a second identical build -> 146/292 (50.00%) cumulative,
+i.e. **100% of the second run's own compiles hit**. Not 0%, so it is wired.
+`--with-cc="ccache gcc"` is load-bearing — nginx's configure ignores a bare `CC=`.
+
+**zizmor.** `zizmor --pedantic .github/workflows/` audits **11** workflows;
+`ls .github/workflows/*.yml` is **11**. Counts match, no member unaudited. "No
+findings to report (3 ignored, 11 suppressed)". All three
+`# zizmor: ignore[misfeature]` still name a reason that is still true — each sits
+on a `shell: cmd` step in `windows-build.yml` (lines 82, 89, 112) that needs the
+environment `vcvars64.bat` installs in that same cmd process. No suppression has
+outlived its subject.
+
+**actionlint and the fromJSON ternary.** Acknowledged, not used as evidence:
+actionlint is clean, and that says nothing about runner labels. The selector is
+`${{ fromJSON(vars.POOL || '["ubuntu-latest"]') }}` on all 10 build-test jobs —
+the approved form, no inline pool, no fork ternary. That is probe 2's finding,
+not actionlint's.
+
+**LINT_ONLY still matches the checkers that exist.** Normalized comparison, both
+directions:
+
+```
+on disk (ci/linter/lint-*.sh): c ci-cadence ci-ports ci-runners ci-secrets
+                               docs-drift nginx perl python sh spelling yaml
+in lint.yml LINT_ONLY:         nginx sh python perl yaml spelling ci-runners
+                               ci-ports ci-cadence ci-secrets docs-drift
+on disk but NOT in LINT_ONLY:  c        <- deliberate, documented lint.yml:9-12
+in LINT_ONLY but NOT on disk:  (empty)
+```
+
+`c` is excluded because flawfinder/clang-tidy/semgrep over `src/` are
+`security-scanners.yml`'s job at the same thresholds (PR2 paired them). No
+orphan in either direction.
+
+**`run-all.sh` reads `git ls-files`** (`ci/linter/lib.sh:50`), so an untracked
+file is invisible and the run reads green while checking nothing. Staged before
+every timing and lint run in this pass. The oracle is the checker's file COUNT,
+not the exit code.
+
+**Hook timing — OVER the ~2s budget on a C change.** Measured, 3 runs each:
+
+```
+docs-only staged change:   0.51 / 0.52 / 0.56 s   OK
+real C file staged:        3.59 / 3.59 s          OVER
+```
+
+The first C measurement (0.49s) was a false pass: the file was `touch`ed but
+unmodified, so pre-commit skipped its hooks. Forcing a real content change gives
+3.59s. Per-hook breakdown with a C file staged:
+
+```
+semgrep    2.17s   <- 60% of the total, alone over budget
+cppcheck   0.63s
+flawfinder 0.13s
+shellcheck 0.08s
+ruff       0.08s
+```
+
+Not fixed here: the cheap levers (`--jobs=1 --metrics=off`) are already set, and
+dropping or narrowing semgrep is a gate-weakening change, not a speed fix. A
+C-file commit paying 3.6s is the honest cost of the current gate. Ledgered.
+
+## Step 32 — re-measure the CI shape (2026-08-22)
+
+Numbers from `gh run list`/`gh run view` on run **32547163515** (PR2's final
+run, 2026-08-22), not estimates.
+
+**Total wall-clock 370s, 18 jobs.** Critical path is
+`resolve(6s) -> build(212s) -> tests(145s)` = 370s. Longest single legs:
+CodeQL 266s, MinGW 254s, build 212s, validation 215s, tests-asan 180s.
+
+**Exactly one `pull_request:` entry point holds.** Parsed with a YAML loader,
+not a grep — `on:` parses as boolean `True` in YAML, so a grep is a different
+test. `ci.yml` is the only one; no member carries `push:`. Step 14's demotion
+therefore still holds, and step 16's long-runner greps return `ci.yml` alone.
+
+**Every member is reached.** ci.yml calls 8 members (lint, build-test,
+security-scanners, codeql, fuzzing, valgrind, asan, windows-build); the set of
+workflows declaring `workflow_call` minus the set ci.yml calls is **empty**, so
+no member keeps a stale-green badge.
+
+**Peak concurrency 15 against 6 slots at t+21s** — measured, and worse than the
+11 recorded at step 29. Two causes:
+
+1. **The step 29 lane fix for `build-old-libzstd` was never actually in the
+   tree.** `adoption-findings.md` recorded it as "landed (safe, single-file,
+   verified)", but `build-test.yml:484` on master was still bare
+   `needs: resolve`. A note claiming a change landed is not evidence it did —
+   `git log -- <file>` showed no such commit. **Now genuinely applied** in this
+   PR: `needs: [resolve, validation]` with `if: ${{ !cancelled() }}`, dropping
+   this workflow's own fan-out from 7 to 6. Job `name:` deliberately unchanged,
+   and the ruleset context `Build & Test / Build (libzstd 1.4.x — fallback
+   paths)` re-checked against the live ruleset after the edit.
+2. **The cross-workflow pile-on is unchanged and unfixable inside step 29.**
+   codeql/security-scanners/fuzzing/valgrind/asan all start at t=0 alongside
+   build-test's fan-out, because `needs:` cannot cross a reusable-workflow-call
+   boundary: `needs:` on a `uses:` job waits for that member's ENTIRE workflow,
+   so laning codeql behind build-test would serialize it behind the 370s
+   critical path instead. The only real remedies are folding those single jobs
+   into build-test.yml's job graph, or adding pool slots. Sent upstream as
+   decision-class feedback (skeleton PR #41, finding 3).
+
+No check was deleted and no threshold widened.

--- a/ci/adoption-findings.md
+++ b/ci/adoption-findings.md
@@ -406,8 +406,12 @@ Vary/no-zstd-client paths, not only on the happy compress path.
 
 `fuzz.dict` is derived from real call sites and gated against drift by
 `gen_dict.sh --check`, which passes: coding tokens `"dcz"` and `"zstd"` match
-`src/*.c`. The parser's table literals are `"*"`, `"identity"`, `"q"` and
-`"zstd"`; all are reachable — the qvalue surface has 5 dedicated dict entries
+the `ngx_http_zstd_coding_weight()` call sites across `src/*.c` **and**
+`src/*.h` (gen_dict.sh:43 globs both — 2 call sites in
+`ngx_http_zstd_filter_module.c`, 2 in `ngx_http_zstd_common.h`, so a
+`.c`-only scan would miss the header's). The parser's table literals are `"*"`,
+`"identity"`, `"q"` and `"zstd"`; all are reachable — the qvalue surface has 5
+dedicated dict entries
 (`";q="`, `"q=0"`, `"q=1"`, `"q=0.0"`, `"q=1.0"`) and 597 of the 9280 corpus
 inputs carry a `q=`. Two regression inputs replay before each fresh run.
 
@@ -471,7 +475,7 @@ not actionlint's.
 **LINT_ONLY still matches the checkers that exist.** Normalized comparison, both
 directions:
 
-```
+```text
 on disk (ci/linter/lint-*.sh): c ci-cadence ci-ports ci-runners ci-secrets
                                docs-drift nginx perl python sh spelling yaml
 in lint.yml LINT_ONLY:         nginx sh python perl yaml spelling ci-runners
@@ -491,7 +495,7 @@ not the exit code.
 
 **Hook timing — OVER the ~2s budget on a C change.** Measured, 3 runs each:
 
-```
+```text
 docs-only staged change:   0.51 / 0.52 / 0.56 s   OK
 real C file staged:        3.59 / 3.59 s          OVER
 ```
@@ -500,7 +504,7 @@ The first C measurement (0.49s) was a false pass: the file was `touch`ed but
 unmodified, so pre-commit skipped its hooks. Forcing a real content change gives
 3.59s. Per-hook breakdown with a C file staged:
 
-```
+```text
 semgrep    2.17s   <- 60% of the total, alone over budget
 cppcheck   0.63s
 flawfinder 0.13s

--- a/ci/fuzz/gen_dict.sh
+++ b/ci/fuzz/gen_dict.sh
@@ -7,7 +7,7 @@
 #
 # This module has no single lookup table of coding names -- unlike a
 # trie-walk scanner, the tokens are two literal call-site arguments to
-# ngx_http_zstd_coding_weight(ae, "TOKEN", ...) in src/*.c (currently
+# ngx_http_zstd_coding_weight(ae, "TOKEN", ...) in src/*.c and src/*.h (currently
 # "zstd" and "dcz"). Extract THOSE, rather than hand-copying them, so a
 # third coding name added to a future call site is picked up
 # automatically and a forgotten dictionary update fails --check instead
@@ -47,7 +47,7 @@ mapfile -t TOKENS < <(
 
 if [ "${#TOKENS[@]}" -eq 0 ]; then
     echo "✗ gen_dict: no ngx_http_zstd_coding_weight(...) call sites found" \
-        "in src/*.c -- parser call convention changed? update gen_dict.sh" >&2
+        "in src/*.c or src/*.h -- parser call convention changed? update gen_dict.sh" >&2
     exit 1
 fi
 
@@ -73,7 +73,7 @@ if [ "${1:-}" = "--check" ]; then
         echo "  Run: ci/fuzz/gen_dict.sh" >&2
         exit 1
     fi
-    echo "✓ fuzz.dict coding tokens match src/*.c call sites: ${TOKENS[*]}"
+    echo "✓ fuzz.dict coding tokens match src/*.c + src/*.h call sites: ${TOKENS[*]}"
     exit 0
 fi
 
@@ -108,4 +108,4 @@ awk -v start="$START_MARK" -v end="$END_MARK" -v gen="$GENERATED" '
 ' "$DICT" >"$TMP"
 mv "$TMP" "$DICT"
 
-echo "✓ regenerated fuzz.dict coding tokens from src/*.c: ${TOKENS[*]}"
+echo "✓ regenerated fuzz.dict coding tokens from src/*.c + src/*.h: ${TOKENS[*]}"


### PR DESCRIPTION
> Final PR of the skeleton adoption: phases 6 and 7, steps 30-42. Follows #128 (steps 6-16) and #130 (steps 17-29). Closes the migration out — `ci/.adopted` is written and all 42 steps are done.

## TL;DR

Checks whether each gate installed by the previous two PRs actually reaches this module, rather than merely existing. Four of the five subjects hold up; one does not, and is recorded as a known gap instead of being papered over. Along the way the docs turned out to be telling contributors to run files that no longer exist.

Adds the step 30-32 audit answers to `ci/adoption-findings.md`, fixes seven dead paths in `README.md`, applies a lane fix that a previous note claimed had landed but had not, and writes the `ci/.adopted` stamp with `steps_degraded: 30`.

**Severity:** `Medium` (`documentation correctness — every "run it locally" command in the README was broken`)

## The docs were broken and no gate noticed

Step 11 moved `t/`, `tools/` and `fuzz/` under `ci/`. Seven README references were never updated, including **all four** "Run the suites locally" commands:

```
prove t/00-filter.t t/01-static.t          -> ci/t/...
python3 tools/test_encoding.py             -> ci/tools/...
bash fuzz/build.sh ... fuzz/corpus/        -> ci/fuzz/...
python3 tools/benchmark.py                 -> ci/tools/...
tools/build-windows.sh, tools/soak.sh, tools/test_reload_leak.sh
```

A contributor following the README hit file-not-found four times. `lint-docs-drift.sh` was green throughout — it reconciles workflows against README rows and knows nothing about paths in prose or fenced blocks. Every path the docs now mention was resolved against the real tree.

Also adds a `Repository layout` tree and a `Linting` section, `CONTRIBUTING.md` gains hook setup (including the `git ls-files` trap that makes an untracked file invisible to a "clean" lint run), and `CHANGES` describes the standardisation.

## The lane fix that was never actually applied

`ci/adoption-findings.md` recorded the step 29 fix for `build-old-libzstd` as "Landed (safe, single-file, verified)". It was not in the tree: `build-test.yml:484` on master was still bare `needs: resolve`, and `git log -- <file>` shows no such commit. Measured peak concurrency was **15 against 6 self-hosted slots**, not the 11 the note implied.

Now genuinely applied — `needs: [resolve, validation]` with `if: ${{ !cancelled() }}`, which drops this workflow's own fan-out from 7 to 6 at no wall-clock cost (validation 216s + build-old-libzstd 135s = 351s, under the 370s critical path). `!cancelled()` is load-bearing: the dependency is for the runner slot only, never for an artifact, so a validation failure must not silently skip a build-matrix leg.

The job's `name:` is deliberately unchanged, and the required context `Build & Test / Build (libzstd 1.4.x — fallback paths)` was re-diffed against the live ruleset after the edit. Renaming a caller job orphans its required check and has blocked a PR here twice.

## Step 30 — does each gate reach the module?

Answered from configuration plus step 26's coverage. No long run started.

- **The seam** holds, proven with a positive control rather than by reading the comment: renaming `ngx_http_zstd_eval_qvalue()` in `src/ngx_http_zstd_common.h` propagates into the generated TU, and a clean regeneration reproduces the committed `.inc` byte for byte. There is no second copy of the parser to drift.
- **Helgrind is not applicable**, settled with `file:line`. No shared cross-worker state exists: `ngx_shared_memory_add`, `shm_zone`, `ngx_slab`, `ngx_atomic`, `ngx_thread` and `pthread` all count 0 over `src/`. The only file-scope mutable state is the two filter-chain pointers at `ngx_http_zstd_filter_module.c:215-216`, assigned once in `ngx_http_zstd_filter_init()` (`:2358`, `:2361`) — the `postconfiguration` hook, master process, before fork.
- **ASan/UBSan, fuzzing and coverage** all reach the module; the detail and the evidence for each is in `ci/adoption-findings.md`.

### The one degraded subject

`valgrind.suppress` is the generic circulated nginx file: all 28 blocks are unedited `<insert_a_suppression_name_here>` placeholders and it names `ngx_http_lua_*` and `drizzle_state_connect`, symbols this module never links. Several blocks suppress bare `fun:malloc` / `fun:memcpy` under short stacks, so it can mask **this module's own** errors — and it is live config, not dead: `ci/tools/soak.sh:71,79` feeds it to both memcheck and helgrind.

Deliberately **not** fixed here. Deriving a real set requires a genuine memcheck soak, which is phase-7 work; renaming the placeholders would make it look derived while still suppressing frames nobody chose. Ledgered OPEN with two acceptable fixes, and sent upstream in skeleton PR #41 — the skeleton ships this same file to every adopter.

`ci/.adopted` therefore records `steps_degraded: 30`, not `none`. A stamp claiming a clean adoption would lie to the next phase-0 triage.

## Step 31 — six drift answers, each with its number

- **ccache** 100% hit rate on a second identical build (0/146 cold, 146/292 cumulative). Not 0%, so it is wired.
- **zizmor** audits 11 workflows against 11 on disk; all three `# zizmor: ignore[misfeature]` suppressions still name a live reason (`shell: cmd` steps that need the environment `vcvars64.bat` installs).
- **`LINT_ONLY`** matches the checker set in both directions; `c` is the only exclusion and is deliberate per `lint.yml:9-12`.
- **Hook timing is over budget**: 0.52s for a docs-only change but **3.59s** with a C file staged, semgrep 2.17s of it. The first C measurement (0.49s) was a false pass — the file was `touch`ed but unmodified, so pre-commit skipped every C hook. Not fixed: the cheap levers are already set and narrowing semgrep would weaken the gate.

## Step 32 — measured CI shape

From run `32547163515`: **370s, 18 jobs**, critical path `resolve(6s) -> build(212s) -> tests(145s)`. `ci.yml` is still the only `pull_request:` entry point — parsed with a YAML loader, since `on:` parses as boolean `True` and a grep is a different test — no member carries `push:`, and every `workflow_call` member is reached.

The cross-workflow concurrency pile-on is unfixed and unfixable inside a lane map: `needs:` cannot cross a reusable-workflow-call boundary, so laning CodeQL behind Build&Test would serialise it behind the full 370s path instead. Sent upstream as skeleton PR #41 finding 3. No check was deleted and no threshold widened.

## Testing

- `ci/linter/run-all.sh` clean — 12 checkers, no skips, no missing tools.
- `actionlint` and `zizmor --pedantic` clean on the changed workflow; `lint-docs-drift.sh` green in both directions.
- Every path named in README, CONTRIBUTING and the layout tree resolved against the real tree.
- Seam positive control run and reverted; regeneration re-diffed clean.
- pre-commit hooks passed at commit time; no `--no-verify`.

No soak, fuzz campaign or valgrind run: phase 6 reads configuration and evidence by design, and the memcheck gap above is exactly the item that needs one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup and testing instructions with the new repository layout and tool paths.
  * Added guidance for configuring pre-commit hooks, running linters, unit tests, fuzzers, coverage checks, and benchmarks.
  * Documented CI architecture, validation coverage, runtime measurements, and known verification limitations.

* **Chores**
  * Standardized repository structure and continuous integration workflows.
  * Improved workflow scheduling to reduce peak concurrency while preserving validation behavior.
  * Added infrastructure for unit testing, fuzzing, coverage, linting, and pre-commit checks.
  * Runtime behavior, module directives, defaults, and binary output remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->