### PR TITLE
refactor: extract q-fraction digit-walk out of eval_qvalue

### DIFF
--- a/ci/fuzz/extract_parser.sh
+++ b/ci/fuzz/extract_parser.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 #
 # Slice the verbatim bodies of the Accept-Encoding parser out of the
-# shipped ../../src/ngx_http_zstd_common.h into generated_parser.inc. That is
-# both ngx_http_zstd_eval_qvalue() (the qvalue evaluator) and its caller
+# shipped ../../src/ngx_http_zstd_common.h into generated_parser.inc. That
+# is ngx_http_zstd_eval_qvalue() (the qvalue evaluator), its
+# ngx_http_zstd_parse_q_fraction() digit-walk helper, and its caller
 # ngx_http_zstd_accept_encoding(), in definition order so the .inc
 # compiles standalone.
 #
@@ -26,9 +27,11 @@ fi
 # closing brace at column 0 (nginx style: definitions close with a bare
 # `}` in col 1). The functions have two distinct return-type lines
 # (`static u_char *` for the skip_quoted helper, `static ngx_int_t` for the
-# two parsers), so match on the following definition line. Capture them in
-# source order (skip_quoted, then eval_qvalue, then accept_encoding) so the
-# generated .inc compiles without forward declarations.
+# rest), so match on the following definition line. Capture them in
+# source order (skip_quoted, then parse_q_fraction, then eval_qvalue --
+# which calls parse_q_fraction, so it must precede eval_qvalue in the
+# generated .inc -- then accept_encoding) so the generated .inc compiles
+# without forward declarations.
 # The leading sub() strips a CR so extraction also works from a Windows
 # checkout smudged to CRLF (core.autocrlf=true): the `$0 == "}"`
 # terminator and the anchored regexes below otherwise never match and
@@ -36,7 +39,7 @@ fi
 awk '
     { sub(/\r$/, "") }
     /^static (ngx_int_t|u_char \*)$/ { pending = 1; buf = $0 ORS; next }
