### PR TITLE
docs: point the reproduce commands at ci/ after the skeleton move

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ Your PR merges when **all** checks are green. If a gate fails and you
 believe the gate is wrong, say so in the PR — with evidence, not vibes.
 
 Before pushing a parser or fuzz-harness change, fuzz locally first:
-`fuzz/build.sh` compiles the target under ASAN+UBSAN
+`ci/fuzz/build.sh` compiles the target under ASAN+UBSAN
 (`-fsanitize=address,undefined`), so a stale harness signature or a
 sanitizer-caught bug surfaces right there instead of in CI. (The
 module's own C sources are compiled `-Werror` — see
@@ -159,10 +159,10 @@ it. Not a follow-up PR. Not "later". Same PR.
   the ugly inputs (empty, oversized, malformed, truncated).
 - Bug fix → a regression test that **fails before the fix and passes
   after**. That's the proof the test actually tests something.
-- New input parser → a libFuzzer target in `fuzz/`.
+- New input parser → a libFuzzer target in `ci/fuzz/`.
 
 Where tests live varies slightly per module (unit suites, `t/*.t`
-Test::Nginx files, runtime suites under `tools/`) — look at the existing
+Test::Nginx files, runtime suites under `ci/tools/`) — look at the existing
 tests in this repo and put yours next to them. A PR that adds code without
 a test will not be merged, and yes, we check.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,11 +71,11 @@ Security-relevant CI runs on every change and is reproducible locally:
 ```bash
 # Memory safety
 # (build nginx with -fsanitize=address,undefined, then:)
-python3 tools/test_encoding.py --nginx-binary /path/to/asan-nginx
-bash tools/test_reload_leak.sh /path/to/asan-nginx
+python3 ci/tools/test_encoding.py --nginx-binary /path/to/asan-nginx
+bash ci/tools/test_reload_leak.sh /path/to/asan-nginx
 
 # Fuzz the request parser
-bash fuzz/build.sh && ./fuzz/fuzz_accept_encoding -max_total_time=60 fuzz/corpus/
+bash ci/fuzz/build.sh && ./ci/fuzz/fuzz_accept_encoding -max_total_time=60 ci/fuzz/corpus/
 ```
 
 See [`.github/workflows/`](.github/workflows/) (build-test, codeql,


### PR DESCRIPTION
> Found in the residue sweep closing out the ci/ skeleton adoption (step 42). Independent of #134 and #135, which touch workflows and the lint selftest.

## TL;DR

Moving the test and fuzzing helpers into a `ci/` directory left the security and
contributor docs pointing at where they used to be. Anyone following the
"reproduce this locally" instructions on a fresh clone gets a file-not-found on
every line. This repoints them.

**Severity:** `Low` (`documentation — broken reproduce instructions; no runtime behaviour`)

## Mechanism

The adoption moved `fuzz/` → `ci/fuzz/` and `tools/` → `ci/tools/`. Four paths in
`SECURITY.md`'s "Security-relevant CI runs on every change and is reproducible
locally" block, and three references in `CONTRIBUTING.md`, kept the old names.
None of `fuzz/`, `tools/` exists any more, so every command in that block fails.

Checked each replacement resolves in the tree, and that `ci/fuzz/build.sh`
actually produces the binary at the path the new invocation runs: `OUT` defaults
to `$FUZZ_DIR/fuzz_accept_encoding`, and `FUZZ_DIR` is the script's own
directory, so the artifact lands at `ci/fuzz/fuzz_accept_encoding`.

`README.md` needed no change — its tree listing already nests `tools/` and
`fuzz/` beneath a `ci/` heading, so the entries there were never wrong.

Worth noting for the gate's own coverage: `lint-docs-drift.sh` was green
throughout. It asserts every workflow is documented in the README, not that a
path named in prose exists. A checker for the latter is a reasonable follow-up
but is not in this PR's scope.

## Testing

- Verified each cited path exists in the tree; confirmed no `fuzz/` or `tools/`
  reference outside a `ci/` prefix survives in either file.
- Read `ci/fuzz/build.sh` for the output path rather than assuming it.
- `_shared/review-lint.sh --diff HEAD` — clean. The two `markdownlint` MD034 hits
  are at `CONTRIBUTING.md:15` and `:202`, outside this diff and pre-existing;
  markdownlint is not a gate in this repo.
