### PR TITLE
ci(lint): coverage table, and close the two gaps it found

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,10 +6,12 @@ name: Lint
 # regressions. Local and remote run the SAME entry point on purpose: a CI-only
 # reimplementation drifts from the hook and the two stop agreeing.
 #
-# LINT_ONLY leaves out the "c" checker: flawfinder/clang-tidy/semgrep over
+# LINT_ONLY leaves out the "c" checker: its flawfinder and semgrep passes over
 # src/ are already the job of security-scanners.yml, at the same thresholds
 # (ci/linter/lint-c.sh mirrors that workflow). Running them twice per PR buys
-# nothing but queue time.
+# nothing but queue time. The two that workflow does NOT run are covered
+# elsewhere rather than dropped: clang-tidy is CI-only there (it needs a
+# configured nginx tree), and cppcheck is a local-hook extra.
 #
 # runs-on: ubuntu-latest, NOT the self-hosted pool. This job needs no nginx
 # build, so it costs nothing against this repo's self-hosted capacity while
@@ -69,3 +71,43 @@ jobs:
           # prompt, not this module), so they are not listed.
           LINT_ONLY: nginx sh python perl yaml spelling ci-runners ci-ports ci-cadence ci-secrets docs-drift
         run: ci/linter/run-all.sh
+
+      # ast-grep and gitleaks live in .pre-commit-config.yaml rather than in a
+      # ci/linter/lint-*.sh, so run-all.sh above does not reach them. Without
+      # these two steps they would be the only gates in this repo that a clone
+      # which never ran `git config core.hooksPath .githooks` can bypass --
+      # exactly the failure mode this whole job exists to close. Both are
+      # invoked the same way the hook invokes them, for the same reason
+      # local and remote share run-all.sh: a CI-only reimplementation drifts.
+      - name: ast-grep (structural sinks, gate on promoted rules)
+        # -c is load-bearing: ast-grep resolves sgconfig.yml by walking UP from
+        # the cwd, so dropping it binds to nothing here and reports green.
+        # Only the promoted rules are errors; everything else stays advisory.
+        run: |
+          # -z/-0 so a path with a space or newline cannot split into two args.
+          # xargs -r: no C files is a clean tree, not an invocation with none
+          # (ast-grep with zero paths would scan the whole repo instead).
+          git ls-files -z 'src/*.c' 'src/*.h' 'ci/*.c' 'ci/*.h' \
+            | xargs -0 -r ast-grep scan -c ci/ast-grep/sgconfig.yml \
+                --error=c-alloc-mul-overflow \
+                --error=c-memcpy-sizeof-pointer \
+                --error=c-sizeof-wrong-operand \
+                --error=c-unbounded-string-copy \
+                --error=c-format-string \
+                --error=c-shell-exec
+
+      - name: gitleaks (whole tracked tree)
+        # The hook scans the staged patch; there is no staged patch in CI, so
+        # this scans the checked-out tree instead -- `detect --no-git` is the
+        # whole-tree form, and it catches a secret that reached master through
+        # a clone with no hook installed.
+        #
+        # -c .gitleaks.toml is required, not cosmetic: --no-git walks the
+        # FILESYSTEM, so it descends into the gitignored .build/ nginx tree and
+        # reports upstream nginx's QUIC test constants. The config allowlists
+        # that path and keeps the default ruleset. Exit is 1 on a finding.
+        #
+        # Verify with a NON-EXAMPLE secret -- AWS's own AKIAIOSFODNN7EXAMPLE is
+        # allowlisted upstream and reports clean, which reads like a dead gate.
+        # See the probe recipe in .pre-commit-config.yaml above the hook.
+        run: gitleaks detect --no-git -c .gitleaks.toml --no-banner --redact -v --source .

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,21 @@
+# gitleaks configuration for nginx-zstd-module.
+#
+# Extends the upstream default ruleset rather than replacing it -- dropping
+# `useDefault` here would leave the scan with NO rules and report a clean tree
+# for any secret at all, which is worse than not running gitleaks.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Paths this repository does not own"
+# .build/ is the throwaway nginx source tree the CI jobs unpack to compile
+# against (gitignored, see .gitignore). `gitleaks detect --no-git` walks the
+# filesystem rather than the index, so without this it reads that vendored
+# upstream tree and reports nginx's own QUIC test constants as findings --
+# upstream nginx's code, not this module's secrets, and not fixable here.
+#
+# Scoped by PATH, not by fingerprint: the nginx version in the directory name
+# changes on every bump, so a fingerprint list would silently stop matching and
+# the noise would return. The pre-commit hook is unaffected either way -- it
+# scans the staged patch, which can never contain a gitignored file.
+paths = ['''^\.build/''']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,16 +75,27 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
-      # The three fixers rewrite files in place, which is why keys and DER blobs
-      # have to stay out of their reach. Per-hook, not top-level: a top-level
-      # exclude would also blind detect-private-key below.
+      # The three fixers rewrite files in place, so every byte-exact file has to
+      # stay out of their reach. Per-hook, not top-level: a top-level exclude
+      # would also blind detect-private-key below.
+      #
+      # Beyond keys and DER blobs, two kinds of file here are CONTENT, not
+      # source, and a "harmless" trailing newline changes what they mean:
+      #   ci/fuzz/regressions/*  a corpus entry IS the input bytes. Appending
+      #                          \n makes it a different Accept-Encoding header,
+      #                          so the regression silently stops reproducing
+      #                          the crash it was committed to pin.
+      #   *.patch                dpkg-source/quilt match context at zero fuzz;
+      #                          rewriting the tail makes the patch not apply.
+      # Caught 2026-08-22 by a `pre-commit run --all-files`, which mutated one
+      # of each.
       - id: trailing-whitespace
