### PR TITLE
fix(valgrind): drop the copied suppression file that muted the Cond class

### DIFF
--- a/ci/.adopted
+++ b/ci/.adopted
@@ -1,12 +1,19 @@
 prompt_version: 241a7ac6f664bf98324f085489ed41a7f67eae56bf0ff500507ec84bb9f2f4eb
 skeleton_sha:   537f28ea996e6e540cebff486a9e8fff824b6918
 adopted_date:   2026-08-22
-steps_degraded: 30
+steps_degraded: none
 
-# step 30: the memcheck subject cannot be answered honestly from configuration.
-# valgrind.suppress is the generic circulated nginx file (28 unfilled
-# <insert_a_suppression_name_here> blocks naming ngx_http_lua_* and
-# drizzle_state_connect, symbols this module never links) and can mask this
-# module's own errors. Deriving a real set needs a memcheck soak = phase 7 work.
-# Tracked: memory/labs/http-zstd/issues.md, and upstream in skeleton PR #41.
-# Every other subject and step is fully satisfied.
+# step 30 was recorded degraded at adoption: valgrind.suppress was the generic
+# circulated nginx file (28 unfilled <insert_a_suppression_name_here> blocks
+# naming ngx_http_lua_* and drizzle_state_connect, symbols this module never
+# links) and could mask this module's own errors.
+#
+# CLEARED at step 41 (2026-08-22). The defect narrowed to one block --
+# Memcheck:Cond over obj:*, which muted the entire use-of-uninitialised-value
+# class in any object including ours. Measured: a program reading one
+# uninitialised int exits 99 without suppressions and 0 with that block alone.
+# Replaced with an empty file carrying the derivation rules; both memcheck and
+# helgrind accept it and the muted error is visible again.
+# Detail: memory/labs/http-zstd/issues.md, ci/adoption-findings.md section 5.
+# Still reported upstream in skeleton PR #41 -- the skeleton ships the same
+# file to every adopter.

--- a/ci/adoption-findings.md
+++ b/ci/adoption-findings.md
@@ -426,16 +426,32 @@ a ~1% figure would have meant nginx core was in the denominator.
 
 ### 5. Valgrind / helgrind
 