-    pending && /^ngx_http_zstd_(skip_quoted|eval_qvalue|coding_weight|accept_encoding)\(/ {
+    pending && /^ngx_http_zstd_(skip_quoted|parse_q_fraction|eval_qvalue|coding_weight|accept_encoding)\(/ {
         capture = 1; pending = 0; print buf; print; next
     }
     pending { pending = 0; buf = "" }
@@ -47,6 +50,7 @@ awk '
 ' "$HEADER" >"$OUT"
 
 if ! grep -q 'ngx_http_zstd_skip_quoted' "$OUT" ||
+    ! grep -q 'ngx_http_zstd_parse_q_fraction' "$OUT" ||
     ! grep -q 'ngx_http_zstd_eval_qvalue' "$OUT" ||
     ! grep -q 'ngx_http_zstd_coding_weight' "$OUT" ||
     ! grep -q 'ngx_http_zstd_accept_encoding' "$OUT" ||
@@ -58,6 +62,6 @@ if ! grep -q 'ngx_http_zstd_skip_quoted' "$OUT" ||
 fi
 
 LINES=$(wc -l <"$OUT")
-echo "✓ extracted ngx_http_zstd_skip_quoted() + ngx_http_zstd_eval_qvalue()" \
-    "+ ngx_http_zstd_coding_weight() + ngx_http_zstd_accept_encoding()" \
-    "— $LINES lines -> $OUT"
+echo "✓ extracted ngx_http_zstd_skip_quoted() + ngx_http_zstd_parse_q_fraction()" \
+    "+ ngx_http_zstd_eval_qvalue() + ngx_http_zstd_coding_weight()" \
+    "+ ngx_http_zstd_accept_encoding() — $LINES lines -> $OUT"

--- a/src/ngx_http_zstd_common.h
+++ b/src/ngx_http_zstd_common.h
@@ -73,6 +73,38 @@ ngx_http_zstd_skip_quoted(u_char *p, const u_char *end)
 
 
 /*
+ * Walk the up-to-three fractional digits of a "q=0.NNN" qvalue, starting
+ * right after the '.'. Advances *p past each digit consumed and returns
+ * the accumulated milli-units contribution (0..900, in multiples of 100,
+ * 10 or 1 as digits are consumed) via the return value. Bounded on both
+ * sides: the loop stops at `end`, and after three digits `scale` has hit
+ * 0 so a fourth or later digit byte is left unconsumed for the caller's
+ * trailing-junk check to reject. Pure digit-walk, no other qvalue state:
+ * splitting it out of ngx_http_zstd_eval_qvalue() shrinks that function's
+ * branching without changing what either side does.
+ */
+static ngx_int_t
+ngx_http_zstd_parse_q_fraction(const u_char *end, u_char **p)
+{
+    /* ngx_int_t (not int) so the digit*scale product widens before the
+     * add — avoids a theoretical int overflow CodeQL flags (the operands
+     * are tiny in practice). */
+    ngx_int_t  scale = 100;
+    ngx_int_t  frac = 0;
+    u_char    *q = *p;
+
+    while (q < end && *q >= '0' && *q <= '9' && scale > 0) {
+        frac += (*q - '0') * scale;
+        scale /= 10;
+        q++;
+    }
+
+    *p = q;
+    return frac;
+}
+
+
+/*
  * Evaluate the optional parameters of a coding token whose name has just
  * been consumed. `p` points at the ';' that introduces the parameters.
  * Returns the weight in milli-units (0..1000) — 1000 when no "q" parameter
@@ -146,23 +178,12 @@ ngx_http_zstd_eval_qvalue(const ngx_str_t *ae, u_char *p)
                 }
 
                 if (*p == '0') {
-                    /* ngx_int_t (not int) so the digit*scale product widens
-                     * before the add — avoids a theoretical int overflow
-                     * CodeQL flags (the operands are tiny in practice). */
-                    ngx_int_t  scale = 100;
-
                     p++;
                     q = 0;
 
                     if (p < end && *p == '.') {
                         p++;
-                        while (p < end && *p >= '0' && *p <= '9'
-                               && scale > 0)
-                        {
-                            q += (*p - '0') * scale;
-                            scale /= 10;
-                            p++;
-                        }
+                        q += ngx_http_zstd_parse_q_fraction(end, &p);
                     }
 
                 } else if (*p == '1') {


### PR DESCRIPTION
## TL;DR

`ngx_http_zstd_eval_qvalue()` parses the optional `;q=` parameter on an
Accept-Encoding coding token and was the densest branching in the module
(CCN 54 across 94 lines) as well as its most attacker-reachable code. This
pulls the "q=0.NNN" fractional-digit accumulation out into its own small,
bounded helper so the parser's remaining control flow is easier to read
and audit.

Extracted the `while` loop that accumulates the fractional digits of a
`q=0.NNN` value into `ngx_http_zstd_parse_q_fraction()` in
`src/ngx_http_zstd_common.h`. `eval_qvalue()` now calls it instead of
inlining the loop; the loop body, its bounds (`end`, digit range, `scale
> 0`), and the caller's post-parse trailing-junk check are all unchanged.

**Severity:** `Low` (`maintainability -- shrinks the densest branching in the module without changing behavior`)

## Fuzz extractor

`ci/fuzz/extract_parser.sh` slices this file's parser functions out of
production source by matching an explicit function-name whitelist. Added
`ngx_http_zstd_parse_q_fraction` to that whitelist (and its doc comment)
so `generated_parser.inc` still compiles standalone -- `eval_qvalue` now
calls the helper, so the fuzz target needs its body too, not just the
caller's.

## Testing

- Full TAP suite: 1750/1750 assertions, same total as before the
  extraction (`00-filter.t` 1155, `02-conf-warn.t` 50, `03-dcz.t` 86,
  `01-static.t` 459).
- `fuzz_accept_encoding` corpus (13,359 seed files) replayed against the
  rebuilt harness with `-runs=0`: 0 crashes.
- 200,000-iteration / 60s ASan+UBSan run of the rebuilt harness against
  the same corpus: 0 crashes, 0 sanitizer reports.
- `generated_parser.inc` diffed against the pre-change extraction: the
  new helper's body is inserted intact (ends in `}`) ahead of
  `eval_qvalue`, and the extracted loop is replaced in `eval_qvalue`'s
  body with a single call -- no truncation, no other function's slice
  changed. `generated_dcz.inc` (unrelated file, unaffected by this diff)
  re-extracted unchanged.
