### PR TITLE
ci: gate heavy build lanes behind validation

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -279,7 +279,7 @@ jobs:
     name: Build (${{ matrix.flavor }})
     runs-on: ${{ fromJSON(vars.POOL || '["ubuntu-latest"]') }}
     timeout-minutes: 30
-    needs: resolve
+    needs: [resolve, validation]
     strategy:
       fail-fast: false
       # nginx mainline, assembled by the resolve job.
@@ -672,7 +672,7 @@ jobs:
     name: Dynamic-module linkage isolation
     runs-on: ${{ fromJSON(vars.POOL || '["ubuntu-latest"]') }}
     timeout-minutes: 15
-    needs: resolve
+    needs: [resolve, validation]
     env:
       NGINX_VERSION: ${{ needs.resolve.outputs.nginx_version }}
 
@@ -915,7 +915,7 @@ jobs:
     name: compression_vary interop (real module)
     runs-on: ${{ fromJSON(vars.POOL || '["ubuntu-latest"]') }}
     timeout-minutes: 15
-    needs: resolve
+    needs: [resolve, validation]
     env:
       NGINX_VERSION: ${{ needs.resolve.outputs.nginx_version }}
       # HanadaLee/ngx_http_compression_vary_filter_module, pinned by
@@ -1082,7 +1082,7 @@ jobs:
     name: Build ASAN+UBSAN
     runs-on: ${{ fromJSON(vars.POOL || '["ubuntu-latest"]') }}
     timeout-minutes: 30
-    needs: resolve
+    needs: [resolve, validation]
 
     env:
       # Resolved mainline nginx — feeds the cache keys, download and the
@@ -1710,7 +1710,7 @@ jobs:
     name: Coverage (gcov/lcov)
     runs-on: ${{ fromJSON(vars.POOL || '["ubuntu-latest"]') }}
     timeout-minutes: 20
-    needs: resolve
+    needs: [resolve, validation]
     env:
       NGINX_VERSION: ${{ needs.resolve.outputs.nginx_version }}
       # This job's own Test::Nginx port band -- see ci/tools/max-port.sh.


### PR DESCRIPTION
> Step 29 of the CI restructure. Independent of the remaining lane item, which
> is blocked on a GitHub Actions platform limit (no job-level `needs:` across a
> reusable-workflow-call boundary).

## TL;DR

The build jobs all started at the same moment as the linting job, so a run whose
lint step was going to fail still spent every available machine compiling first.
Now the builds wait for linting to pass, and a bad branch is rejected after one
cheap job instead of six expensive ones.

`build`, `linkage`, `cvary-interop`, `build-asan` and `coverage` change from
`needs: resolve` to `needs: [resolve, validation]`.

**Severity:** `Low` (`ci-efficiency — six-job fan-out contends for six real runner slots`)

## Mechanism

`resolve` and `validation` both start at t=0. `resolve` is a short version
lookup, so it finishes early and released a six-job wave —
`build` (matrix), `build-old-libzstd`, `linkage`, `cvary-interop`, `build-asan`
and `coverage` — against a pool of six real slots. `validation` was still
running at that point, so its actionlint/shellcheck/cppcheck/scan-build failures
could only ever arrive after the builders had already been dispatched.

`build-old-libzstd` was the only job already laned this way. This PR gives the
other five the same dependency.

## Why no `if:` term is owed

`build-old-libzstd` carries `if: ${{ !cancelled() && needs.resolve.result == 'success' }}`,
which is required precisely *because* it has an `if:` — an `if:` on a job
overrides the default skip for every one of its dependencies. None of the five
jobs changed here has an `if:`, so the default semantics apply: a failed or
skipped `validation` skips them, with no explicit `needs.<id>.result` term
needed.

## Required contexts

The 13 required contexts on ruleset 16557047 are keyed on `<caller job> / <job
name>`. This diff changes only `needs:` — no workflow name, no caller job name,
no `name:` field — so every context still reports and none is orphaned.

## Testing

`actionlint` clean (rc=0). `zizmor --persona=auditor` v1.26.1: "No findings to
report". Full `review-lint.sh --branch master` roster clean; the yamllint
line-length warnings it prints are on pre-existing lines untouched by this diff.
Remote CI on this PR is the real check — it exercises the new ordering directly.
