### PR TITLE
ci: add a jobs input so a ci-deep dispatch can run a subset

### DIFF
--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -8,8 +8,13 @@ name: CI Deep
 # multi-flavor build matrix (mainline/stable/angie) plus hours-long fuzzing
 # and full Memcheck/Helgrind soaks that would blow the PR-gate time budget.
 #
+# A manual dispatch can run a SUBSET via the `jobs` input (default `all`);
+# the monthly cron passes no inputs and therefore always runs everything.
+# Use a subset when the full set would monopolise the shared pool for the
+# hours the fuzz and helgrind legs need.
+#
 # Jobs: build-flavors (nginx mainline/stable + angie) · fuzz (14400s/target) ·
-#   memcheck soak · helgrind soak · scanners.
+#   memcheck soak · helgrind soak · scanners · coverage (src/).
 #   * memcheck AND helgrind run under ci/tools/soak.sh, which already passes
 #     --suppressions=valgrind.suppress and --error-exitcode=99 for BOTH tools
 #     (see ci/tools/soak.sh) — the drift-fix baseline for every module.
@@ -41,6 +46,22 @@ on:
         description: "Per-target fuzz duration (seconds)"
         required: false
         default: "3600"
+      jobs:
+        # Which jobs a manual dispatch should run. The full set occupies most
+        # of the shared self-hosted pool for hours (fuzz alone is capped at
+        # 600min), so an on-demand run usually wants a subset -- e.g. after a
+        # suppression-file fix, only the memcheck soak is meaningful. The
+        # scheduled monthly run supplies no inputs, so `all` is the default and
+        # cron behaviour is unchanged.
+        description: "Jobs to run"
+        required: false
+        default: all
+        type: choice
+        options:
+          - all
+          - memcheck+coverage
+          - build-flavors
+          - scanners
 
 concurrency:
   group: ci-deep-${{ github.workflow }}-${{ github.ref }}
@@ -52,6 +73,7 @@ permissions:
 jobs:
   build-flavors:
     name: Build & Test::Nginx (${{ matrix.flavor }} ${{ matrix.version }})
+    if: ${{ contains(fromJSON('["all","build-flavors"]'), inputs.jobs || 'all') }}
     runs-on: ${{ fromJSON(vars.POOL || '["ubuntu-latest"]') }}
     timeout-minutes: 30
     env:
@@ -211,6 +233,7 @@ jobs:
 
   fuzz:
     name: Fuzz (Accept-Encoding, long)
+    if: ${{ (inputs.jobs || 'all') == 'all' }}
     runs-on: ${{ fromJSON(vars.POOL || '["ubuntu-latest"]') }}
     timeout-minutes: 600
     steps:
@@ -315,6 +338,7 @@ jobs:
 
   memcheck:
     name: Valgrind Memcheck soak
+    if: ${{ contains(fromJSON('["all","memcheck+coverage"]'), inputs.jobs || 'all') }}
     runs-on: ${{ fromJSON(vars.POOL || '["ubuntu-latest"]') }}
     timeout-minutes: 240
     steps:
@@ -382,6 +406,7 @@ jobs:
 
   helgrind:
     name: Valgrind Helgrind soak
+    if: ${{ (inputs.jobs || 'all') == 'all' }}
     runs-on: ${{ fromJSON(vars.POOL || '["ubuntu-latest"]') }}
     timeout-minutes: 240
     steps:
@@ -449,6 +474,7 @@ jobs:
 
   scanners:
     name: Security scanners
+    if: ${{ contains(fromJSON('["all","scanners"]'), inputs.jobs || 'all') }}
     runs-on: ${{ fromJSON(vars.POOL || '["ubuntu-latest"]') }}
     timeout-minutes: 20
     steps:
@@ -532,6 +558,7 @@ jobs:
   # from-scratch coverage-instrumented build plus the whole ci/t/ suite.
   coverage:
     name: Coverage report (src/)
+    if: ${{ contains(fromJSON('["all","memcheck+coverage"]'), inputs.jobs || 'all') }}
     runs-on: ${{ fromJSON(vars.POOL || '["ubuntu-latest"]') }}
     timeout-minutes: 30
     env:


### PR DESCRIPTION
> Prerequisite for dispatching the deep-analysis lanes on demand. The `valgrind.suppress` fix in #133 made the Memcheck soak meaningful again, but there was no way to run it without also starting the hours-long fuzz and Helgrind legs.

## TL;DR

The deep-analysis workflow is all-or-nothing: triggering it by hand starts every
job, which can tie up most of the shared build machines for the better part of a
day. Usually only one or two of those jobs are the ones you actually want. This
adds a dropdown to the manual-run form so you can pick a subset.

Adds a `jobs` choice input to `.github/workflows/ci-deep.yml` and an `if:` guard
on each of the six jobs keying off it.

**Severity:** `Low` (`CI ergonomics — no change to what any job asserts`)

## Mechanism

`ci-deep.yml` runs six jobs, all on the shared self-hosted pool: worst case is
fuzz at 600 min, memcheck 240, helgrind 240, plus build-flavors, scanners and
coverage. No job declares `needs`, so they all start at once and the run occupies
most of the pool's slots for as long as the slowest leg takes.

The new input offers `all` (default), `memcheck+coverage`, `build-flavors` and
`scanners`. Each job's guard reads `inputs.jobs || 'all'`, so:

- a `workflow_dispatch` that leaves the dropdown alone gets `all`;
- the monthly `schedule` trigger supplies no inputs at all, `inputs.jobs`
  evaluates to null, and the fallback yields `all`.

Scheduled behaviour is therefore byte-for-byte what it was.

The `if:`-on-a-job hazard that bit this repo twice — an `if:` overriding the
default `needs` skip and letting a job run against a failed dependency — does not
apply: `grep -n needs .github/workflows/ci-deep.yml` matches only two prose
comments, so no job in this file has a dependency to skip on.

Also corrects the header comment's job list, which named five jobs and omitted
`coverage`.

## Testing

- `actionlint .github/workflows/ci-deep.yml` — clean.
- `_shared/review-lint.sh --branch master` — clean; the `yamllint` line-length and
  `checkov` CKV_GHA_7 hits are pre-existing. CKV_GHA_7 (workflow_dispatch inputs
  must be empty) already fired on the unmodified file for the existing
  `fuzz_seconds` input; confirmed by re-running checkov against a stashed tree.
- Guard semantics for the `schedule` path are reasoned from the expression
  contract, not executed — the next real exercise of it is the monthly cron.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual selection of CI job groups when starting a workflow.
  * Preserved full execution for scheduled runs and the default manual option.
  * Added support for running build checks, memory checks, coverage, and scanners as grouped subsets.

* **Documentation**
  * Updated workflow guidance to explain job selection and coverage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->