### PR TITLE
security(dcz): fail closed on duplicate negotiation headers

### DIFF
--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -63,8 +63,20 @@ on:
           - build-flavors
           - scanners
 
+# A long soak is often the ONLY evidence for a finding: fuzz is capped at
+# 600 minutes, memcheck and helgrind at 240. Keying the group on the job
+# selection (and on the run id for the scheduled run) keeps a targeted
+# dispatch -- e.g. `jobs=scanners`, a ~2 minute job, the documented common
+# case above -- from cancelling an in-flight monthly cron run on the same
+# ref and destroying hours of soak with no artifact. Two dispatches of the
+# SAME selection still coalesce, which is the only case where cancelling is
+# the intended behaviour.
 concurrency:
-  group: ci-deep-${{ github.workflow }}-${{ github.ref }}
+  group: >-
+    ci-deep-${{ github.workflow }}-${{ github.ref
+    }}-${{ github.event_name == 'schedule'
+    && format('schedule-{0}', github.run_id)
+    || format('dispatch-{0}', inputs.jobs || 'all') }}
   cancel-in-progress: true
 
 permissions:

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,23 @@
 Changes with http-zstd
 
+    *) Security: the dcz cross-origin gate could be bypassed by a
+       duplicate request header. Sec-Fetch-Site and Available-Dictionary
+       are not in nginx's known-header table, so nginx chains duplicate
+       occurrences rather than rejecting them, and this module evaluated
+       only the first. A request carrying "Sec-Fetch-Site: same-origin"
+       ahead of the client's real "cross-site" therefore passed the RFC
+       9842 section 8.3 same-origin partitioning check, and the response
+       was compressed against a dictionary that must not be used
+       cross-site. Both headers are now counted and dcz falls back to
+       plain zstd when either appears more than once.
+       Affects only configurations using zstd_dcz_dict_file, which is
+       new in this release and not present in 0.90.8 or earlier, so no
+       released version is vulnerable. Reaching it also requires an
+       intermediary that merges or forwards a client-supplied duplicate
+       header, or a request-smuggling desync; a browser cannot trigger
+       it alone. Found during this release's audit, not reported
+       externally, so no CVE is assigned.
+
     *) Change: the repository adopted the myguard nginx-module skeleton
        standard. CI material moved under ci/ (t/, tests/unit/, tools/,
        fuzz/, linter/), the module sources moved to src/, and .github/

--- a/ci/t/03-dcz.t
+++ b/ci/t/03-dcz.t
@@ -590,3 +590,74 @@ GET /t
 hashed=1
 --- no_error_log
 [error]
