### PR TITLE
test(lint): cover the two lint.yml gates that are not lint-*.sh scripts

### DIFF
--- a/ci/linter/selftest.sh
+++ b/ci/linter/selftest.sh
@@ -291,6 +291,31 @@ fi
 case_ 0 "lint-spelling is dispatched by run-all.sh" \
     bash -c 'ci/linter/run-all.sh --list | grep -q lint-spelling.sh'
 
+# The control above closes the loop for checkers that ARE a ci/linter/lint-*.sh
+# script. Two gates in lint.yml are not: ast-grep and gitleaks live in
+# .pre-commit-config.yaml and are invoked as their own `run:` steps, because
+# run-all.sh discovers checkers by the lint-*.sh glob and can never reach them.
+# That left them structurally unguarded -- delete either step from lint.yml and
+# every control here still passed, which is how they came to be hook-only (and
+# so absent from every PR) until 2026-08-22.
+#
+# Keying on the step NAME rather than the tool binary is deliberate: the name is
+# what the job summary shows, and a step renamed out of this list is a step
+# whose disappearance from the UI nobody would notice either.
+for step in \
+    'ast-grep (structural sinks, gate on promoted rules)' \
+    'gitleaks (whole tracked tree)'
+do
+    if grep -qF -- "- name: $step" .github/workflows/lint.yml; then
+        echo "ok   lint.yml still runs the non-script gate: $step"
+    else
+        echo "FAIL lint.yml no longer runs: $step" >&2
+        echo "       | it is not a ci/linter/lint-*.sh script, so run-all.sh" >&2
+        echo "       | cannot dispatch it and no other control covers it" >&2
+        rc=1
+    fi
+done
+
 # The prompt-steps temp root went with the checker (see below), leaving only
 # $badroot. Its trap is registered here because `trap ... EXIT` REPLACES any
 # earlier EXIT trap rather than adding to it.


### PR DESCRIPTION
> Closes the structural hole recorded when the linter coverage table was built (step 37 of the ci/ skeleton adoption). The table is what surfaced it; nothing in the gate itself would have.

## TL;DR

The lint job runs a dozen checks. Most are shell scripts, and a self-test makes
sure none of them quietly stops running. Two of the checks are not scripts, and
the self-test never looked at those — anyone could delete them and every test
still passed. This adds the missing check.

Adds a control to `ci/linter/selftest.sh` asserting the `ast-grep` and
`gitleaks` steps are still present in `.github/workflows/lint.yml`.

**Severity:** `Low` (`test integrity — a gate could be removed silently; no runtime behaviour`)

## Mechanism

`run-all.sh` discovers checkers with the `ci/linter/lint-*.sh` glob, and
`selftest.sh` already asserts every such script is named in `lint.yml`'s
`LINT_ONLY`. That closes the loop for glob-discovered checkers.

`ast-grep` and `gitleaks` are configured in `.pre-commit-config.yaml`, not as
`lint-*.sh` scripts, so the glob cannot reach them and they are invoked as their
own `run:` steps in `lint.yml`. No control covered those steps. Deleting either
one left `selftest.sh` fully green.

That gap is how both ended up hook-only — running locally and in the pre-commit
hook, but on no PR — until they were added as explicit steps on 2026-08-22.

The control keys on the step *name* rather than the tool binary. The name is what
the job summary renders, so a step renamed out of the list is also a step whose
disappearance from the UI nobody would notice.

## Testing

- `ci/linter/selftest.sh` — all controls held, including the two new rows.
- **Negative control, run both directions.** With the `gitleaks` step renamed in
  `lint.yml`, `selftest.sh` exits 1 and prints
  `FAIL lint.yml no longer runs: gitleaks (whole tracked tree)`; with the file
  restored it exits 0 and prints `all controls held`. The control is not vacuous.
- `ci/linter/run-all.sh` — clean.
- `_shared/review-lint.sh --diff HEAD` — clean. The one `shellcheck` hit (SC2001,
  style) is at `selftest.sh:38`, outside this diff, and sits below the severity
  `lint-sh.sh` gates on.