-**Memcheck: NOT trustworthy as a gate — see `issues.md`.** `valgrind.suppress`
-is the generic circulated nginx file: all 28 blocks are unedited
-`<insert_a_suppression_name_here>` placeholders and the set names
-`ngx_http_lua_*` and `drizzle_state_connect`, symbols this module never links.
-Several blocks suppress bare `fun:malloc` / `fun:memcpy` under short stacks, so
-it can mask this module's own errors. It is live config, not dead:
-`ci/tools/soak.sh:71,79` passes it to both tools. Deliberately NOT fixed here —
-deriving a real set needs a genuine memcheck soak, which is phase-7 work.
-Ledgered OPEN with two acceptable fixes, and sent upstream (skeleton PR #41)
-because the skeleton ships the same file to every adopter.
+**Memcheck: was not trustworthy as a gate — FIXED at step 41 (2026-08-22).**
+`valgrind.suppress` was the generic circulated nginx file: all 28 blocks unedited
+`<insert_a_suppression_name_here>` placeholders, naming `ngx_http_lua_*` and
+`drizzle_state_connect`, symbols this module never links. It is live config, not
+dead — `ci/tools/soak.sh:71,79` passes it to both memcheck and helgrind.
+
+The `fun:malloc` / `fun:memcpy` blocks turned out to be **anchored** to full
+nginx call stacks (`ngx_alloc` → `ngx_set_environment` → …) and could not reach
+this module's frames. The real defect was a single block:
+
+    { <insert_a_suppression_name_here>
+      Memcheck:Cond
+      obj:* }
+
+`Memcheck:Cond` + `obj:*` matches an uninitialised-value conditional in any
+object at any depth, muting that whole class — including in
+`ngx_http_zstd_filter_module.so`. Measured on a four-line C program reading one
+uninitialised int: without suppressions valgrind exits 99 with 1 error; with
+that block alone it exits 0 with none. So `Memcheck lite (60s soak)` was green
+by construction for the Cond class, however long it ran.
+
+Fixed by replacing the file with an empty one (option 1 of the two the ledger
+recorded) carrying the derivation rules — suppress nothing, hide nothing.
+Verified that both memcheck and helgrind accept a comment-only suppressions
+file and that the previously-muted error becomes visible again. Sent upstream
+(skeleton PR #41) because the skeleton ships the same file to every adopter.
 
 **Helgrind: NOT applicable, settled with evidence.** The module has no shared
 cross-worker state. Counted over `src/*.c` and `src/*.h`: `ngx_shared_memory_add`

--- a/valgrind.suppress
+++ b/valgrind.suppress
@@ -1,218 +1,45 @@
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Addr1
-   fun:ngx_init_cycle
-   fun:ngx_master_process_cycle
-   fun:main
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Addr4
-   fun:ngx_init_cycle
-   fun:ngx_master_process_cycle
-   fun:main
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Cond
-   fun:ngx_vslprintf
-   fun:ngx_snprintf
-   fun:ngx_sock_ntop
-   fun:ngx_event_accept
-   fun:ngx_epoll_process_events
-   fun:ngx_process_events_and_timers
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Addr1
-   fun:ngx_vslprintf
-   fun:ngx_snprintf
-   fun:ngx_sock_ntop
-   fun:ngx_event_accept
-}
-{
-   <insert_a_suppression_name_here>
-   exp-sgcheck:SorG
-   fun:ngx_http_lua_ndk_set_var_get
-}
-{
-   <insert_a_suppression_name_here>
-   exp-sgcheck:SorG
-   fun:ngx_http_variables_init_vars
-   fun:ngx_http_block
-}
-{
-   <insert_a_suppression_name_here>
-   exp-sgcheck:SorG
-   fun:ngx_conf_parse
-}
-{
-   <insert_a_suppression_name_here>
-   exp-sgcheck:SorG
-   fun:ngx_vslprintf
-   fun:ngx_log_error_core
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Param
-   epoll_ctl(event)
-   fun:epoll_ctl
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Cond
-   fun:ngx_conf_flush_files
-   fun:ngx_single_process_cycle
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Cond
-   fun:memcpy
-   fun:ngx_vslprintf
-   fun:ngx_log_error_core
-   fun:ngx_http_charset_header_filter
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Param
-   socketcall.setsockopt(optval)
-   fun:setsockopt
-   fun:drizzle_state_connect
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Cond
-   fun:ngx_conf_flush_files
-   fun:ngx_single_process_cycle
-   fun:main
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Leak
-   fun:malloc
-   fun:ngx_alloc
-   fun:ngx_event_process_init
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Param
-   sendmsg(mmsg[0].msg_hdr)
-   fun:sendmmsg
-   fun:__libc_res_nsend
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Param
-   sendmsg(msg.msg_iov[0])
-   fun:__sendmsg_nocancel
-   fun:ngx_write_channel
-   fun:ngx_pass_open_channel
-   fun:ngx_start_cache_manager_processes
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Cond
-   fun:ngx_init_cycle
-   fun:ngx_master_process_cycle
-   fun:main
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Cond
-   fun:index
-   fun:expand_dynamic_string_token
-   fun:_dl_map_object
-   fun:map_doit
-   fun:_dl_catch_error
-   fun:do_preload
-   fun:dl_main
-   fun:_dl_sysdep_start
-   fun:_dl_start
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Param
-   sendmsg(mmsg[0].msg_hdr)
-   fun:sendmmsg
-   fun:__libc_res_nsend
-   fun:__libc_res_nquery
-   fun:__libc_res_nquerydomain
-   fun:__libc_res_nsearch
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:ngx_alloc
-   fun:ngx_set_environment
-   fun:ngx_single_process_cycle
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Cond
-   obj:*
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:ngx_alloc
-   fun:ngx_set_environment
-   fun:ngx_worker_process_init
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:ngx_alloc
-   fun:ngx_create_pool
-   fun:main
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Param
-   epoll_pwait(sigmask)
-   fun:epoll_pwait
-   fun:epoll_wait
-   fun:ngx_epoll_process_events
-   fun:ngx_process_events_and_timers
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Param
-   epoll_pwait(sigmask)
-   fun:epoll_pwait
-   fun:epoll_wait
-   fun:ngx_epoll_test_rdhup
-   fun:ngx_epoll_init
-   fun:ngx_event_process_init
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Param
-   epoll_pwait(sigmask)
-   fun:epoll_pwait
-   fun:ngx_epoll_process_events
-   fun:ngx_process_events_and_timers
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Param
-   epoll_pwait(sigmask)
-   fun:epoll_pwait
-   fun:ngx_epoll_test_rdhup
-   fun:ngx_epoll_init
-   fun:ngx_event_process_init
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Leak
-   match-leak-kinds: possible
-   fun:malloc
-   fun:ngx_alloc
-   fun:ngx_crc32_table_init
-   fun:main
-}
+# Valgrind suppressions for nginx-zstd-module.
+#
+# DELIBERATELY EMPTY. Read this before adding a block.
+#
+# What was here until 2026-08-22: the 28-block generic nginx suppression file
+# that circulates online. Every block still carried the unedited
+# `<insert_a_suppression_name_here>` placeholder, and the set named
+# `ngx_http_lua_*` and `drizzle_state_connect` -- symbols this module does not
+# link. It had been adopted wholesale, never derived.
+#
+# Most of it was merely inert. One block was not:
+#
+#     { <insert_a_suppression_name_here>
+#       Memcheck:Cond
+#       obj:* }
+#
+# `Memcheck:Cond` with `obj:*` matches a use-of-uninitialised-value conditional
+# in ANY object at ANY depth, including ngx_http_zstd_filter_module.so. It muted
+# that entire error class -- the class most likely to catch a real bug in this
+# module's header parsing -- across both the memcheck and helgrind lanes, since
+# ci/tools/soak.sh feeds this file to both.
+#
+# Measured, not inferred. A four-line C program reading one uninitialised int:
+#     without suppressions          valgrind exits 99, 1 uninitialised error
+#     with that block alone         valgrind exits 0,  0 errors
+# So `Memcheck lite (60s soak)` was reporting green by construction for the Cond
+# class, and would have kept doing so however long the soak ran.
+#
+# Empty is the correct default: it suppresses nothing and therefore hides
+# nothing. A soak that goes red on genuine nginx-core noise is a real result to
+# triage, not a reason to restore a file nobody derived.
+#
+# ADDING A BLOCK -- the rules, so this does not silently regrow:
+#
+#   1. Derive it, never copy it. ci/tools/soak.sh already passes
+#      --gen-suppressions=all, so a real soak prints the exact block to paste.
+#   2. Name it. A placeholder name means nobody decided what is being
+#      suppressed; that is the state this file was just rescued from.
+#   3. Anchor it to a named frame that is NOT ours -- an `ngx_*` core symbol or
+#      a libc entry point reached from one. A block whose stack could match a
+#      frame in src/ suppresses our own bug.
+#   4. Never use `obj:*`, and never let `...` be the only frame constraint.
+#      Both match arbitrary code, which is a mute rather than a suppression.
+#   5. Say WHY in a comment above the block: which run produced it, and why the
+#      finding is not this module's to fix.


### PR DESCRIPTION
> Skeleton-adoption phase 7. This is the step-30 degraded item the ledger has been carrying, and it turned out to be a prerequisite for the step-38 soak dispatch rather than a follow-up to it.

## TL;DR

The project carried a list of "ignore these known-harmless warnings" rules for its memory checker, copied wholesale from a generic template rather than written for this code. One of those rules was far broader than intended: it silenced an entire category of memory error everywhere, including in this module's own code. The memory-check job has therefore been passing partly because it was unable to report that category at all. The list is now empty, so nothing is hidden.

Replaces `valgrind.suppress` with an empty file carrying derivation rules; updates `ci/.adopted` to `steps_degraded: none` and rewrites section 5 of `ci/adoption-findings.md`.

**Severity:** `Medium` (`test integrity — a gate green by construction, no known escaped bug`)

## What was wrong

All 28 blocks still carried the unedited `<insert_a_suppression_name_here>` placeholder, and the set named `ngx_http_lua_*` and `drizzle_state_connect` — symbols this module does not link. It was adopted wholesale, never derived. This is live config: `ci/tools/soak.sh:71,79` feeds it to **both** memcheck and helgrind, and `ci-deep.yml` pairs it with `--error-exitcode=99`.

Most of it was inert, and the ledger's original description was too pessimistic. It recorded "several blocks suppress bare `fun:malloc` / `fun:memcpy`". Those blocks are in fact **anchored** to full nginx call stacks — `fun:ngx_alloc` → `fun:ngx_set_environment` → `fun:ngx_worker_process_init` and similar — so they reach nginx-core startup allocations only and cannot match this module's per-request frames.

One block was the real defect:

```
{ <insert_a_suppression_name_here>
  Memcheck:Cond
  obj:* }
```

`Memcheck:Cond` with `obj:*` matches a use-of-uninitialised-value conditional in **any object at any depth**, including `ngx_http_zstd_filter_module.so`. It muted that whole error class — the class most likely to catch a real bug in this module's header parsing — across both lanes. No block uses `...`, so no other block reaches arbitrary depth.

## Evidence

Measured, not inferred. A four-line C program reading one uninitialised `int`:

| suppressions | exit | uninitialised errors |
|---|---|---|
| none | 99 | 1 |
| that block alone | 0 | 0 |

So `Memcheck lite (60s soak)` was green by construction for the Cond class, and would have stayed green however long the soak ran. That is what makes this a prerequisite for the phase-7 soak dispatch — soaking first would have bought a green that proves nothing.

## The fix

Empty file, which is option 1 of the two the ledger recorded. It suppresses nothing and therefore hides nothing. A soak that goes red on genuine nginx-core noise is a result to triage, not a reason to restore a file nobody derived.

The file keeps the rules for adding a block later, so it does not silently regrow: derive it from the soak's own `--gen-suppressions=all` output (`soak.sh` already passes it), name it, anchor it to a frame that is not ours, never use `obj:*` or a bare `...`, and record why.

## Testing

- Verified both memcheck **and** helgrind accept a comment-only suppressions file — the empty file does not break either lane.
- Verified the previously-muted error is visible again with it in place: exit 99, 1 error.
- `ci/linter/run-all.sh` clean.

Expect the memcheck lane to be genuinely exercised for the first time on this branch. If it goes red on nginx-core noise, that is a real finding to triage into named, anchored blocks — not a reason to revert.

## Related

Still reported upstream in skeleton PR #41: the skeleton ships this same file to every adopter, so the `obj:*` block is not just this repo's problem.