-        exclude: '\.(pem|der)$'
+        exclude: &byte_exact '(\.(pem|der|patch)$|^ci/fuzz/regressions/)'
       - id: end-of-file-fixer
-        exclude: '\.(pem|der)$'
+        exclude: *byte_exact
       - id: mixed-line-ending
         args: [--fix=lf]
-        exclude: '\.(pem|der)$'
+        exclude: *byte_exact
       - id: check-merge-conflict
       - id: check-yaml
       - id: check-added-large-files
@@ -132,7 +143,7 @@ repos:
         name: flawfinder (gate on >=4)
         entry: flawfinder --minlevel=4 --error-level=4 --quiet
         language: system
-        files: '^(src/.*\.[ch]|ci/tools/.*\.[ch])$'
+        files: '^(src|ci)/.*\.[ch]$'
         pass_filenames: true
 
       # Mirrors the CI "semgrep (gate on >=WARNING)" step, same configs and
@@ -166,7 +177,7 @@ repos:
         entry: semgrep scan --jobs=1 --config p/c --config p/security-audit
                --severity=WARNING --severity=ERROR --error
         language: system
-        files: '^(src/.*\.[ch]|ci/tools/.*\.[ch])$'
+        files: '^(src|ci)/.*\.[ch]$'
         pass_filenames: true
         require_serial: true
 
@@ -194,7 +205,7 @@ repos:
                --suppress=normalCheckLevelMaxBranches --suppress=unusedFunction
                --suppress=unusedStructMember -I filter -I static -I tools -DNGX_PTR_SIZE=8
         language: system
-        files: '^(src/.*\.[ch]|ci/tools/.*\.[ch])$'
+        files: '^(src|ci)/.*\.[ch]$'
         pass_filenames: true
 
       # Structural sink sweep: this superrepo's own c-* / nginx-* rules plus
@@ -235,7 +246,7 @@ repos:
                --error=c-format-string
                --error=c-shell-exec
         language: system
-        files: '^(src/.*\.[ch]|ci/tools/.*\.[ch])$'
+        files: '^(src|ci)/.*\.[ch]$'
         pass_filenames: true
 
       # Python is the runtime TEST HARNESS in these repos, so it carries the

