### PR TITLE
test: reproduce sub_filter/CCtx-reset regression with uncoalesced backend reads

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1622,7 +1622,7 @@ jobs:
           python3 ci/tools/test_slow_drain.py \
             --nginx-binary "$TEST_NGINX_BINARY" --port 18110 --backend-port 18111 \
             --log-level warn
-          # See the release job's "sub_filter/CCtx-reset" step for why
+          # See the tests job's "sub_filter/CCtx-reset" step for why
           # this exists. --log-level warn: same UBSAN debug-log trap as
           # test_slow_drain.py above -- the body round-trip assertion
           # still runs, only the invocation-count self-check is skipped.
@@ -1872,7 +1872,7 @@ jobs:
           # forces both paths every run.
           python3 ci/tools/test_slow_drain.py \
             --nginx-binary "$TEST_NGINX_BINARY" --port 19110 --backend-port 19111
-          # See build-test.yml's release job for the ci/t/00-filter.t
+          # See the tests job's "sub_filter/CCtx-reset" step for the
           # TEST 92 coalescing gap this closes.
           python3 ci/tools/test_sub_filter_cctx_reset.py \
             --nginx-binary "$TEST_NGINX_BINARY" --port 19112 --backend-port 19113

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1151,6 +1151,7 @@ jobs:
             --with-debug \
             --with-cc-opt="-DZSTD_STATIC_LINKING_ONLY $SAN $(pkg-config --cflags libzstd zlib libpcre2-8)" \
             --with-ld-opt="$SAN $(pkg-config --libs libzstd zlib libpcre2-8)" \
+            --with-http_sub_module \
             --add-module="$GITHUB_WORKSPACE"
           make -j"$(nproc)"
           if grep -q 'NGX_HTTP_ZSTD_HAVE_LIBCRYPTO' objs/ngx_auto_config.h; then

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1370,6 +1370,18 @@ jobs:
             --nginx-binary "$TEST_NGINX_BINARY" \
             --port 18100 --backend-port 18101
           echo "✓ slow-drain backpressure + data-less flush passed"
+          # ci/t/00-filter.t TEST 92 pins the sub_filter/CCtx-reset
+          # contract but its Test::Nginx tcp_reply array-send coalesces
+          # the three backend chunks into one read locally, so it never
+          # exercises the mid-stream sync-carrier path the bug needs
+          # (see memory/labs/http-zstd/issues.md, 2026-08-13). This tool
+          # drives the same scenario over a raw socket backend with a
+          # real sleep between each send() call, and self-checks that
+          # the reads stayed uncoalesced before trusting its own result.
+          python3 ci/tools/test_sub_filter_cctx_reset.py \
+            --nginx-binary "$TEST_NGINX_BINARY" \
+            --port 18102 --backend-port 18103
+          echo "✓ sub_filter/CCtx-reset mid-stream regression passed"
 
       - name: Run broad compression correctness matrix
         timeout-minutes: 12
@@ -1608,6 +1620,13 @@ jobs:
           # coverage jobs, whose binaries are not sanitized.
           python3 ci/tools/test_slow_drain.py \
             --nginx-binary "$TEST_NGINX_BINARY" --port 18110 --backend-port 18111 \
+            --log-level warn
+          # See the release job's "sub_filter/CCtx-reset" step for why
+          # this exists. --log-level warn: same UBSAN debug-log trap as
+          # test_slow_drain.py above -- the body round-trip assertion
+          # still runs, only the invocation-count self-check is skipped.
+          python3 ci/tools/test_sub_filter_cctx_reset.py \
+            --nginx-binary "$TEST_NGINX_BINARY" --port 18114 --backend-port 18115 \
             --log-level warn
           # Matrix under ASAN/UBSAN at repeat=1 (252 cells) — the
           # truncation/zero-size-buf/livelock class has UB+lifetime
@@ -1852,6 +1871,10 @@ jobs:
           # forces both paths every run.
           python3 ci/tools/test_slow_drain.py \
             --nginx-binary "$TEST_NGINX_BINARY" --port 19110 --backend-port 19111
