### PR TITLE
ci(deep): point the monthly scanners job at src/ and let it fail

### DIFF
--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -514,8 +514,15 @@ jobs:
           CC=gcc ./configure --with-compat --add-dynamic-module="$GITHUB_WORKSPACE" >/dev/null
           echo "NGINX_SRC_TREE=$PWD" >> "$GITHUB_ENV"
       - name: flawfinder
+        # Threshold mirrors ci/linter/lint-c.sh and security-scanners.yml
+        # exactly: gate at >=4. --error-level is what makes flawfinder itself
+        # exit non-zero; --minlevel alone only controls what gets PRINTED, so
+        # the previous bare --minlevel=1 could never fail this step regardless
+        # of what it found. Move a threshold here, move it in lint-c.sh and
+        # security-scanners.yml in the SAME commit.
         run: |
-          flawfinder --minlevel=1 \
+          set -o pipefail
+          flawfinder --minlevel=4 --error-level=4 \
             "$GITHUB_WORKSPACE/src/ngx_http_zstd_filter_module.c" \
             "$GITHUB_WORKSPACE/src/ngx_http_zstd_static_module.c" 2>&1 | tee flawfinder.log
       - name: clang-tidy (cert-*, security.*)
@@ -537,9 +544,19 @@ jobs:
           done
           exit "$status"
       - name: semgrep
+        # Same target and threshold as ci/linter/lint-c.sh and
+        # security-scanners.yml: src/ is the module's real source directory --
+        # filter/ and static/ are the pre-skeleton layout this job was still
+        # pointed at, so the scan matched no files at all. Gate >=WARNING, and
+        # --jobs=1 --metrics=off (--jobs=1 is a CORRECTNESS flag on this host's
+        # shared RLIMIT_MEMLOCK, not a speed one). The dropped `|| true` meant
+        # this step could never fail on a real finding.
         run: |
+          set -o pipefail
           semgrep scan --config p/c --config p/security-audit \
-            "$GITHUB_WORKSPACE/filter/" "$GITHUB_WORKSPACE/static/" 2>&1 | tee semgrep.log || true
+            --severity=WARNING --severity=ERROR --error \
+            --jobs=1 --metrics=off \
+            "$GITHUB_WORKSPACE/src/" 2>&1 | tee semgrep.log
       - name: Upload reports
         if: always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5


### PR DESCRIPTION
> Last row of the `ci/skeleton-findings.md` #4 drift: step 27 fixed the same two
> defects in `security-scanners.yml` but the monthly `ci-deep.yml` copy was out of
> that slice. No production code is touched.

## TL;DR

The monthly deep-scan workflow had a security scanner pointed at two directories
that were deleted months ago, so it was scanning nothing and reporting success.
A second scanner in the same job printed its findings but was never wired to
actually fail. Both now match the per-PR scanner job that was already corrected.

`ci-deep.yml`'s `scanners` job: semgrep retargeted from `filter/`+`static/` to
`src/` with `--severity=WARNING --severity=ERROR --error` and the `|| true`
dropped; flawfinder moved from `--minlevel=1` to `--minlevel=4 --error-level=4`;
`set -o pipefail` added to both steps.

**Severity:** `Medium` (`dead gate — two scanners in the monthly security lane could not fail`)

## Why it was green

Two independent reasons, both silent:

- **semgrep matched no files.** `filter/` and `static/` were the pre-skeleton
  source layout; the sources live in `src/` since the adoption move. semgrep
  exits 0 on an empty target set, and `|| true` would have masked a real finding
  anyway.
- **flawfinder cannot fail on `--minlevel` alone.** That flag controls what gets
  *printed*. `--error-level` is what makes flawfinder exit non-zero, and it was
  absent — so the step passed regardless of what the scan found.

`tee` also swallowed both exit statuses; `set -o pipefail` closes that.

## Consistency

The three places that scan the module's C sources now agree on target and
threshold: `ci/linter/lint-c.sh`, `.github/workflows/security-scanners.yml`
(fixed in step 27) and this job. The flawfinder comment says so, so a future
threshold move has a written reason to touch all three together.

## Testing

`review-lint.sh --diff HEAD` clean on the new roster members (actionlint,
zizmor, semgrep, ast-grep, gitleaks, trufflehog, codespell, lizard). The
remaining findings are pre-existing and were confirmed to fire on the unmodified
tree: five yamllint `line-length` warnings on untouched lines, and checkov
CKV_GHA_7 on the `workflow_dispatch` inputs added by #134.

This job runs on the monthly schedule and on manual dispatch, so this PR's own
CI does not exercise it. Whether the retargeted semgrep run is clean on `src/`
is not yet known — `security-scanners.yml` runs the same scan with the same
config and threshold on every PR and is green, which is good evidence but not
the same invocation.