+
+
+
+=== TEST 24: duplicate Sec-Fetch-Site fails closed
+# The §8.3 cross-origin gate must not be decided by whichever line sorts
+# first. Sec-Fetch-Site is not in nginx's headers_in table, so duplicates
+# are chained rather than rejected and reach the module; a proxy that
+# merges a client-supplied duplicate, or a smuggling desync, could
+# otherwise prepend an agreeable value and switch the gate off. A browser
+# never sends two, so more than one falls back to plain zstd.
+--- config
+    location /t {
+        zstd on;
+        zstd_min_length 16;
+        zstd_dcz_dict_file $TEST_NGINX_PERL_PATH/suite/dcz-dict;
+        default_type text/plain;
+        return 200 "dcz negotiation body: shared-boilerplate compute render\n";
+    }
+--- request
+GET /t
+--- more_headers eval
+"Accept-Encoding: zstd, dcz\nAvailable-Dictionary: :$::dict_b64:\nSec-Fetch-Site: same-origin\nSec-Fetch-Site: cross-site"
+--- response_headers
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 25: duplicate Sec-Fetch-Site fails closed regardless of order
+# The cross-site line first: still plain zstd, so the result does not
+# depend on which duplicate the lookup happens to reach.
+--- config
+    location /t {
+        zstd on;
+        zstd_min_length 16;
+        zstd_dcz_dict_file $TEST_NGINX_PERL_PATH/suite/dcz-dict;
+        default_type text/plain;
+        return 200 "dcz negotiation body: shared-boilerplate compute render\n";
+    }
+--- request
+GET /t
+--- more_headers eval
+"Accept-Encoding: zstd, dcz\nAvailable-Dictionary: :$::dict_b64:\nSec-Fetch-Site: cross-site\nSec-Fetch-Site: same-origin"
+--- response_headers
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 26: duplicate Available-Dictionary fails closed
+# Same reasoning: a single-valued structured field, not deduplicated by
+# nginx. Two of them is not a browser, and picking the first would let a
+# second dictionary hash be smuggled past the operator's expectation.
+--- config
+    location /t {
+        zstd on;
+        zstd_min_length 16;
+        zstd_dcz_dict_file $TEST_NGINX_PERL_PATH/suite/dcz-dict;
+        default_type text/plain;
+        return 200 "dcz negotiation body: shared-boilerplate compute render\n";
+    }
+--- request
+GET /t
+--- more_headers eval
+"Accept-Encoding: zstd, dcz\nAvailable-Dictionary: :$::dict_b64:\nAvailable-Dictionary: :$::dict_b64:\nSec-Fetch-Site: same-origin"
+--- response_headers
+Content-Encoding: zstd
+--- no_error_log
+[error]

--- a/ci/tools/soak.sh
+++ b/ci/tools/soak.sh
@@ -31,6 +31,18 @@ head -c 200000 /dev/urandom | base64 >"$WORK/html/medium"
 head -c 4000000 /dev/urandom | base64 >"$WORK/html/large"
 printf 'AAAAAAAAAA%.0s' $(seq 1 20000) >"$WORK/html/compressible"
 
+# RFC 9842 dcz dictionary. The soak previously sent only zstd/gzip, so the
+# whole dcz path -- negotiation, ZSTD_CCtx_refPrefix, the 40-byte frame
+# header, dictionary lifetime across requests -- ran under NEITHER sanitizer
+# lane despite being the newest and largest block of code in the module.
+# The dictionary content overlaps the response bodies below so refPrefix has
+# real matches to find rather than compressing a miss.
+printf 'shared-boilerplate compute render %.0s' $(seq 1 200) \
+    >"$WORK/html/dcz-dict"
+DICT_B64="$(openssl dgst -sha256 -binary "$WORK/html/dcz-dict" | base64)"
+printf 'shared-boilerplate compute render %.0s' $(seq 1 400) \
+    >"$WORK/html/dczbody"
+
 cat >"$WORK/conf/nginx.conf" <<EOF
 daemon off;
 master_process on;
@@ -51,6 +63,13 @@ http {
             zstd_max_length 8m;
             zstd_types text/plain;
         }
+        location /dcz {
+            zstd on;
+            zstd_min_length 100;
+            zstd_types text/plain;
+            zstd_dcz_dict_file $WORK/html/dcz-dict;
+            alias $WORK/html/dczbody;
+        }
         location /bypass {
             zstd on;
             zstd_min_length 1;
@@ -61,6 +80,8 @@ http {
     }
 }
 EOF
+
+export DICT_B64
 
 ASAN_OPTIONS="${ASAN_OPTIONS:-}:detect_leaks=1:abort_on_error=1:exitcode=42:log_path=$WORK/logs/asan"
 export ASAN_OPTIONS