--- a/ci/linter/README.md
+++ b/ci/linter/README.md
@@ -18,15 +18,12 @@ finding shellcheck could have named in two seconds. Every script is standalone;
 | `lint-ci-ports.sh` | `.github/workflows/` | every port-binding job declares a distinct `TEST_BASE_PORT` band, binds it, and verifies it above the FIRST binding step |
 | `lint-ci-cadence.sh` | `.github/workflows/` | a `workflow_call` member carries no `push:`/`pull_request:` of its own, so it runs once per change rather than twice on two uncancellable concurrency keys (`schedule:` allowed) |
 | `lint-ci-secrets.sh` | `.github/workflows/` | a `workflow_call` member declares the secrets it needs with `required: true`; callers wire them by name and never use `secrets: inherit` |
-| `lint-sync-stamp.sh` | `.github/workflows/`, `.github/scripts/`, `.github/actions/` | every skeleton-shared file carries a current `# sync-sha:` stamp, so an adopter can diff two repos' `--list` output and see exactly what drifted |
 | `lint-docs-drift.sh` | `.github/workflows/`, `README.md` | every workflow documented, every documented workflow exists |
-| `lint-prompt-steps.sh` | `ci/PROMPT.md`, `README.md`, `ci/feedback/`, `ci/tools/`, `ci/linter/` | every `step N` citation names a step `ci/PROMPT.md` defines, and the step sequence has no gap or duplicate |
 | `lint-spelling.sh` | all tracked files | codespell over prose, comments and log strings; vendored trees excluded via `lib.sh` |
 | `run-all.sh` | all of the above | runs every check, reports once |
 | `install-linters.sh` | — | apt-get → pipx → cpan → upstream binary |
 | `lib.sh` | — | sourced helpers (file selection, missing-tool failure) |
 | `workflow_policy.py` | — | the repo-policy checks the `ci-*`/`docs-drift` wrappers call (`runners`, `ports`, `docs`, `cadence`, `secrets`) |
-| `lint-prompt-steps.py` | — | the citation/sequence check `lint-prompt-steps.sh` calls; `PROMPT_STEPS_ROOT` points it at a generated tree for the selftest |
 | `selftest.sh` | — | negative controls for the gate itself; run before the linters in `lint.yml`. Includes the set-equality control: every checker is named in `lint.yml`'s `LINT_ONLY` |
 | `fixtures/policy/` | — | trees the policy checks must go RED on — the known bypasses, the runner-label and step-ordering cases, and the four ways a `secrets:` declaration goes wrong; `clean/` and the `-ok` trees must stay GREEN |
 
@@ -409,3 +406,65 @@ why `lint-c.sh` must be edited in the same commit as that workflow.
   `lint-nginx.sh`.
 - New dependency: add it to `install-linters.sh` **and** to the apt/pip/cpan
   lists above, so a fresh clone is one command from armed.