+          # See build-test.yml's release job for the ci/t/00-filter.t
+          # TEST 92 coalescing gap this closes.
+          python3 ci/tools/test_sub_filter_cctx_reset.py \
+            --nginx-binary "$TEST_NGINX_BINARY" --port 19112 --backend-port 19113
           python3 ci/tools/test_terminal_frame.py --nginx-binary "$TEST_NGINX_BINARY" --port 19093
           python3 ci/tools/test_window_cap.py \
             --nginx-binary "$TEST_NGINX_BINARY" --port 19104 --backend-port 19105

--- a/ci/tools/test_sub_filter_cctx_reset.py
+++ b/ci/tools/test_sub_filter_cctx_reset.py
@@ -110,16 +110,21 @@ def parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
-def detect_module(explicit: str | None, nginx: pathlib.Path) -> pathlib.Path:
+def detect_module(explicit: str | None, nginx: pathlib.Path) -> pathlib.Path | None:
+    """Resolve the filter .so: explicit path, or beside the binary.
+
+    Returns None when neither is present, which is the normal case for a
+    STATICALLY linked CI build -- the filter is already in the binary and
+    emitting a `load_module` line for it would make nginx refuse to start.
+    Same contract as ci/tools/test_slow_drain.py's detect_module().
+    """
     if explicit:
-        return pathlib.Path(explicit)
-    sib = nginx.parent / "ngx_http_zstd_filter_module.so"
-    if sib.exists():
-        return sib
-    raise FileNotFoundError(
-        "ngx_http_zstd_filter_module.so not found next to the nginx binary; "
-        "pass --filter-module explicitly"
-    )
+        return pathlib.Path(explicit).resolve()
+    # resolve(): nginx resolves a relative load_module path against its
+    # PREFIX (-p, a temp dir here), not against the cwd, so a relative
+    # path dlopen()s from inside the temp dir and fails.
+    sib = (nginx.parent / "ngx_http_zstd_filter_module.so").resolve()
+    return sib if sib.exists() else None
 
 
 def wait_port(port: int, timeout: float = 10.0) -> None:
@@ -245,8 +250,9 @@ def main() -> int:
     if not nginx.exists():
         raise FileNotFoundError(f"nginx binary not found: {nginx}")
     module = detect_module(args.filter_module, nginx)
-    if not module.exists():
+    if module is not None and not module.exists():
         raise FileNotFoundError(f"module not found: {module}")
+    load = f"load_module {module};\n" if module else ""
 
     with tempfile.TemporaryDirectory(prefix="zstd-subfilter-") as td:
         root = pathlib.Path(td)