@@ -110,7 +131,7 @@ fail=0
 worker() {
     local wid="$1"
     local paths=(/tiny /medium /large /compressible
-        "/bypass" "/bypass?nozstd=1")
+        "/bypass" "/bypass?nozstd=1" /dcz)
     local i=0 ok=0 bad=0
     while [ "$(date +%s)" -lt "$END" ]; do
         p=${paths[$((RANDOM % ${#paths[@]}))]}
@@ -118,14 +139,41 @@ worker() {
         ae=$([ $((RANDOM % 4)) -eq 0 ] && echo "gzip" || echo "zstd")
         i=$((i + 1))
         body="$WORK/r.${wid}.${i}"
-        if curl -fsS -H "Accept-Encoding: $ae" \
+        # /dcz alternates between a request that negotiates dcz and one that
+        # does not, so both the refPrefix path and the plain-zstd fallback
+        # out of the same location run under the sanitizer.
+        hdrs=(-H "Accept-Encoding: $ae")
+        if [ "$p" = "/dcz" ] && [ $((RANDOM % 2)) -eq 0 ]; then
+            hdrs=(-H "Accept-Encoding: zstd, dcz"
+                  -H "Available-Dictionary: :${DICT_B64}:"
+                  -H "Sec-Fetch-Site: same-origin")
+        fi
+        if curl -fsS "${hdrs[@]}" \
             "http://127.0.0.1:18222$p" -o "$body" 2>/dev/null; then
             # If it came back zstd-encoded, it must decode cleanly.
-            if head -c4 "$body" | od -An -tx1 | grep -q '28 b5 2f fd'; then
+            #
+            # A dcz response starts with the skippable-frame magic
+            # 5e2a4d18, NOT 28b52ffd, so testing only for the zstd magic
+            # would let every dcz response fall through to the unchecked
+            # else-branch and count as ok without ever being decoded --
+            # a green soak that proves nothing about the path it was
+            # extended to cover. Decode dcz against the same dictionary
+            # the request advertised: that verifies the frame header, the
+            # refPrefix output and the dictionary content all agree.
+            magic="$(head -c4 "$body" | od -An -tx1 | tr -d ' ')"
+            if [ "$magic" = "28b52ffd" ]; then
                 if zstd -dq -c "$body" >/dev/null 2>&1; then
                     ok=$((ok + 1))
                 else
                     echo "BAD zstd $p"
+                    bad=$((bad + 1))
+                fi
+            elif [ "$magic" = "5e2a4d18" ]; then
+                if zstd -dq -D "$WORK/html/dcz-dict" -c "$body" \
+                    >/dev/null 2>&1; then
+                    ok=$((ok + 1))
+                else
+                    echo "BAD dcz $p"
                     bad=$((bad + 1))
                 fi
             else

--- a/ci/tools/soak.sh
+++ b/ci/tools/soak.sh
@@ -132,7 +132,7 @@ worker() {
     local wid="$1"
     local paths=(/tiny /medium /large /compressible
         "/bypass" "/bypass?nozstd=1" /dcz)
-    local i=0 ok=0 bad=0
+    local i=0 ok=0 bad=0 dcz_seen=0
     while [ "$(date +%s)" -lt "$END" ]; do
         p=${paths[$((RANDOM % ${#paths[@]}))]}
         # Vary Accept-Encoding incl. clients that do not support zstd.
@@ -142,8 +142,21 @@ worker() {
         # /dcz alternates between a request that negotiates dcz and one that
         # does not, so both the refPrefix path and the plain-zstd fallback
         # out of the same location run under the sanitizer.
+        #
+        # The FIRST iteration always sends the negotiating variant, and
+        # dcz_seen below records that a dcz frame actually came back. Both
+        # the path pick and the alternation are random, so without that the
+        # worker could take a short duration or an unlucky seed and send no
+        # dcz request at all -- and worse, a dcz regression that silently
+        # served plain zstd would decode fine in the 28b52ffd branch and
+        # keep the soak green. Coverage that can quietly stop covering is
+        # the same trap this oracle was extended to close, one level up.
+        dcz_want=0
         hdrs=(-H "Accept-Encoding: $ae")
-        if [ "$p" = "/dcz" ] && [ $((RANDOM % 2)) -eq 0 ]; then
+        if [ "$i" -eq 1 ] || { [ "$p" = "/dcz" ] && [ $((RANDOM % 2)) -eq 0 ]; }
+        then
+            p=/dcz
+            dcz_want=1
             hdrs=(-H "Accept-Encoding: zstd, dcz"
                   -H "Available-Dictionary: :${DICT_B64}:"
                   -H "Sec-Fetch-Site: same-origin")
@@ -172,12 +185,27 @@ worker() {
                 if zstd -dq -D "$WORK/html/dcz-dict" -c "$body" \
                     >/dev/null 2>&1; then
                     ok=$((ok + 1))
+                    dcz_seen=$((dcz_seen + 1))
                 else
                     echo "BAD dcz $p"
                     bad=$((bad + 1))
                 fi
+            elif [ "$dcz_want" -eq 1 ]; then
+                # Asked for dcz with a matching dictionary and a
+                # same-origin fetch, and got something that is neither a
+                # dcz frame nor a zstd frame.
+                echo "BAD dcz $p: negotiated request returned magic $magic"
+                bad=$((bad + 1))
             else
                 ok=$((ok + 1))
+            fi
+
+            # A negotiated request that came back as a plain zstd frame is
+            # a dcz regression, not a pass: the gate silently declined and
+            # the 28b52ffd branch above would otherwise have accepted it.
+            if [ "$dcz_want" -eq 1 ] && [ "$magic" = "28b52ffd" ]; then
+                echo "BAD dcz $p: negotiated request fell back to plain zstd"
+                bad=$((bad + 1))
             fi
         else
             echo "FAIL request $p (curl exit $?)"
@@ -185,7 +213,11 @@ worker() {
         fi
         rm -f "$body"
     done
-    echo "worker $wid: $ok ok, $bad bad/failed"
+    echo "worker $wid: $ok ok, $bad bad/failed, $dcz_seen dcz"
+    if [ "$dcz_seen" -eq 0 ]; then
+        echo "FAIL worker $wid: no dcz response was ever verified"
+        return 1
+    fi
     [ "$bad" -eq 0 ] && [ "$ok" -gt 0 ]
 }
 

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -302,7 +302,7 @@ static void ngx_http_zstd_cleanup_cctx(void *data);
 static char *ngx_http_zstd_dcz_dict_file(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 static ngx_table_elt_t *ngx_http_zstd_find_request_header(
-    ngx_http_request_t *r, const char *name, size_t len);
+    ngx_http_request_t *r, const char *name, size_t len, ngx_uint_t *count);
 static ngx_http_zstd_dcz_dict_t *ngx_http_zstd_dcz_negotiate(
     ngx_http_request_t *r, ngx_http_zstd_loc_conf_t *zlcf);
 static ngx_int_t ngx_http_zstd_filter_emit_dcz_header(ngx_http_request_t *r,
@@ -730,16 +730,32 @@ ngx_http_zstd_header_filter(ngx_http_request_t *r)
  * walk — both headers appear at most once and only on dictionary-aware
  * requests, so a hashed lookup buys nothing here.
  */
+/*
+ * Find a request header by name. Neither header this is used for
+ * (Available-Dictionary, Sec-Fetch-Site) appears in nginx's
+ * ngx_http_headers_in table, so neither gets ngx_http_process_unique_
+ * header_line's duplicate rejection: a request may legitimately reach a
+ * module carrying two of them, and a plain first-match lookup would let
+ * whichever line sorts first decide the outcome. Both are single-valued
+ * by their specifications and a browser never sends either twice, so
+ * `*count` reports how many occurrences exist and the dcz caller fails
+ * closed on more than one -- for Sec-Fetch-Site that check is the RFC
+ * 9842 SS8.3 cross-origin partitioning gate, and a proxy that merges or
+ * forwards a client-supplied duplicate, or a request-smuggling desync,
+ * must not be able to turn it off by prepending an agreeable value.
+ */
 static ngx_table_elt_t *
 ngx_http_zstd_find_request_header(ngx_http_request_t *r, const char *name,
-    size_t len)
+    size_t len, ngx_uint_t *count)
 {
     ngx_uint_t        i;
     ngx_list_part_t  *part;
-    ngx_table_elt_t  *h;
+    ngx_table_elt_t  *h, *found;
 
     part = &r->headers_in.headers.part;
     h = part->elts;
+    found = NULL;
+    *count = 0;
 
     for (i = 0; ; i++) {
 
@@ -756,11 +772,15 @@ ngx_http_zstd_find_request_header(ngx_http_request_t *r, const char *name,
         if (h[i].key.len == len
             && ngx_strncasecmp(h[i].key.data, (u_char *) name, len) == 0)
         {
-            return &h[i];
+            (*count)++;
+
+            if (found == NULL) {
+                found = &h[i];
+            }
         }
     }
 
-    return NULL;
+    return found;
 }
 
 
@@ -794,7 +814,7 @@ ngx_http_zstd_dcz_negotiate(ngx_http_request_t *r,
 {
     u_char                     buf[48];
     ngx_str_t                  b64, decoded;
-    ngx_uint_t                 i;
+    ngx_uint_t                 i, nheaders;
     ngx_table_elt_t           *h, *ae;
     ngx_http_zstd_dcz_dict_t  *dicts;
 
@@ -806,14 +826,30 @@ ngx_http_zstd_dcz_negotiate(ngx_http_request_t *r,
         return NULL;
     }
 
+    /*
+     * Accept-Encoding is in nginx's headers_in table, so duplicate lines
+     * are chained on ae->next rather than rejected. Only the first line's
+     * value is evaluated here -- byte-for-byte what nginx's own gzip
+     * filter does, so this is upstream parity rather than a gap: a client
+     * splitting its codings across two header lines has the second line
+     * ignored and falls back to plain zstd, which is the safe direction.
+     */
     ae = r->headers_in.accept_encoding;
     if (ae == NULL) {
         return NULL;
     }
 
     h = ngx_http_zstd_find_request_header(r, "available-dictionary",
-                                          sizeof("available-dictionary") - 1);
+                                          sizeof("available-dictionary") - 1,
+                                          &nheaders);
     if (h == NULL) {
+        return NULL;
+    }
+
+    if (nheaders > 1) {
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "zstd dcz: skip, %ui Available-Dictionary headers",
+                       nheaders);
         return NULL;
     }
 
@@ -848,7 +884,20 @@ ngx_http_zstd_dcz_negotiate(ngx_http_request_t *r,
     }
 
     h = ngx_http_zstd_find_request_header(r, "sec-fetch-site",
-                                          sizeof("sec-fetch-site") - 1);
+                                          sizeof("sec-fetch-site") - 1,
+                                          &nheaders);
+
+    /*
+     * More than one Sec-Fetch-Site is never a browser and cannot be
+     * evaluated: fail closed rather than trust the first line.
+     */
+    if (nheaders > 1) {
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "zstd dcz: skip, %ui Sec-Fetch-Site headers",
+                       nheaders);
+        return NULL;
+    }
+
     if (h != NULL
         && !(h->value.len == sizeof("same-origin") - 1
              && ngx_strncasecmp(h->value.data, (u_char *) "same-origin",
@@ -962,6 +1011,17 @@ ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
         ngx_chain_update_chains(r->pool, &ctx->free, &ctx->busy, &cl,
                                 (ngx_buf_tag_t) &ngx_http_zstd_filter_module);
+
+        /*
+         * Same reason as the invalidation after the other
+         * ngx_chain_update_chains() below: the buffer ctx->out_buf points
+         * at may have just been recycled onto the free chain. Reaching
+         * here with a stale non-NULL out_buf is currently unreachable --
+         * it would need get_buf's top guard to fail, which requires a
+         * memzero'd buffer_out -- but that argument spans three functions
+         * and a future edit should not have to re-derive it to stay safe.
+         */
+        ctx->out_buf = NULL;
 
         flush = 0;
         ctx->nomem = 0;

--- a/src/ngx_http_zstd_sha256.h
+++ b/src/ngx_http_zstd_sha256.h
@@ -196,7 +196,16 @@ ngx_http_zstd_sha256_final(ngx_http_zstd_sha256_t *c,
 
     bits = c->total * 8;
 
-    /* padding: 0x80, zeros, then the 64-bit big-endian bit length */
+    /*
+     * padding: 0x80, zeros, then the 64-bit big-endian bit length.
+     *
+     * The append below is unguarded because update() never returns with a
+     * full block: it compresses and resets block_len to 0 the moment the
+     * block fills, so block_len is in [0, 63] on entry here and writing
+     * block[block_len] stays in bounds. Keep that invariant if update()
+     * is ever restructured -- an entry with block_len == 64 would write
+     * one past the array before the bounds test below runs.
+     */
     c->block[c->block_len++] = 0x80;
 
     if (c->block_len > 56) {


### PR DESCRIPTION
> Found while auditing the 53 commits between `0.90.8` and `bdadb06` for release. Three findings from that pass; the header one is a security fix, the other two are gaps in what our own analysis lanes were actually testing.

## TL;DR

Browsers can now be handed a compression dictionary — a chunk of common text kept on the client so repeated pages can be sent as little more than "same as before, with these edits". That only stays safe while a dictionary picked up on one site cannot be used to compress a response from another, and the request carries a header saying which site asked. We were reading only the first copy of that header, so anyone able to add a second copy in front of it could answer for the browser and get a dictionary used where it should not have been.

`ngx_http_zstd_find_request_header()` returned the first match and ignored the rest, so a duplicate `Sec-Fetch-Site` decided the RFC 9842 §8.3 cross-origin partitioning gate. Both dcz call sites now count occurrences and fail closed on more than one.

**Severity:** `Medium` (`security — cross-origin dictionary reuse, requires a header-injecting intermediary`)

## Why the first match was the wrong one

Neither `Sec-Fetch-Site` nor `Available-Dictionary` appears in nginx's `ngx_http_headers_in` table (`src/http/ngx_http_request.c`). That table is what routes a known header to `ngx_http_process_unique_header_line`, which is the thing that rejects duplicates with a 400. Miss the table, and you get `ngx_http_process_header_line` semantics instead: nginx chains every copy onto `r->headers_in.headers` and hands the module all of them, complaining about none.

Our lookup walked that list and returned on the first key match. So for a request carrying

```http
Sec-Fetch-Site: same-origin
Sec-Fetch-Site: cross-site
```

the gate saw `same-origin` and compressed the response against the dictionary. The second line — the honest one, in the scenario where a browser sent it and something prepended the first — never got looked at.

Reaching this needs an intermediary that merges or forwards a client-supplied duplicate, or a request-smuggling desync; it is not reachable by a browser on its own. That is why this is Medium rather than High. It is still the only control standing between a cross-site response and a same-origin dictionary, and a gate that can be switched off by prepending a nicer value is not a gate.

Both headers are single-valued by their specs and no browser sends either twice, so treating "more than one" as "cannot evaluate this" costs a fallback to plain zstd and nothing else.

## The soaks were green on code they never ran

`ci/tools/soak.sh` sent `Accept-Encoding: zstd` or `gzip`, and nothing else. dcz negotiation, `ZSTD_CCtx_refPrefix`, the 40-byte frame header and dictionary lifetime across requests therefore ran under **neither** the ASan/UBSan lane nor the memcheck lane — the newest and largest block of code in the module, with two dynamic-analysis lenses pointed slightly to the left of it.

The soak now serves a `/dcz` location and alternates negotiated and non-negotiated requests against it.

Extending the traffic was the easy half. The response oracle also had to change: a dcz response starts with the skippable-frame magic `5e2a4d18`, not `28b52ffd`, so the existing check would have dropped every dcz response into the unchecked `else` branch and counted it `ok` without decoding it. That is the failure mode where you add coverage, watch it go green, and have proved nothing about the path you added it for. dcz responses are now decoded against the dictionary the request advertised, which checks the frame header, the refPrefix output and the dictionary content agree.

## `ci-deep` cancelled its own soaks

The concurrency group keyed on `github.workflow` and `github.ref` with `cancel-in-progress: true`. Dispatching `jobs=scanners` — about two minutes, and the case the input's own comment calls typical — cancelled an in-flight monthly cron run on the same ref. `fuzz` is capped at 600 minutes and `memcheck`/`helgrind` at 240, and a soak is frequently the only evidence a finding ever had, so that trade was hours of runtime for a two-minute job, with no artifact left behind.

The group now includes the job selection, and the run id for the scheduled run. Two dispatches of the same selection still coalesce, which was the only case where cancelling was wanted.

## Also in this diff

Two invariants this audit had to reconstruct by hand, now written down where the next reader will be standing:

- `ngx_http_zstd_sha256_final()` appends `0x80` before its bounds test, which is safe only because `update()` never returns with a full block. That is a real invariant in another function, not a local one.
- Reading only the first `Accept-Encoding` line is deliberate parity with nginx's own gzip filter, not an oversight.

And `ctx->out_buf = NULL` after the nomem-recovery `ngx_chain_update_chains()`, matching its sibling call. Currently unreachable — getting there needs `get_buf`'s top guard to fail, which needs a memzero'd `buffer_out` — but that argument spans three functions, and the sibling call site documents the same invalidation as mandatory.

## Testing

Everything below ran locally on this branch against nginx 1.31.4.

- **TAP suite: 1663/1663.** 1654 existing plus 9 new in `ci/t/03-dcz.t` (TEST 24-26).
- **Negative control, both directions.** Against the pre-fix binary, TEST 24 and TEST 26 fail — the module answered `Content-Encoding: dcz` to a request with `Sec-Fetch-Site: cross-site` appended after `same-origin`. Against the fixed binary, all pass. TEST 25 passes either way by construction: it puts the cross-site value first, where first-match already refused. Kept anyway, because it pins the result as order-independent, which is the property that actually matters.
- **Oracle negative control.** The new dcz decode check was verified to reject a corrupted frame (`rc=1`) and a wrong dictionary (`rc=1`) before being trusted.
- **ASan+UBSan soak:** 60s @ 4 concurrent, 18687 requests, clean, dcz exercised.
- **Valgrind memcheck soak:** 60s @ 4 concurrent, 6265 requests, clean, zero suppressions, dcz exercised.
- **Fuzz:** 15.9M runs on `fuzz_accept_encoding`, no crashes, leaks or timeouts.
- **Artifact:** `abidiff --harmless` against the `0.90.8` build reports no ABI change for either module; module signature `8,4,8,0000111111010111001110111111100110` matches the target nginx binary, both modules load under `nginx -t`; `checksec` identical to `0.90.8`.
- **Linters:** `review-lint.sh --diff HEAD` clean, all four TUs parsed by clang-tidy, no coverage-gap block. `actionlint` and `zizmor` clean on the workflow.

## Known gap

There is no fuzz harness for the dcz header parsing — `Available-Dictionary` base64 decoding and the hash compare. Both are bounds-verified by reading (`h->value.len - 2 > 44` evaluated after the `len >= 2` check, decoding at most 33 bytes into a 48-byte buffer, and a full 32-byte `ngx_memcmp`), and the input space is narrow, so this is not blocking the release. Filed as a roadmap item rather than fixed here, to keep this diff on one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dcz content negotiation by safely rejecting requests with duplicate security or dictionary headers.
  * Fixed a response-processing issue that could cause stale buffer references during memory-constrained operations.
  * Ensured duplicate headers consistently fall back to standard zstd handling when appropriate.

* **Tests**
  * Expanded coverage for dcz negotiation, fallback behavior, dictionary responses, and sustained request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->