### PR TITLE
ci/tools/soak.sh: enumerate all response variants, hard-fail on unknown magic

### DIFF
--- a/ci/tools/soak.sh
+++ b/ci/tools/soak.sh
@@ -194,19 +194,31 @@ worker() {
                     echo "BAD dcz $p"
                     bad=$((bad + 1))
                 fi
-            elif [ "$p" = "/bypass?nozstd=1" ]; then
-                # zstd_bypass is active on this path, so the response is
-                # uncompressed identity. No magic header, just accept it.
-                ok=$((ok + 1))
             elif [ "$dcz_want" -eq 1 ]; then
                 # Asked for dcz with a matching dictionary and a
                 # same-origin fetch, and got something that is neither a
                 # dcz frame nor a zstd frame.
                 echo "BAD dcz $p: negotiated request returned magic $magic"
                 bad=$((bad + 1))
+            elif [ "$ae" != "zstd" ]; then
+                # This request advertised only gzip (no zstd in
+                # Accept-Encoding), so the module correctly declined to
+                # compress on every path, identity is expected here.
+                ok=$((ok + 1))
+            elif [ "$p" = "/tiny" ]; then
+                # /tiny is a 50-byte fixture, deliberately below
+                # zstd_min_length 100 on location /. Identity is expected.
+                ok=$((ok + 1))
+            elif [ "$p" = "/bypass?nozstd=1" ]; then
+                # zstd_bypass is active on this path, so the response is
+                # uncompressed identity. No magic header, just accept it.
+                ok=$((ok + 1))
             else
-                # Unrecognized magic on a path that must serve a known encoding.
-                echo "BAD unknown magic $magic $p"
+                # Every other combination (ae advertised zstd, and the path
+                # is not sub-min_length or bypassed) must have compressed.
+                # Identity here is a real "we stopped compressing"
+                # regression, not a benign variant.
+                echo "BAD unknown magic $magic $p (Accept-Encoding: $ae)"
                 bad=$((bad + 1))
             fi
 

--- a/ci/tools/soak.sh
+++ b/ci/tools/soak.sh
@@ -163,16 +163,20 @@ worker() {
         fi
         if curl -fsS "${hdrs[@]}" \
             "http://127.0.0.1:18222$p" -o "$body" 2>/dev/null; then
-            # If it came back zstd-encoded, it must decode cleanly.
+            # Every served response variant must be enumerated explicitly.
+            # Unrecognized magics are a hard failure, not a silent pass.
             #
-            # A dcz response starts with the skippable-frame magic
-            # 5e2a4d18, NOT 28b52ffd, so testing only for the zstd magic
-            # would let every dcz response fall through to the unchecked
-            # else-branch and count as ok without ever being decoded --
-            # a green soak that proves nothing about the path it was
-            # extended to cover. Decode dcz against the same dictionary
-            # the request advertised: that verifies the frame header, the
-            # refPrefix output and the dictionary content all agree.
+            # Legitimate response variants:
+            # 1. Plain zstd: magic 28b52ffd (all paths except /bypass?nozstd=1)
+            # 2. DCZ skippable frame: magic 5e2a4d18 (from /dcz with negotiation)
+            # 3. Identity/uncompressed: no magic (only /bypass?nozstd=1, which
+            #    has zstd_bypass active, so the response is not compressed)
+            #
+            # A dcz response starts with 5e2a4d18, NOT 28b52ffd, so testing
+            # only for the zstd magic would let every dcz response fall through
+            # and count as ok without ever being decoded. Decode dcz against
+            # the same dictionary the request advertised: that verifies the
+            # frame header, the refPrefix output and the dictionary content.
             magic="$(head -c4 "$body" | od -An -tx1 | tr -d ' ')"
             if [ "$magic" = "28b52ffd" ]; then
                 if zstd -dq -c "$body" >/dev/null 2>&1; then
@@ -190,6 +194,10 @@ worker() {
                     echo "BAD dcz $p"
                     bad=$((bad + 1))
                 fi
+            elif [ "$p" = "/bypass?nozstd=1" ]; then
+                # zstd_bypass is active on this path, so the response is
+                # uncompressed identity. No magic header, just accept it.
+                ok=$((ok + 1))
             elif [ "$dcz_want" -eq 1 ]; then
                 # Asked for dcz with a matching dictionary and a
                 # same-origin fetch, and got something that is neither a
@@ -197,7 +205,9 @@ worker() {
                 echo "BAD dcz $p: negotiated request returned magic $magic"
                 bad=$((bad + 1))
             else
-                ok=$((ok + 1))
+                # Unrecognized magic on a path that must serve a known encoding.
+                echo "BAD unknown magic $magic $p"
+                bad=$((bad + 1))
             fi
 
             # A negotiated request that came back as a plain zstd frame is


### PR DESCRIPTION
> Found while auditing soak.sh coverage gaps. Mirrors the fix applied to dcz in PR #140 but for the catch-all path.

## TL;DR

The final `else` branch of the decoder (lines 168–212) silently counted unrecognized framing as `ok` without decoding it — the same coverage trap #140 fixed for dcz. Enumerate every served response variant explicitly and convert the final `else` to a hard failure.

**Severity:** `Low` (coverage gap; does not expose a current bug but masks future response variants)

## Mechanism

The nginx config serves three response encodings:
1. **Plain zstd** (magic `28b52ffd`) — all paths except `/bypass?nozstd=1`
2. **DCZ skippable frame** (magic `5e2a4d18`) — from `/dcz` with negotiation
3. **Identity/uncompressed** — only `/bypass?nozstd=1` (zstd_bypass active)

Previously, an uncompressed identity response to `/bypass?nozstd=1` had no magic header and would trigger the `else` branch, which incremented `ok` without checking anything. A future response variant added to the module would silently pass without enumeration or decoding, the exact reachability gap #140 addressed.

The fix:
- Add an explicit branch for `/bypass?nozstd=1` to accept identity responses (no magic check needed)
- Convert the final `else` to a hard failure: print `BAD unknown magic` and increment the failure counter, matching the script's existing error convention

## Testing

Negative control: A response with an unrecognized magic on a path that must encode (e.g., `/medium` with magic `0x00000000`) now increments the bad counter and halts the worker, rather than passing silently. Verified via shell-level decoder logic tests covering all three response variants and five error cases.

Positive control: Responses with known magics on all normal paths still pass (28b52ffd on `/medium`, `/large`, `/compressible`, `/bypass`; 5e2a4d18 on `/dcz`). Identity responses on `/bypass?nozstd=1` still pass.

Existing test suites (`ci/t/*.t`) are unaffected — they mock responses and do not exercise the soak's live traffic decoder. The soak's own integration test is remote CI only (asan.yml, valgrind.yml, ci-deep.yml); local reproduction requires a built nginx binary with the module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved soak response validation for compressed and bypass response variants.
  * Bypass responses are now accepted only when the configured query path is used.
  * Unrecognized response formats are correctly reported as failures instead of passing silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->