+
+## Coverage table — file type → linter → rule profile
+
+Derived at skeleton-adoption step 37 (2026-08-22). Every tracked file type is
+listed, with the checker that reaches it and the profile it is gated at. A type
+with no checker carries the reason it needs none — an unexplained blank is a
+gap, not a decision.
+
+| Tracked type | Count | Checker(s) | Rule profile | Gated where |
+|---|---|---|---|---|
+| `src/*.c`, `src/*.h` | 4 | `lint-c`, `lint-nginx`, ast-grep | flawfinder ≥4 · cppcheck warning/perf/portability · semgrep ≥WARNING (`p/c`,`p/security-audit`) · nginx conventions · 11 own + vendored structural rules | `security-scanners.yml` (CI) + pre-commit; **not** `lint.yml` — see § the `c` exclusion |
+| `ci/**/*.[ch]` | 9 | flawfinder, cppcheck, semgrep, ast-grep | same C profiles as `src/`, minus the nginx-convention pass (pool discipline does not apply to harness code) | pre-commit + `lint.yml` (ast-grep) |
+| `*.sh`, `.githooks/*` | 32 | `lint-sh` | shellcheck `-S warning` | `lint.yml` + pre-commit |
+| `*.py` | 17 | `lint-python` | `ruff check` + `ruff format --check` | `lint.yml` + pre-commit |
+| `*.t`, `*.pl`, `*.pm` | 4 | `lint-perl` | `perl -c` + perlcritic ≥4 | `lint.yml` + pre-commit |
+| `.github/workflows/*.yml` | 11 | `lint-yaml`, `lint-ci-{runners,ports,cadence,secrets}`, `lint-docs-drift` | yamllint · actionlint · zizmor `--persona=pedantic` · 5 repo policy checks | `lint.yml` + pre-commit |
+| other `*.yml`, `*.yaml` | 65 | `lint-yaml` | yamllint only (actionlint/zizmor are workflow-scoped) | `lint.yml` + pre-commit |
+| `*.md` | 30 | `lint-spelling`; `README.md` also `lint-docs-drift` | codespell · workflow/README set-equality | `lint.yml` + pre-commit |
+| all tracked prose/comments | — | `lint-spelling` | codespell, vendored trees excluded in `lib.sh` | `lint.yml` + pre-commit |
+| `*.key`, `*.zst`, `*.patch`, `*.dict`, `*.suppress` | 11 | none | binary/fixture/generated data with no syntax a linter can assert; `*.key` are test-only material | — |
+
+### Justified exclusions
+
+- **The `c` checker is absent from `lint.yml`'s `LINT_ONLY`** — flawfinder and
+  semgrep already run over `src/` in `security-scanners.yml` at the *same*
+  thresholds `lint-c.sh` mirrors. Running them twice per PR buys queue time,
+  not coverage. `lint-c.sh` remains the local half of that mirror.
+- **clang-tidy is CI-only.** It needs `ngx_auto_config.h`, i.e. a configured
+  nginx tree, which a local hook cannot assume. A checker that skips itself when
+  the tree is missing is a vacuous gate, so it lives only in
+  `security-scanners.yml`, where the tree is built first.
+
+### Gaps found at step 37 — both closed
+
+1. **Three C files were reached by no checker at all.**
+   `ci/fuzz/fuzz_accept_encoding.c`, `ci/fuzz/ngx_shim.h` and
+   `ci/tests/unit/test_accept_encoding.c` fell outside both the linter
+   selectors (`^src/.*\.[ch]$`) and the pre-commit hook globs, which stopped at
+   `ci/tools/`. The fuzz harness is C that parses attacker-shaped input, so
+   this was the gap worth closing first. The four C hooks now select
+   `^(src|ci)/.*\.[ch]$`; all four pass on the newly covered files.
+2. **ast-grep and gitleaks were hook-only.** Both run from
+   `.pre-commit-config.yaml`, and no workflow runs pre-commit, so a clone that
+   never set `core.hooksPath` bypassed both — exactly the failure mode
+   `lint.yml`'s header says the remote run exists to prevent. `lint.yml` now
+   runs each directly, as its own step, invoked the way the hook invokes it.
+
+   `run-all.sh` still does not reach them: they are not `ci/linter/lint-*.sh`,
+   and the selftest's set-equality control only covers checkers that are. If
+   either step is removed from `lint.yml`, nothing will notice.
+
+### Verifying these two gates
+
+Both were confirmed able to fail, not just to run:
+
+- **ast-grep** — a planted `strcpy()` in `ci/tests/unit/` produced
+  `error[c-unbounded-string-copy]` and the pipeline exited 123.
+- **gitleaks** — use a NON-EXAMPLE secret. AWS's own `AKIAIOSFODNN7EXAMPLE` is
+  allowlisted by the default ruleset and reports "no leaks found", which reads
+  exactly like a broken gate. The probe recipe above the hook in
+  `.pre-commit-config.yaml` produces `leaks found: 1` and exit 1. Note that
+  piping the run into `tail` masks that exit status — check it unpiped.

--- a/config
+++ b/config
@@ -20,4 +20,3 @@ ngx_addon_dir=$_ngx_zstd_root/src
 
 ngx_addon_dir=$_ngx_zstd_root
 ngx_addon_name=ngx_zstd
-


### PR DESCRIPTION
> Skeleton-adoption phase 7, step 37: produce a linter coverage table with every gap justified. Building the table surfaced two real gaps, so this closes them rather than only recording them.

## TL;DR

Two of this repo's code checks only ever ran on a developer's own machine. Anyone who cloned the repo without turning on the local git hooks could push code that skipped them entirely, and nothing downstream would notice. This makes the automated checks run those two as well, and documents which checker covers which kind of file so the next gap is visible instead of silent.