@@ -256,8 +262,7 @@ def main() -> int:
         lvl = args.log_level
         conf = root / "nginx.conf"
         conf.write_text(
-            f"""load_module {module};
-worker_processes 1;
+            f"""{load}worker_processes 1;
 error_log {logs}/error.log {lvl};
 pid {root}/nginx.pid;
 events {{ worker_connections 64; }}

--- a/ci/tools/test_sub_filter_cctx_reset.py
+++ b/ci/tools/test_sub_filter_cctx_reset.py
@@ -303,7 +303,25 @@ http {{
             text=True,
         )
         try:
-            wait_port(args.port)
+            try:
+                wait_port(args.port)
+            except RuntimeError:
+                # nginx never listened -- almost always a config-load
+                # rejection (a directive whose module is not compiled in,
+                # a bad path). Its stderr is the only thing that says
+                # WHICH, and it is on the pipe, so surface it instead of
+                # letting the bare "nothing listening" hide the cause.
+                proc.terminate()
+                try:
+                    out = proc.communicate(timeout=5)[0] or ""
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    out = proc.communicate()[0] or ""
+                if out.strip():
+                    sys.stderr.write("nginx output:\n")
+                    for line in out.strip().splitlines()[:20]:
+                        sys.stderr.write(f"  {line}\n")
+                raise
             failures: list[str] = []
             start_backend_listener(args.backend_port)
 

--- a/ci/tools/test_sub_filter_cctx_reset.py
+++ b/ci/tools/test_sub_filter_cctx_reset.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Regression test: sub_filter partial-match sync bufs must not reset the
+zstd CCtx mid-stream.
+
+Background
+----------
+The body filter used to infer "first body data for this request" from
+``ctx->buffer_in.src == NULL``, but ``add_data`` reloads ``buffer_in.src``
+from every incoming buffer. ``ngx_http_sub_filter`` emits a data-less sync
+carrier (``pos == NULL``) whenever an in-memory input buffer is entirely
+absorbed into a cross-buffer match candidate and produces no output that
+call. Loading that carrier re-armed the old first-call check, so the next
+invocation re-ran ``ZSTD_CCtx_reset()`` mid-stream and everything libzstd
+had buffered but not yet flushed was silently discarded. The response
+still ended as ONE well-formed frame (200 + valid zstd), just missing the
+pre-reset content. Seen in production as truncated HTML on
+sub_filter-rewritten pages fed by a slow chunked upstream. Fixed by an
+explicit ``cctx_ready`` latch instead of inferring lifecycle state from a
+data pointer.
+
+Why ci/t/00-filter.t TEST 92 does not detect this
+--------------------------------------------------
+That test relies on Test::Nginx's ``tcp_reply_delay`` + an array-form
+``tcp_reply`` to model three separate upstream chunks. Measured (see
+memory/labs/http-zstd/issues.md, 2026-08-13): the harness sleeps ONCE
+before the whole array, then writes every element back-to-back in a tight
+loop with no pause between ``$client->send()`` calls. Locally the three
+segments arrive COALESCED -- 2 body-filter invocations for 3 requests, not
+the 3-per-request the test's three delayed segments assume -- so the
+mid-stream carrier this bug needs never occurs; the test passes against
+BOTH the pre-fix and the fixed module and pins the contract without
+detecting a regression in it.
+
+This test reproduces the same production trigger a different way: a raw
+socket backend that ``send()``s each chunk as its own syscall with a
+real sleep in between, through ``proxy_buffering off`` (which forwards
+each upstream read immediately instead of coalescing them), so nginx's
+event loop genuinely dispatches three separate reads. The body-filter
+invocation count is read back from ``error_log debug`` -- counting
+invocations, not assuming chunk boundaries, per the coalescing trap this
+test exists to avoid repeating.
+
+It MUST fail (decoded body missing the pre-reset content, or a decode
+error) on a module with the old ``buffer_in.src == NULL`` first-call
+check, and pass with the ``cctx_ready`` fix.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.request
+
+FROM = "http://upstream.example"
+TO = "https://very-long-replacement-host.example"
+
+# seg2 lies strictly inside FROM: absorbed into the sub_filter match
+# candidate with no output on its own call, producing the data-less sync
+# carrier the bug needs.
+SEG1 = b"EARLY-CONTENT that must survive the match holdback http://up"
+SEG2 = b"stream.exa"
+SEG3 = b"mple/path LATE-CONTENT after the match completes\n"
+
+EXPECTED_BODY = (
+    b"EARLY-CONTENT that must survive the match holdback "
+    + TO.encode()
+    + b"/path LATE-CONTENT after the match completes\n"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=(
+            "Regression test for the sub_filter mid-stream CCtx-reset "
+            "truncation bug (uncoalesced backend reads)."
+        )
+    )
+    p.add_argument("--nginx-binary", required=True)
+    p.add_argument("--filter-module")
+    p.add_argument("--zstd-bin", default="zstd")
+    p.add_argument("--port", type=int, default=18096)
+    p.add_argument("--backend-port", type=int, default=18097)
+    p.add_argument(
+        "--chunk-delay",
+        type=float,
+        default=0.15,
+        help="Seconds slept between each backend send() call.",
+    )
+    p.add_argument("--repeat", type=int, default=3)
+    p.add_argument(
+        "--log-level",
+        choices=("debug", "warn"),
+        default="debug",
+        help="Location error_log level. The invocation-count harness "
+        "-integrity guard only runs at debug (it counts 'http zstd "
+        "filter' lines). Use warn under sanitizer builds: UBSAN "
+        "(-fno-sanitize-recover) fatally traps nginx core's own "
+        "debug logging, so a sanitized nginx cannot log at debug at "
+        "all -- see ci/tools/test_slow_drain.py's --log-level for the "
+        "same trap. The body round-trip assertion still runs either "
+        "way; only the coalescing self-check is skipped at warn.",
+    )
+    return p.parse_args()
+
+
+def detect_module(explicit: str | None, nginx: pathlib.Path) -> pathlib.Path:
+    if explicit:
+        return pathlib.Path(explicit)
+    sib = nginx.parent / "ngx_http_zstd_filter_module.so"
+    if sib.exists():
+        return sib
+    raise FileNotFoundError(
+        "ngx_http_zstd_filter_module.so not found next to the nginx binary; "
+        "pass --filter-module explicitly"
+    )
+
+
+def wait_port(port: int, timeout: float = 10.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), 0.5):
+                return
+        except OSError:
+            time.sleep(0.1)
+    raise RuntimeError(f"nothing listening on 127.0.0.1:{port}")
+
+
+def chunk(data: bytes) -> bytes:
+    return b"%x\r\n%s\r\n" % (len(data), data)
+
+
+def serve_one(sock: socket.socket, delay: float) -> None:
+    """Accept connections until one sends an actual request, read it, then
+    stream the three chunks as three distinct send() calls with a real
+    sleep between each -- the part Test::Nginx's tcp_reply array-send
+    cannot do. wait_port()'s own bare probe connect (no data, immediate
+    close) is skipped rather than consumed, so it never steals the one
+    real request this call is meant to serve."""
+    while True:
+        conn, _ = sock.accept()
+        conn.settimeout(10)
+        buf = b""
+        try:
+            while b"\r\n\r\n" not in buf:
+                b = conn.recv(4096)
+                if not b:
+                    break
+                buf += b
+        except OSError:
+            buf = b""
+        if not buf:
+            conn.close()
+            continue
+        break
+    try:
+        header = (
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: text/plain\r\n"
+            b"Transfer-Encoding: chunked\r\n"
+            b"Connection: close\r\n\r\n"
+        )
+        conn.sendall(header + chunk(SEG1))
+        conn.sendall(b"")  # no-op, keeps parity with syscall-per-segment intent
+        time.sleep(delay)
+        conn.sendall(chunk(SEG2))
+        time.sleep(delay)
+        conn.sendall(chunk(SEG3) + b"0\r\n\r\n")
+    finally:
+        conn.close()
+
+
+_BACKEND_SOCK: socket.socket | None = None
+
+
+def start_backend_listener(port: int) -> None:
+    """Bind+listen once, up front, so wait_port's own probe connect cannot
+    be mistaken for -- and consumed by -- a real request in serve_one()."""
+    global _BACKEND_SOCK
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", port))
+    sock.listen(8)
+    _BACKEND_SOCK = sock
+
+
+def accept_one_request(delay: float) -> threading.Thread:
+    assert _BACKEND_SOCK is not None
+    t = threading.Thread(target=serve_one, args=(_BACKEND_SOCK, delay), daemon=True)
+    t.start()
+    return t
+
+
+def http_get_raw(port: int, path: str, timeout: float = 20.0) -> bytes:
+    """GET the response and return the fully dechunked body. nginx
+    re-chunks the compressed output (the upstream sent no
+    Content-Length), so the wire body is HTTP chunked framing wrapping
+    the zstd frame, not the zstd frame itself -- urllib's HTTPResponse
+    does the dechunking so this stays a plain byte-exact comparison."""
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}",
+        headers={"Accept-Encoding": "zstd", "Connection": "close"},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"unexpected status: {resp.status}")
+        if (resp.headers.get("Content-Encoding") or "").lower() != "zstd":
+            raise RuntimeError(
+                f"missing Content-Encoding: zstd, got "
+                f"{resp.headers.get('Content-Encoding')!r}"
+            )
+        return resp.read()
+
+
+def zstd_decompress(zstd_bin: str, blob: bytes) -> bytes:
+    if blob[:4] != b"\x28\xb5\x2f\xfd":
+        raise RuntimeError(f"missing zstd magic; first 16B hex={blob[:16].hex()}")
+    r = subprocess.run(
+        [zstd_bin, "-d", "-q", "-c"], input=blob, capture_output=True, check=False
+    )
+    if r.returncode != 0:
+        raise RuntimeError(
+            "zstd -d failed: " + r.stderr.decode("utf-8", "replace").strip()
+        )
+    return r.stdout
+
+
+def count_filter_invocations(error_log: pathlib.Path) -> int:
+    if not error_log.exists():
+        return 0
+    text = error_log.read_text("utf-8", "replace")
+    return len(re.findall(r"http zstd filter", text))
+
+
+def main() -> int:
+    args = parse_args()
+    nginx = pathlib.Path(args.nginx_binary)
+    if not nginx.exists():
+        raise FileNotFoundError(f"nginx binary not found: {nginx}")
+    module = detect_module(args.filter_module, nginx)
+    if not module.exists():
+        raise FileNotFoundError(f"module not found: {module}")
+
+    with tempfile.TemporaryDirectory(prefix="zstd-subfilter-") as td:
+        root = pathlib.Path(td)
+        logs = root / "logs"
+        logs.mkdir()
+
+        lvl = args.log_level
+        conf = root / "nginx.conf"
+        conf.write_text(
+            f"""load_module {module};
+worker_processes 1;
+error_log {logs}/error.log {lvl};
+pid {root}/nginx.pid;
+events {{ worker_connections 64; }}
+http {{
+    access_log off;
+    default_type text/plain;
+    server {{
+        listen 127.0.0.1:{args.port};
+        location /filter {{
+            zstd on;
+            zstd_min_length 1;
+            zstd_types text/plain;
+            sub_filter '{FROM}' '{TO}';
+            sub_filter_once off;
+            sub_filter_types text/plain;
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_pass http://127.0.0.1:{args.backend_port}/;
+        }}
+    }}
+}}
+""",
+            encoding="utf-8",
+        )
+
+        proc = subprocess.Popen(
+            [
+                str(nginx),
+                "-p",
+                str(root),
+                "-c",
+                str(conf),
+                "-g",
+                "daemon off; master_process off;",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        try:
+            wait_port(args.port)
+            failures: list[str] = []
+            start_backend_listener(args.backend_port)
+
+            for attempt in range(1, args.repeat + 1):
+                label = f"attempt={attempt}/{args.repeat}"
+                backend_thread = accept_one_request(args.chunk_delay)
+                try:
+                    try:
+                        blob = http_get_raw(args.port, "/filter")
+                        decoded = zstd_decompress(args.zstd_bin, blob)
+                    except Exception as exc:  # noqa: BLE001
+                        failures.append(f"{label}: {exc}")
+                        continue
+                    if decoded != EXPECTED_BODY:
+                        failures.append(
+                            f"{label}: decoded body mismatch "
+                            f"(TRUNCATION/CORRUPTION): got {decoded!r}, "
+                            f"expected {EXPECTED_BODY!r}"
+                        )
+                finally:
+                    backend_thread.join(timeout=10)
+
+            invocations = -1
+            if args.log_level == "debug":
+                invocations = count_filter_invocations(logs / "error.log")
+                # This is the harness-integrity guard for this test:
+                # fewer than 2 invocations per request means the three
+                # backend sends coalesced into a single read after all
+                # (the exact failure mode that makes TEST 92 inert) and
+                # the run below proves nothing either way. Only checked
+                # at --log-level debug (see that flag's help): a
+                # sanitizer build cannot log at debug at all, so this
+                # guard is skipped there and the body round-trip
+                # assertion is the only oracle for that job.
+                min_expected = 2 * args.repeat
+                if invocations < min_expected:
+                    sys.stderr.write(
+                        f"HARNESS INTEGRITY FAILURE: only {invocations} "
+                        f"'http zstd filter' invocations logged across "
+                        f"{args.repeat} requests (need >= {min_expected}); "
+                        f"the backend chunks coalesced into fewer reads "
+                        f"than intended and this run cannot distinguish "
+                        f"the bug from a false pass.\n"
+                    )
+                    return 2
+
+            invocation_note = (
+                f"{invocations} filter invocations observed"
+                if args.log_level == "debug"
+                else "invocation count not checked at --log-level warn"
+            )
+
+            if failures:
+                sys.stderr.write(
+                    f"sub_filter/CCtx-reset regression FAILED "
+                    f"({len(failures)} failing checks), {invocation_note}:\n"
+                )
+                for f in failures[:20]:
+                    sys.stderr.write(f"  - {f}\n")
+                return 1
+
+            print(
+                f"OK: {args.repeat} sub_filter + proxy_buffering-off zstd "
+                f"responses round-tripped byte-exact across uncoalesced "
+                f"backend reads ({invocation_note})"
+            )
+            return 0
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=30)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise


### PR DESCRIPTION
> Closes the open item in memory/labs/http-zstd/issues.md, 2026-08-13: TEST 92 in ci/t/00-filter.t was landed as the regression test for the mid-stream CCtx-reset truncation bug (PR #116) but does not detect it.

## TL;DR

TEST 92 relies on Test::Nginx's `tcp_reply` array-send to model three separate upstream chunks, but the harness sleeps once before writing the whole array back to back — locally the chunks coalesce into fewer reads than the test's three delayed segments assume, so the mid-stream sync-carrier the bug needs never occurs. The test passes against both the pre-fix and fixed module and proves nothing.

Adds `ci/tools/test_sub_filter_cctx_reset.py`, wired into all three `test_proxy_unbuffered_truncation.py`-adjacent CI steps in `build-test.yml`. It reproduces the same scenario with a raw socket backend that sends each chunk as its own syscall with a real sleep between them, through `proxy_buffering off` so nginx forwards each upstream read immediately instead of coalescing them, and self-checks (by counting `"http zstd filter"` debug-log invocations) that the reads actually stayed uncoalesced before trusting the round-trip result.

**Severity:** `Low` (`test integrity — an existing regression test does not detect its own regression`)

## Why not fix TEST 92 itself, or add a unit seam

Two approaches were on the table (see issues.md). (a) Making Test::Nginx's `tcp_reply` deliver each array element as its own observed read: not achievable — `Test::Nginx::Util`'s TCP server sleeps once (`tcp_reply_delay`), then sends every array element back to back in a tight loop (`$client->send($r)` per element, no delay between them); that file is a vendored Perl module, not part of this repo. (b) A unit seam on `add_data`/`compress` instead of growing the streaming harness: the `cctx_ready` latch this bug's fix touches lives on `ngx_http_zstd_ctx_t`, wired into the full request/pool/module-context lifecycle, not a pure function like the Accept-Encoding parser `ci/tests/unit/` already isolates — building a fake `ngx_http_request_t` + body-filter chain harness from scratch would be a heavier lift than the existing streaming layer, not a lighter one.

`ci/tools/test_proxy_unbuffered_truncation.py` already proves the pattern this PR reuses: a Python backend driving a real built nginx over raw sockets gives exact control over syscall boundaries that Test::Nginx's declarative fixtures cannot express.

## Testing

Both-ways negative control, run locally (5 repeats each, no flakes):

```
$ python3 ci/tools/test_sub_filter_cctx_reset.py --nginx-binary <de4ced9 nginx> \
    --filter-module <de4ced9 ngx_http_zstd_filter_module.so> --port 18896 --backend-port 18897 --repeat 5
sub_filter/CCtx-reset regression FAILED (5 failing checks), 20 filter invocations observed:
  - attempt=1/5: zstd -d failed: /*stdin*\ : Decoding error (36) : Data corruption detected
  - attempt=2/5: zstd -d failed: /*stdin*\ : Decoding error (36) : Data corruption detected
  ... (5/5)

$ python3 ci/tools/test_sub_filter_cctx_reset.py --nginx-binary <master nginx> --port 18796 --backend-port 18797 --repeat 5
OK: 5 sub_filter + proxy_buffering-off zstd responses round-tripped byte-exact across uncoalesced backend reads (20 filter invocations observed)
```

20 invocations across 5 requests (4/request) confirms the reads did not coalesce in either arm, so the FAIL/PASS split reflects the actual bug, not a harness artifact. `de4ced9` is the true pre-#116 filter source, built against nginx 1.31.4.

`review-lint.sh --branch master`: clean (ruff/mypy/bandit/vulture/yamllint/actionlint/zizmor/gitleaks/trufflehog/codespell/lizard/jscpd/semgrep/trivy/checkov/ast-grep). The pre-existing bandit/semgrep `urlopen` advisory on a fixed localhost f-string matches the identical pattern already in `test_proxy_unbuffered_truncation.py` and `test_slow_drain.py`, unsuppressed there too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for streaming responses compressed with zstd when content filtering resets compression context mid-response.
  * Verifies response headers, decompressed content, repeated requests, delayed backend chunks, and correct handling across standard, sanitizer, and coverage test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->