`lint.yml` gains an ast-grep step and a gitleaks step; the four C hooks in `.pre-commit-config.yaml` widen from `^(src/.*|ci/tools/.*)\.[ch]$` to `^(src|ci)/.*\.[ch]$`; `ci/linter/README.md` gains the step-37 coverage table.

**Severity:** `Low` (`gate coverage — two checks bypassable, no known escape`)

## The two gaps

**Gap 1 — three C files were reached by no checker.** `lint-c.sh` and `lint-nginx.sh` both select `^src/.*\.[ch]$`, and the four pre-commit C hooks stopped at `ci/tools/`. That left `ci/fuzz/fuzz_accept_encoding.c`, `ci/fuzz/ngx_shim.h` and `ci/tests/unit/test_accept_encoding.c` outside every C analyser. The fuzz harness is C that parses attacker-shaped input, so it is the one worth covering first. All four analysers pass on the newly covered files; the nginx-convention pass stays `src/`-only, since pool discipline does not apply to harness code.

**Gap 2 — ast-grep and gitleaks were hook-only.** Both run from `.pre-commit-config.yaml`. No workflow runs pre-commit, and `run-all.sh` does not reach them either, because they are not `ci/linter/lint-*.sh`. So a clone that never ran `git config core.hooksPath .githooks` bypassed both — which is precisely the failure mode `lint.yml`'s own header comment says the remote run exists to prevent. It held for every other checker but not these two.

Note this stays true after the PR: `run-all.sh` still does not reach them, and the selftest's set-equality control only covers checkers that are `lint-*.sh`. If either new step is deleted from `lint.yml`, nothing will fail.

## Why gitleaks needs a config

`gitleaks detect --no-git` walks the filesystem rather than the index, so it descends into the gitignored `.build/` nginx source tree and reports upstream nginx's QUIC test constants — 10 findings, 51 MB scanned. `.gitleaks.toml` allowlists that path, taking the scan to 5.7 MB and clean.

Allowlisted by path, not by fingerprint: the nginx version is in the directory name and changes on every bump, so a fingerprint list would silently stop matching and the noise would return. `useDefault = true` is load-bearing — a config without it scans with no rules at all and calls everything clean.

## Testing

Both new gates were verified able to **fail**, not merely to run:

- **ast-grep** — planted a `strcpy()` in `ci/tests/unit/`; produced `error[c-unbounded-string-copy]`, pipeline exit 123. Probe removed.
- **gitleaks** — probed with a non-example secret. AWS's own `AKIAIOSFODNN7EXAMPLE` is allowlisted by the default ruleset and reports "no leaks found", which reads exactly like a dead gate; the recipe above the hook in `.pre-commit-config.yaml` documents this. The real probe gives `leaks found: 1` and exit 1, clean tree exit 0. Checked unpiped — piping into `tail` masks the exit status.

Also: `ci/linter/run-all.sh` clean, `ci/linter/selftest.sh` all controls held, `actionlint` clean on the edited workflow, and the four pre-commit C hooks pass over the widened globs.

## Also here

Both found while verifying the above:

- **The whitespace fixers were rewriting byte-exact files.** They excluded only `\.(pem|der)$`, so `pre-commit run --all-files` mutated a fuzz regression corpus entry and a quilt patch. A corpus entry *is* the input bytes — appending `\n` makes it a different `Accept-Encoding` header, and the regression stops reproducing the crash it was committed to pin. Patches match context at zero fuzz. Both patterns now excluded via a shared YAML anchor.
- **Two documentation drifts.** `lint.yml`'s header credited the `c` checker with clang-tidy, which it does not run (clang-tidy is CI-only in `security-scanners.yml` — it needs a configured nginx tree) and omitted cppcheck, which it does run and CI does not. `ci/linter/README.md` documented `lint-sync-stamp.sh` and `lint-prompt-steps.*`, which track the skeleton's own adoption prompt and do not exist in this repo.

The one-line `config` change is the end-of-file fixer removing a stray trailing blank line, now that it runs cleanly.
