### PR TITLE
refactor(static): extract the .zst frame probe into a pure, testable helper

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -146,11 +146,14 @@ jobs:
           cd "$GITHUB_WORKSPACE/ci/tools"
           python3 -m unittest -v test_test_encoding test_test_package_artifact
 
-      # Cheapest test layer over the real Accept-Encoding decision function:
-      # no nginx build tree, no network, sub-second. Regenerates and links
-      # the shipped src/ngx_http_zstd_common.h via ci/fuzz/extract_parser.sh
-      # (see ci/tests/unit/run.sh header) so a stale copy can never pass.
-      - name: Accept-Encoding parser unit tests (real decision TU)
+      # Cheapest test layer over the real pure decision functions -- the
+      # Accept-Encoding parser and the .zst frame-header probe: no nginx
+      # build tree, no network, sub-second. Regenerates and links the
+      # shipped src/ngx_http_zstd_common.h and
+      # src/ngx_http_zstd_static_module.c via ci/fuzz/extract_parser.sh and
+      # ci/fuzz/extract_static_probe.sh (see ci/tests/unit/run.sh header) so
+      # a stale copy can never pass.
+      - name: Pure-function unit tests (Accept-Encoding parser + frame probe)
         run: bash "$GITHUB_WORKSPACE/ci/tests/unit/run.sh"
           echo "✓ Python harness unit tests passed"
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -154,7 +154,8 @@ jobs:
       # ci/fuzz/extract_static_probe.sh (see ci/tests/unit/run.sh header) so
       # a stale copy can never pass.
       - name: Pure-function unit tests (Accept-Encoding parser + frame probe)
-        run: bash "$GITHUB_WORKSPACE/ci/tests/unit/run.sh"
+        run: |
+          bash "$GITHUB_WORKSPACE/ci/tests/unit/run.sh"
           echo "✓ Python harness unit tests passed"
 
       # Audit sha e289021 F1/F7 regression coverage: no nginx build needed,

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ ci/fuzz/fuzz_accept_encoding
 ci/fuzz/generated_parser.inc
 ci/fuzz/fuzz_dcz
 ci/fuzz/generated_dcz.inc
+ci/fuzz/generated_static_probe.inc
 ci/fuzz/crash-*
 ci/fuzz/corpus-min/
 ci/fuzz/corpus-dcz-min/
@@ -55,5 +56,6 @@ ci/fuzz/corpus/*
 
 # Unit test build artifacts (source + run.sh IS tracked)
 ci/tests/unit/test_accept_encoding
+ci/tests/unit/test_static_probe
 ci/tests/unit/*.gcda
 ci/tests/unit/*.gcno

--- a/ci/fuzz/extract_static_probe.sh
+++ b/ci/fuzz/extract_static_probe.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 Thijs Eilander
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Slice the verbatim body of the .zst frame-header probe out of the shipped
+# ../../src/ngx_http_zstd_static_module.c into generated_static_probe.inc.
+# That is ngx_http_zstd_static_probe_frame() -- the pure arithmetic half of
+# the static module's serve-time frame check, which decides from the first
+# bytes of a .zst file whether the leading frame may be served.
+#
+# Same contract as extract_parser.sh / extract_dcz.sh: this keeps the unit
+# test locked to production code. There is no hand-maintained copy of the
+# probe; if the function body changes upstream, the next unit-test build
+# picks it up automatically. If the function can no longer be found, we fail
+# loudly rather than test nothing.
+
+set -euo pipefail
+
+FUZZ_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$FUZZ_DIR/../../src/ngx_http_zstd_static_module.c"
+OUT="$FUZZ_DIR/generated_static_probe.inc"
+
+if [ ! -f "$SRC" ]; then
+    echo "✗ cannot find $SRC" >&2
+    exit 1
+fi
+
+# Same extraction shape as extract_parser.sh: match the two-line
+# `static ngx_int_t` / function-name declaration style, then capture
+# through the matching closing brace at column 0. The leading sub()
+# strips a CR for CRLF checkouts, same reason as extract_parser.sh.
+awk '
+    { sub(/\r$/, "") }
+    /^static (ngx_int_t|u_char \*)$/ { pending = 1; buf = $0 ORS; next }
+    pending && /^ngx_http_zstd_static_probe_frame\(/ {
+        capture = 1; pending = 0; print buf; print; next
+    }
+    pending { pending = 0; buf = "" }
+    capture {
+        print
+        if ($0 == "}") { capture = 0 }
+    }
+' "$SRC" >"$OUT"
+
+if ! grep -q 'ngx_http_zstd_static_probe_frame' "$OUT" ||
+    [ "$(tail -n1 "$OUT")" != "}" ]; then
+    echo "✗ failed to extract ngx_http_zstd_static_probe_frame() from $SRC" >&2
+    echo "  (function signature/layout changed? update extract_static_probe.sh)" >&2
+    rm -f "$OUT"
+    exit 1
+fi
+
+LINES=$(wc -l <"$OUT")
+echo "✓ extracted ngx_http_zstd_static_probe_frame() — $LINES lines -> $OUT"

--- a/ci/tests/unit/run.sh
+++ b/ci/tests/unit/run.sh
@@ -2,9 +2,11 @@
 # Copyright (C) 2026 Thijs Eilander
 # SPDX-License-Identifier: BSD-2-Clause
 #
-# ci/tests/unit/run.sh -- build and run the Accept-Encoding parser unit tests.
+# ci/tests/unit/run.sh -- build and run the pure-function unit tests: the
+# Accept-Encoding parser (src/ngx_http_zstd_common.h) and the .zst
+# frame-header probe (src/ngx_http_zstd_static_module.c).
 #
-#   ci/tests/unit/run.sh            # regenerate the parser slice, build, run
+#   ci/tests/unit/run.sh            # regenerate both slices, build, run
 #   ci/tests/unit/run.sh clean      # remove build products
 #   COVERAGE=1 ci/tests/unit/run.sh # also instrument, so ci/tools/coverage.sh
 #                                   # can gcov src/ afterwards
@@ -44,9 +46,10 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$DIR/../../.." && pwd)"
 FUZZ_DIR="$ROOT/ci/fuzz"
 BIN="$DIR/test_accept_encoding"
+PROBE_BIN="$DIR/test_static_probe"
 
 if [ "${1:-}" = "clean" ]; then
-    rm -f "$BIN" "$DIR"/*.o "$DIR"/*.gcda "$DIR"/*.gcno
+    rm -f "$BIN" "$PROBE_BIN" "$DIR"/*.o "$DIR"/*.gcda "$DIR"/*.gcno
     echo "unit test binary removed"
     exit 0
 fi
@@ -83,3 +86,26 @@ echo "==> Running"
 # the job burns its whole 15-minute budget and the log never says which layer
 # failed.
 timeout 60s "$BIN"
+
+# ---------------------------------------------------------------------------
+# The .zst frame-header probe (src/ngx_http_zstd_static_module.c:
+# ngx_http_zstd_static_probe_frame). Same shape as the parser suite above:
+# extract the shipped function body first, so this binary can never link a
+# hand-copied drifted version. The probe is pure arithmetic over a fixed
+# 18-byte buffer -- no nginx tree, no libzstd, no filesystem -- so it belongs
+# in this cheapest layer too.
+# ---------------------------------------------------------------------------
+bash "$FUZZ_DIR/extract_static_probe.sh"
+
+echo "==> Building $PROBE_BIN with ${CC}"
+# shellcheck disable=SC2086
+$CC "${OWN_CFLAGS[@]}" -I"$FUZZ_DIR" -c "$DIR/test_static_probe.c" \
+    -o "$DIR/test_static_probe.o"
+# shellcheck disable=SC2086
+$CC "${LINK_EXTRA[@]}" -o "$PROBE_BIN" "$DIR/test_static_probe.o"
+
+echo "==> Running"
+# Bounded for the same reason as above; the probe has no loop that can run
+# away, but a timeout costs nothing and keeps the layer's failure mode
+# uniform.
+timeout 60s "$PROBE_BIN"

--- a/ci/tests/unit/test_static_probe.c
+++ b/ci/tests/unit/test_static_probe.c
@@ -1,0 +1,564 @@
+/*
+ * Copyright (C) 2026 Thijs Eilander
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Unit tests for the .zst frame-header probe
+ * (src/ngx_http_zstd_static_module.c: ngx_http_zstd_static_probe_frame()).
+ *
+ * WHY THIS EXISTS ALONGSIDE ci/t/01-static.t
+ *
+ *   ci/t/01-static.t   drives the probe through a live nginx serving real
+ *                      files from ci/t/suite/. It proves the probe is wired
+ *                      into the request path and that a declined file falls
+ *                      back correctly -- but every boundary it wants to
+ *                      reach has to be reached by materialising a file on
+ *                      disk with exactly the right bytes, and a probe
+ *                      verdict is only observable through the resulting
+ *                      status code plus an error-log line.
+ *   this file          states the verdict directly, at named byte
+ *                      boundaries, for buffers the on-disk fixtures cannot
+ *                      conveniently express (a 4-byte file, an exactly-18-
+ *                      byte file, a Single_Segment header whose content-size
+ *                      field is one byte short of the buffer), with no
+ *                      nginx process and no filesystem, in well under a
+ *                      second.
+ *
+ * The probe is deliberately PURE -- no I/O, no logging, no pool, no
+ * request -- precisely so this layer can exist. The handler keeps the
+ * pread(2), the directio alignment and every ngx_log_error() call; this
+ * function is the arithmetic over the bytes that read returned. That split
+ * is what makes the bounds below directly assertable: an off-by-one in the
+ * "did I get enough bytes for this layout" checks is the entire risk in
+ * this code, and it is invisible from an end-to-end test that only ever
+ * feeds it complete frames.
+ *
+ * Like ci/tests/unit/test_accept_encoding.c this does NOT re-implement the
+ * function: run.sh runs ci/fuzz/extract_static_probe.sh before every build,
+ * so this binary always links the SHIPPED src/ngx_http_zstd_static_module.c
+ * body, never a hand-copied version that can drift.
+ *
+ * Extend: add a case_*() function and one line in main().
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+typedef intptr_t       ngx_int_t;
+typedef uintptr_t      ngx_uint_t;
+typedef unsigned char  u_char;
+
+/*
+ * From <zstd.h>, stable since 0.8.0. Reproduced rather than included so
+ * this layer needs no libzstd headers -- same reasoning as ngx_shim.h for
+ * the parser suite. If upstream ever changes these the module stops
+ * building against the real header first, long before this copy matters.
+ */
+#define ZSTD_MAGICNUMBER             0xFD2FB528U
+#define ZSTD_MAGIC_SKIPPABLE_START   0x184D2A50U
+#define ZSTD_MAGIC_SKIPPABLE_MASK    0xFFFFFFF0U
+
+/* Mirrored from src/ngx_http_zstd_static_module.c. */
+#define NGX_HTTP_ZSTD_STATIC_MAX_WINDOW  (8 * 1024 * 1024)
+
+#define NGX_HTTP_ZSTD_STATIC_FRAME_OK          0
+#define NGX_HTTP_ZSTD_STATIC_FRAME_NOT_ZSTD    1
+#define NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED   2
+#define NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG  3
+
+/*
+ * Included by RELATIVE path, not via -I, for the same reason
+ * test_accept_encoding.c does: a static analyser invoked from anywhere
+ * must be able to resolve it. An analyser that cannot resolve an include
+ * SKIPS THE WHOLE TRANSLATION UNIT and reports no findings, which is
+ * indistinguishable from a clean result.
+ */
+#include "../../fuzz/generated_static_probe.inc"
+
+
+static int  failures;
+static int  checks;
+
+
+static void
+check(int ok, const char *what)
+{
+    checks++;
+    if (ok) {
+        printf("ok   %s\n", what);
+        return;
+    }
+    printf("FAIL %s\n", what);
+    failures++;
+}
+
+
+/*
+ * Poisoned probe buffer: 18 usable bytes preceded and followed by a guard
+ * region of 0xA5. A read past either end that happens to land on a guard
+ * byte changes the verdict (0xA5A5A5A5 is neither magic), and the trailing
+ * guard is what would absorb an off-by-one in the "enough bytes for this
+ * layout" checks -- so a mutant that reads hdr[n] instead of stopping is
+ * reading a defined, wrong value rather than heap garbage that might
+ * happen to be correct.
+ */
+#define GUARD  8
+
+static u_char  buf[GUARD + 18 + GUARD];
+
+
+static const u_char *
+frame(const u_char *bytes, size_t len)
+{
+    memset(buf, 0xA5, sizeof(buf));
+    if (len) {
+        memcpy(buf + GUARD, bytes, len);
+    }
+    return buf + GUARD;
+}
+
+
+static ngx_int_t
+probe(const u_char *bytes, size_t len, uint64_t *window)
+{
+    *window = 0;
+    return ngx_http_zstd_static_probe_frame(frame(bytes, len), len, window);
+}
+
+
+/* Little-endian ZSTD_MAGICNUMBER, the leading 4 bytes of a regular frame. */
+#define MAGIC  0x28, 0xB5, 0x2F, 0xFD
+
+
+/*
+ * A file shorter than the 18-byte probe buffer: only `n` bytes are valid
+ * and the probe must never look past them. Here n == 4 -- a valid magic
+ * and nothing else. A regular frame needs at least a Frame_Header_
+ * Descriptor at hdr[4], which is not present, so the verdict is TRUNCATED
+ * and NOT a window decision made from the guard byte.
+ */
+static void
+case_shorter_than_probe_buffer(void)
+{
+    static const u_char  f[] = { MAGIC };
+    uint64_t             w;
+
+    check(probe(f, sizeof(f), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED,
+          "a 4-byte file (magic only, no descriptor) is TRUNCATED, not "
+          "parsed from bytes past the read");
+
+    /*
+     * n == 5: descriptor present, Single_Segment clear, so a
+     * Window_Descriptor is required at hdr[5] and is past the read.
+     * This is the exact off-by-one the `n < 6` guard exists for.
+     */
+    static const u_char  g[] = { MAGIC, 0x00 };
+
+    check(probe(g, sizeof(g), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED,
+          "a 5-byte streaming frame (descriptor but no Window_Descriptor) "
+          "is TRUNCATED");
+}
+
+
+/*
+ * n == 6 is the smallest COMPLETE streaming frame header the probe can
+ * decide on: descriptor 0x00 (no dict id, no content size, Single_Segment
+ * clear) plus one Window_Descriptor byte. 0x00 => exponent 10, mantissa 0
+ * => a 1 KB window, far under the cap.
+ */
+static void
+case_smallest_complete_streaming_header(void)
+{
+    static const u_char  f[] = { MAGIC, 0x00, 0x00 };
+    uint64_t             w;
+
+    check(probe(f, sizeof(f), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_OK,
+          "a 6-byte streaming frame declaring a 1 KB window is OK");
+}
+
+
+/*
+ * A file exactly the size of the probe buffer: all 18 bytes valid, no
+ * short-read path involved. Descriptor 0xE0 sets Single_Segment (0x20) and
+ * Frame_Content_Size_flag 3 (0xC0 => an 8-byte field), dict-id flag 0, so
+ * the content size occupies hdr[5..12] -- entirely inside 18 bytes. Value
+ * 4 MB, under the cap.
+ */
+static void
+case_exactly_probe_buffer_size(void)
+{
+    static const u_char  f[] = {
+        MAGIC, 0xE0,
+        0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00,  /* 4 MB, LE64 */
+        0x11, 0x22, 0x33, 0x44, 0x55                     /* trailing payload */
+    };
+    uint64_t  w;
+
+    check(sizeof(f) == 18, "the exact-size fixture really is 18 bytes");
+
+    check(probe(f, sizeof(f), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_OK,
+          "an exactly-18-byte file with a 4 MB single-segment window is OK");
+}
+
+
+/*
+ * A valid, ordinary .zst frame -- the shape every real precompressed asset
+ * has: streaming frame, no dictionary, a modest window. Window_Descriptor
+ * 0x68 => exponent 10 + 13 = 23 (8 MB base), mantissa 0 => exactly the
+ * 8 MB cap, which is ACCEPTED (the check is `> MAX`, not `>=`).
+ */
+static void
+case_valid_zst_frame(void)
+{
+    static const u_char  f[] = { MAGIC, 0x00, 0x68 };
+    uint64_t             w;
+
+    check(probe(f, sizeof(f), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_OK,
+          "a frame declaring exactly the 8 MB window cap is OK "
+          "(the limit is inclusive)");
+
+    /* One mantissa step above the cap must be rejected, and must report
+     * the value it computed so the operator's log line is actionable. */
+    static const u_char  g[] = { MAGIC, 0x00, 0x69 };
+
+    check(probe(g, sizeof(g), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG,
+          "one mantissa step above the 8 MB cap is WINDOW_BIG");
+    check(w == (uint64_t) NGX_HTTP_ZSTD_STATIC_MAX_WINDOW
+               + (NGX_HTTP_ZSTD_STATIC_MAX_WINDOW / 8),
+          "WINDOW_BIG reports the declared window (8 MB + one eighth)");
+}
+
+
+/*
+ * A skippable leading frame is a legal start to a zstd stream and is
+ * exempt from the window check -- the real header sits after a
+ * variable-length skip. All 16 skippable magics must be accepted, and none
+ * of them may fall through into the regular-frame window parse (which
+ * would read a Window_Descriptor out of what is actually a length field).
+ */
+static void
+case_skippable_frame_accepted_and_window_exempt(void)
+{
+    uint64_t  w;
+    int       i, ok = 1;
+
+    for (i = 0; i < 16; i++) {
+        /* ZSTD_MAGIC_SKIPPABLE_START | i, little-endian, then a frame
+         * length field whose bytes would decode as a 128 MB window if the
+         * regular-frame path were wrongly taken. */
+        u_char  f[] = { 0x50 + (u_char) i, 0x2A, 0x4D, 0x18,
+                        0xFF, 0xFF, 0xFF, 0xFF };
+
+        if (probe(f, sizeof(f), &w) != NGX_HTTP_ZSTD_STATIC_FRAME_OK) {
+            ok = 0;
+        }
+    }
+
+    check(ok, "all 16 skippable-frame magics are OK and exempt from the "
+              "window check");
+}
+
+
+/*
+ * A file whose magic does not match -- the `cp foo.txt foo.zst` case the
+ * probe exists for. It must be NOT_ZSTD regardless of what follows, and
+ * must not be mistaken for a truncation.
+ */
+static void
+case_magic_mismatch(void)
+{
+    static const u_char  f[] = { 'h', 'e', 'l', 'l', 'o', ' ', 'w', 'o',
+                                 'r', 'l', 'd', '\n' };
+    uint64_t             w;
+
+    check(probe(f, sizeof(f), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_NOT_ZSTD,
+          "plain text is NOT_ZSTD");
+
+    /*
+     * One bit off the real magic, and one bit off the skippable range --
+     * the two near-misses a naive mask comparison would wave through.
+     */
+    static const u_char  g[] = { 0x29, 0xB5, 0x2F, 0xFD, 0x00, 0x00 };
+
+    check(probe(g, sizeof(g), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_NOT_ZSTD,
+          "a one-bit-off zstd magic is NOT_ZSTD");
+
+    /* 0x184D2A40: one nibble below ZSTD_MAGIC_SKIPPABLE_START. */
+    static const u_char  h[] = { 0x40, 0x2A, 0x4D, 0x18, 0x00, 0x00 };
+
+    check(probe(h, sizeof(h), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_NOT_ZSTD,
+          "the value one below the skippable magic range is NOT_ZSTD");
+
+    /* 0x184D2A60: one nibble above the range. */
+    static const u_char  k[] = { 0x60, 0x2A, 0x4D, 0x18, 0x00, 0x00 };
+
+    check(probe(k, sizeof(k), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_NOT_ZSTD,
+          "the value one above the skippable magic range is NOT_ZSTD");
+}
+
+
+/*
+ * A zero-length file never reaches the probe: the handler rejects
+ * of.size < 4 with its own "too small to be a zstd frame" line, and
+ * rejects a pread returning fewer than 4 bytes before calling. The probe's
+ * contract is therefore n >= 4, and this case pins the boundary that
+ * contract rests on -- the smallest n the probe is ever handed is exactly
+ * the 4 bytes the magic compare needs, so the compare itself never reads
+ * past the read even at the minimum.
+ *
+ * Asserting it here rather than trusting the comment: the 4-byte call is
+ * the one that would read hdr[4] if the `n < 5` guard were dropped, and
+ * the poisoned buffer makes that read a guard byte rather than a lucky
+ * zero.
+ */
+static void
+case_zero_length_file_never_reaches_the_probe(void)
+{
+    static const u_char  f[] = { MAGIC };
+    uint64_t             w;
+
+    check(probe(f, 4, &w) == NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED,
+          "the minimum n the probe accepts (4) decides on the magic alone "
+          "and never indexes hdr[4]");
+}
+
+
+/*
+ * Single_Segment content-size widths. Frame_Content_Size_flag selects a
+ * 1, 2, 4 or 8-byte field (flag 0 means ONE byte when Single_Segment is
+ * set -- the flag only means "absent" when it is clear), and the 2-byte
+ * form is offset by 256 per RFC 8878. Each width's truncation boundary is
+ * one byte before the field ends.
+ */
+static void
+case_single_segment_content_size_widths(void)
+{
+    uint64_t  w;
+
+    /* flag 0 => 1-byte field at hdr[5]. 0x40 = 64 bytes. */
+    static const u_char  a[] = { MAGIC, 0x20, 0x40 };
+    check(probe(a, sizeof(a), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_OK,
+          "Single_Segment with a 1-byte content size is OK");
+
+    /* ...and one byte short of that field is TRUNCATED. */
+    static const u_char  a0[] = { MAGIC, 0x20 };
+    check(probe(a0, sizeof(a0), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED,
+          "Single_Segment missing its 1-byte content size is TRUNCATED");
+
+    /* flag 1 (0x40) => 2-byte field, +256 offset. 0x0000 => 256. */
+    static const u_char  b[] = { MAGIC, 0x60, 0x00, 0x00 };
+    check(probe(b, sizeof(b), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_OK,
+          "Single_Segment with a 2-byte content size is OK");
+
+    static const u_char  b0[] = { MAGIC, 0x60, 0x00 };
+    check(probe(b0, sizeof(b0), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED,
+          "Single_Segment one byte short of its 2-byte content size is "
+          "TRUNCATED");
+
+    /*
+     * The +256 offset is load-bearing at the cap: 0xFFFF00 would be
+     * (8 MB - 256) without it and (8 MB) with it -- both accepted -- so
+     * pin it where it changes the verdict instead. 2-byte field
+     * 0xFFFF = 65535, +256 = 65791, comfortably OK; the offset is
+     * observable through WINDOW_BIG's reported value below.
+     */
+    static const u_char  b1[] = { MAGIC, 0x60, 0xFF, 0xFF };
+    check(probe(b1, sizeof(b1), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_OK,
+          "a 2-byte content size of 65535 (+256) is under the cap");
+
+    /* flag 2 (0x80) => 4-byte field. 16 MB, over the cap. */
+    static const u_char  c[] = { MAGIC, 0xA0, 0x00, 0x00, 0x00, 0x01 };
+    check(probe(c, sizeof(c), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG,
+          "Single_Segment declaring a 16 MB content size is WINDOW_BIG");
+    check(w == 16777216, "the 4-byte content size is decoded little-endian");
+
+    static const u_char  c0[] = { MAGIC, 0xA0, 0x00, 0x00, 0x00 };
+    check(probe(c0, sizeof(c0), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED,
+          "Single_Segment one byte short of its 4-byte content size is "
+          "TRUNCATED");
+
+    /* flag 3 (0xC0) => 8-byte field. */
+    static const u_char  d0[] = { MAGIC, 0xE0,
+                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    check(probe(d0, sizeof(d0), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED,
+          "Single_Segment one byte short of its 8-byte content size is "
+          "TRUNCATED");
+}
+
+
+/*
+ * The Dictionary_ID_flag widens the offset of the content-size field by
+ * 0, 1, 2 or 4 bytes. Getting that table wrong reads the content size
+ * from the dictionary id (or from payload), so each width gets a case
+ * whose content-size bytes sit at a DIFFERENT offset from the previous
+ * one, with dictionary-id bytes chosen so that misreading them would
+ * produce a different verdict.
+ */
+static void
+case_dictionary_id_shifts_the_content_size(void)
+{
+    uint64_t  w;
+
+    /*
+     * Single_Segment + 1-byte content size, dict-id flag 1 => a 1-byte
+     * dict id at hdr[5], content size at hdr[6]. The dict-id byte is 0xFF
+     * and the content size 0x01: reading the wrong one is 255 vs 1, both
+     * OK, so pin it via the 4-byte-content-size form instead where the
+     * shift changes the magnitude by orders of magnitude.
+     *
+     * Descriptor 0xA1: Single_Segment(0x20) + FCS flag 2 (0x80 => 4
+     * bytes) + dict-id flag 1 (0x01 => 1 byte).
+     * Layout: hdr[5] = dict id, hdr[6..9] = content size = 16 MB.
+     */
+    static const u_char  a[] = { MAGIC, 0xA1,
+                                 0xFF,                     /* dict id */
+                                 0x00, 0x00, 0x00, 0x01 }; /* 16 MB LE32 */
+    check(probe(a, sizeof(a), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG,
+          "a 1-byte dictionary id shifts the content-size field by one");
+    check(w == 16777216,
+          "the content size is read from behind the 1-byte dictionary id");
+
+    /* dict-id flag 2 => 2 bytes; content size at hdr[7..10]. */
+    static const u_char  b[] = { MAGIC, 0xA2,
+                                 0xFF, 0xFF,
+                                 0x00, 0x00, 0x00, 0x01 };
+    check(probe(b, sizeof(b), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG
+          && w == 16777216,
+          "the content size is read from behind a 2-byte dictionary id");
+
+    /* dict-id flag 3 => 4 bytes; content size at hdr[9..12]. */
+    static const u_char  c[] = { MAGIC, 0xA3,
+                                 0xFF, 0xFF, 0xFF, 0xFF,
+                                 0x00, 0x00, 0x00, 0x01 };
+    check(probe(c, sizeof(c), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG
+          && w == 16777216,
+          "the content size is read from behind a 4-byte dictionary id");
+
+    /*
+     * The widest layout the probe must handle: 4-byte dict id + 8-byte
+     * content size ends at hdr[16], inside the 18-byte buffer. One byte
+     * short of it is TRUNCATED -- this is the outermost bound in the
+     * function and the one an off-by-one would most plausibly break.
+     */
+    static const u_char  d[] = { MAGIC, 0xE3,
+                                 0xFF, 0xFF, 0xFF, 0xFF,
+                                 0x00, 0x00, 0x00, 0x00,
+                                 0x00, 0x00, 0x00 };   /* 7 of 8 bytes */
+    check(sizeof(d) == 16, "the widest-layout truncation fixture is 16 bytes");
+    check(probe(d, sizeof(d), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED,
+          "the widest header (4-byte dict id + 8-byte content size) one "
+          "byte short is TRUNCATED");
+
+    static const u_char  e[] = { MAGIC, 0xE3,
+                                 0xFF, 0xFF, 0xFF, 0xFF,
+                                 0x00, 0x00, 0x00, 0x00,
+                                 0x00, 0x00, 0x00, 0x00 };  /* all 8 */
+    check(sizeof(e) == 17, "the widest-layout complete fixture is 17 bytes");
+    check(probe(e, sizeof(e), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_OK,
+          "the widest header, complete at 17 bytes, is decided (OK)");
+}
+
+
+/*
+ * Window_Descriptor arithmetic on streaming frames: RFC 8878 3.1.1.1.2
+ * defines window = (1 << (10 + exponent)) + ((1 << (10 + exponent)) >> 3)
+ * * mantissa, where exponent = byte >> 3 and mantissa = byte & 7. The
+ * verdict boundary sits between two adjacent byte values, so the pair
+ * below is exactly the mutation-sensitive point.
+ */
+static void
+case_window_descriptor_arithmetic(void)
+{
+    uint64_t  w;
+
+    /* exponent 12 (0x60 >> 3 = 12) => 1 << 22 = 4 MB, mantissa 0. */
+    static const u_char  a[] = { MAGIC, 0x00, 0x60 };
+    check(probe(a, sizeof(a), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_OK,
+          "Window_Descriptor 0x60 (4 MB) is OK");
+
+    /* exponent 13 => 8 MB exactly, mantissa 0 -- the inclusive cap. */
+    static const u_char  b[] = { MAGIC, 0x00, 0x68 };
+    check(probe(b, sizeof(b), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_OK,
+          "Window_Descriptor 0x68 (exactly 8 MB) is OK");
+
+    /* exponent 14 => 16 MB. */
+    static const u_char  c[] = { MAGIC, 0x00, 0x70 };
+    check(probe(c, sizeof(c), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG,
+          "Window_Descriptor 0x70 (16 MB) is WINDOW_BIG");
+    check(w == 16777216, "the exponent-only window is 1 << (10 + exponent)");
+
+    /*
+     * Mantissa contribution: exponent 13, mantissa 7 => 8 MB + 7/8 MB.
+     * A mutant that drops the mantissa term reports exactly 8 MB and
+     * flips this to OK.
+     */
+    static const u_char  d[] = { MAGIC, 0x00, 0x6F };
+    check(probe(d, sizeof(d), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG,
+          "the mantissa pushes an 8 MB-exponent frame over the cap");
+    check(w == (uint64_t) NGX_HTTP_ZSTD_STATIC_MAX_WINDOW
+               + (NGX_HTTP_ZSTD_STATIC_MAX_WINDOW / 8) * 7,
+          "the mantissa contributes (window >> 3) * mantissa");
+
+    /*
+     * The largest Window_Descriptor, 0xFF: exponent 31 => 1 << 41, plus
+     * mantissa. This must not overflow the 64-bit accumulator into a
+     * small value that reads as OK -- the reason the computation is
+     * uint64_t rather than the ngx_uint_t the surrounding code uses.
+     */
+    static const u_char  e[] = { MAGIC, 0x00, 0xFF };
+    check(probe(e, sizeof(e), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG,
+          "the maximum Window_Descriptor (0xFF) is WINDOW_BIG, not "
+          "wrapped to a small window");
+    check(w == ((uint64_t) 1 << 41) + (((uint64_t) 1 << 41) >> 3) * 7,
+          "the maximum window is computed in 64 bits without wrapping");
+}
+
+
+/*
+ * The window out-param is written ONLY on WINDOW_BIG. The handler reads it
+ * only in that branch, but a probe that scribbled on it unconditionally
+ * would make the handler's other log lines depend on uninitialised-looking
+ * state if that ever changed, and it is free to pin here.
+ */
+static void
+case_window_untouched_unless_oversized(void)
+{
+    uint64_t  w;
+
+    static const u_char  ok[] = { MAGIC, 0x00, 0x00 };
+    w = 0xDEADBEEF;
+    ngx_http_zstd_static_probe_frame(frame(ok, sizeof(ok)), sizeof(ok), &w);
+    check(w == 0xDEADBEEF, "window is untouched on OK");
+
+    static const u_char  bad[] = { 'n', 'o', 'p', 'e' };
+    w = 0xDEADBEEF;
+    ngx_http_zstd_static_probe_frame(frame(bad, sizeof(bad)), sizeof(bad), &w);
+    check(w == 0xDEADBEEF, "window is untouched on NOT_ZSTD");
+
+    static const u_char  trunc[] = { MAGIC, 0x00 };
+    w = 0xDEADBEEF;
+    ngx_http_zstd_static_probe_frame(frame(trunc, sizeof(trunc)),
+                                     sizeof(trunc), &w);
+    check(w == 0xDEADBEEF, "window is untouched on TRUNCATED");
+}
+
+
+int
+main(void)
+{
+    case_shorter_than_probe_buffer();
+    case_smallest_complete_streaming_header();
+    case_exactly_probe_buffer_size();
+    case_valid_zst_frame();
+    case_skippable_frame_accepted_and_window_exempt();
+    case_magic_mismatch();
+    case_zero_length_file_never_reaches_the_probe();
+    case_single_segment_content_size_widths();
+    case_dictionary_id_shifts_the_content_size();
+    case_window_descriptor_arithmetic();
+    case_window_untouched_unless_oversized();
+
+    printf("\n%d/%d checks passed\n", checks - failures, checks);
+    return failures ? 1 : 0;
+}

--- a/src/ngx_http_zstd_static_module.c
+++ b/src/ngx_http_zstd_static_module.c
@@ -129,6 +129,134 @@ ngx_module_t  ngx_http_zstd_static_module = {
 };
 
 
+#if !(NGX_WIN32) && (NGX_HAVE_PREAD)
+
+/*
+ * Verdicts from ngx_http_zstd_static_probe_frame(). The caller maps each
+ * to the log line and return code the inlined probe used to emit, so the
+ * split changes no observable behaviour — only where the arithmetic
+ * lives.
+ */
+#define NGX_HTTP_ZSTD_STATIC_FRAME_OK          0
+#define NGX_HTTP_ZSTD_STATIC_FRAME_NOT_ZSTD    1
+#define NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED   2
+#define NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG  3
+
+
+/*
+ * Pure frame-header probe: decides whether the leading frame of a .zst
+ * file may be served, given the first `n` bytes read from offset 0.
+ *
+ * Reads at most 18 bytes of `hdr` (magic(4) + descriptor(1) + dictionary
+ * id(<=4) + content size(<=8)) and NEVER reads past `n`; every layout
+ * path checks it got the bytes that layout requires before indexing
+ * them. `n` is the byte count the caller's pread(2) actually returned
+ * and is >= 4 by contract — the caller rejects a shorter read (and a
+ * file smaller than 4 bytes) before calling, because those two cases
+ * carry different log lines.
+ *
+ * On NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG the declared window is
+ * stored through `window` for the caller's error message. `window` is
+ * untouched on every other verdict.
+ *
+ * No I/O, no logging, no allocation, no request state: this is the
+ * arithmetic only, so ci/tests/unit/ can state its boundaries directly
+ * (a short file, an exact-18-byte file, a valid frame, a bad magic)
+ * without standing up an nginx.
+ */
+static ngx_int_t
+ngx_http_zstd_static_probe_frame(const u_char *hdr, size_t n, uint64_t *window)
+{
+    uint32_t    mw;
+    uint64_t    w;
+    ngx_uint_t  i, fhd, fcs_size, off;
+
+    static const ngx_uint_t  did_len[4] = { 0, 1, 2, 4 };
+
+    mw = ((uint32_t) hdr[0])
+       | ((uint32_t) hdr[1] << 8)
+       | ((uint32_t) hdr[2] << 16)
+       | ((uint32_t) hdr[3] << 24);
+
+    if (mw != ZSTD_MAGICNUMBER
+        && (mw & ZSTD_MAGIC_SKIPPABLE_MASK) != ZSTD_MAGIC_SKIPPABLE_START)
+    {
+        return NGX_HTTP_ZSTD_STATIC_FRAME_NOT_ZSTD;
+    }
+
+    /*
+     * Declared-window check (RFC 8878 §3.1.1.1) on regular frames —
+     * see NGX_HTTP_ZSTD_STATIC_MAX_WINDOW for why: a frame declaring
+     * more than 8 MB is rejected by every browser before decoding, so
+     * serving it produces a page-breaking decode error that curl and
+     * the zstd CLI do not reproduce. Declining keeps the site working
+     * (the zstd filter, gzip_static or identity takes over) and puts
+     * the actionable cause in the error log.
+     *
+     * The check covers the LEADING frame only. A skippable leading
+     * frame is exempt (the real header sits after a variable-length
+     * skip), and in a concatenation of regular frames only the first
+     * is inspected: a regular frame's header does not declare its
+     * compressed length, so walking the sequence would mean decoding
+     * every block header in every frame — unbounded I/O for a
+     * serve-time guard. Multi-frame .zst web assets are pathological
+     * (no common tooling emits them); the README documents the
+     * leading-frame scope.
+     */
+    if (mw != ZSTD_MAGICNUMBER) {
+        return NGX_HTTP_ZSTD_STATIC_FRAME_OK;
+    }
+
+    if (n < 5) {
+        return NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED;
+    }
+
+    fhd = hdr[4];
+
+    if (!(fhd & 0x20)) {
+        /* No Single_Segment flag: Window_Descriptor follows. */
+        if (n < 6) {
+            return NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED;
+        }
+
+        w = (uint64_t) 1 << (10 + (hdr[5] >> 3));
+        w += (w >> 3) * (hdr[5] & 7);
+
+    } else {
+        /*
+         * Single_Segment: no Window_Descriptor; the window is the
+         * frame content size, read from behind the optional dictionary
+         * id. Frame_Content_Size_flag 0 means a 1-byte field here (the
+         * flag only means "absent" when Single_Segment is unset).
+         */
+        fcs_size = (fhd >> 6) ? ((ngx_uint_t) 1 << (fhd >> 6)) : 1;
+        off = 5 + did_len[fhd & 3];
+
+        if (n < off + fcs_size) {
+            return NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED;
+        }
+
+        w = 0;
+        for (i = 0; i < fcs_size; i++) {
+            w |= (uint64_t) hdr[off + i] << (8 * i);
+        }
+
+        if (fcs_size == 2) {
+            w += 256;  /* RFC 8878: 2-byte field is offset */
+        }
+    }
+
+    if (w > NGX_HTTP_ZSTD_STATIC_MAX_WINDOW) {
+        *window = w;
+        return NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG;
+    }
+
+    return NGX_HTTP_ZSTD_STATIC_FRAME_OK;
+}
+
+#endif /* !NGX_WIN32 && NGX_HAVE_PREAD */
+
+
 static ngx_int_t
 ngx_http_zstd_static_handler(ngx_http_request_t *r)
 {
@@ -331,7 +459,7 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
         u_char    *hdr;
         size_t     want;
         ssize_t    n;
-        uint32_t   mw;
+        uint64_t   window;
 
         if (of.size < 4) {
             ngx_log_error(NGX_LOG_ERR, log, 0,
@@ -380,15 +508,9 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
                            "directio file \"%s\"", want, path.data);
         }
 
-        mw = ((uint32_t) hdr[0])
-           | ((uint32_t) hdr[1] << 8)
-           | ((uint32_t) hdr[2] << 16)
-           | ((uint32_t) hdr[3] << 24);
+        switch (ngx_http_zstd_static_probe_frame(hdr, (size_t) n, &window)) {
 
-        if (mw != ZSTD_MAGICNUMBER
-            && (mw & ZSTD_MAGIC_SKIPPABLE_MASK)
-               != ZSTD_MAGIC_SKIPPABLE_START)
-        {
+        case NGX_HTTP_ZSTD_STATIC_FRAME_NOT_ZSTD:
             ngx_log_error(NGX_LOG_ERR, log, 0,
                           "zstd static: \"%s\" is not a zstd frame "
                           "(leading bytes 0x%02xd%02xd%02xd%02xd)",
@@ -396,95 +518,28 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
                           (ngx_uint_t) hdr[0], (ngx_uint_t) hdr[1],
                           (ngx_uint_t) hdr[2], (ngx_uint_t) hdr[3]);
             return NGX_DECLINED;
-        }
 
-        /*
-         * Declared-window check (RFC 8878 §3.1.1.1) on regular frames —
-         * see NGX_HTTP_ZSTD_STATIC_MAX_WINDOW for why: a frame
-         * declaring more than 8 MB is rejected by every browser before
-         * decoding, so serving it produces a page-breaking decode error
-         * that curl and the zstd CLI do not reproduce. Declining keeps
-         * the site working (the zstd filter, gzip_static or identity
-         * takes over) and puts the actionable cause in the error log.
-         *
-         * The check covers the LEADING frame only. A skippable leading
-         * frame is exempt (the real header sits after a variable-length
-         * skip), and in a concatenation of regular frames only the
-         * first is inspected: a regular frame's header does not declare
-         * its compressed length, so walking the sequence would mean
-         * decoding every block header in every frame — unbounded I/O
-         * for a serve-time guard. Multi-frame .zst web assets are
-         * pathological (no common tooling emits them); the README
-         * documents the leading-frame scope.
-         */
-        if (mw == ZSTD_MAGICNUMBER) {
-            uint64_t    window;
-            ngx_uint_t  i, fhd, fcs_size, off;
+        case NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED:
+            ngx_log_error(NGX_LOG_ERR, log, 0,
+                          "zstd static: \"%s\" frame header truncated",
+                          path.data);
+            return NGX_DECLINED;
 
-            static const ngx_uint_t  did_len[4] = { 0, 1, 2, 4 };
+        case NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG:
+            ngx_log_error(NGX_LOG_ERR, log, 0,
+                          "zstd static: \"%s\" declares a %uL-byte "
+                          "decompression window, above the 8 MB limit "
+                          "browsers enforce for Content-Encoding: zstd "
+                          "(RFC 8878) — declining so a fallback "
+                          "encoding is used; recompress with a window "
+                          "log <= 23 (streaming encoders default to "
+                          "the compression level's window when not "
+                          "told the input size)",
+                          path.data, window);
+            return NGX_DECLINED;
 
-            if (n < 5) {
-                ngx_log_error(NGX_LOG_ERR, log, 0,
-                              "zstd static: \"%s\" frame header truncated",
-                              path.data);
-                return NGX_DECLINED;
-            }
-
-            fhd = hdr[4];
-
-            if (!(fhd & 0x20)) {
-                /* No Single_Segment flag: Window_Descriptor follows. */
-                if (n < 6) {
-                    ngx_log_error(NGX_LOG_ERR, log, 0,
-                                  "zstd static: \"%s\" frame header "
-                                  "truncated", path.data);
-                    return NGX_DECLINED;
-                }
-
-                window = (uint64_t) 1 << (10 + (hdr[5] >> 3));
-                window += (window >> 3) * (hdr[5] & 7);
-
-            } else {
-                /*
-                 * Single_Segment: no Window_Descriptor; the window is
-                 * the frame content size, read from behind the optional
-                 * dictionary id. Frame_Content_Size_flag 0 means a
-                 * 1-byte field here (the flag only means "absent" when
-                 * Single_Segment is unset).
-                 */
-                fcs_size = (fhd >> 6) ? ((ngx_uint_t) 1 << (fhd >> 6)) : 1;
-                off = 5 + did_len[fhd & 3];
-
-                if ((size_t) n < off + fcs_size) {
-                    ngx_log_error(NGX_LOG_ERR, log, 0,
-                                  "zstd static: \"%s\" frame header "
-                                  "truncated", path.data);
-                    return NGX_DECLINED;
-                }
-
-                window = 0;
-                for (i = 0; i < fcs_size; i++) {
-                    window |= (uint64_t) hdr[off + i] << (8 * i);
-                }
-
-                if (fcs_size == 2) {
-                    window += 256;  /* RFC 8878: 2-byte field is offset */
-                }
-            }
-
-            if (window > NGX_HTTP_ZSTD_STATIC_MAX_WINDOW) {
-                ngx_log_error(NGX_LOG_ERR, log, 0,
-                              "zstd static: \"%s\" declares a %uL-byte "
-                              "decompression window, above the 8 MB limit "
-                              "browsers enforce for Content-Encoding: zstd "
-                              "(RFC 8878) — declining so a fallback "
-                              "encoding is used; recompress with a window "
-                              "log <= 23 (streaming encoders default to "
-                              "the compression level's window when not "
-                              "told the input size)",
-                              path.data, window);
-                return NGX_DECLINED;
-            }
+        default:
+            break;
         }
     }
 #endif /* NGX_HAVE_PREAD */


### PR DESCRIPTION
> From the release-audit backlog: `ngx_http_zstd_static_handler` was the most complex function in the tree. Pure refactor — no behaviour change intended, and the differential below is the evidence for that claim.

## TL;DR

When someone asks nginx for a file, this module can hand over a pre-compressed copy sitting on disk instead of compressing it on the fly. Before it does, it peeks at the first few bytes to check the file really is what it claims to be — a renamed text file or a half-finished download would otherwise reach the browser as garbage. That peek was buried in the middle of a 265-line function that also opens files, talks to the disk and builds the response, which made the one part of it that is easy to get subtly wrong — counting how many bytes it is allowed to look at — the part nothing could test directly.

The frame-header parse is lifted out of `ngx_http_zstd_static_handler()` into a pure `ngx_http_zstd_static_probe_frame()` that takes the buffer and the byte count and returns one of four verdicts; the handler keeps every `pread(2)`, directio-alignment and `ngx_log_error()` call and maps each verdict back to the return it already made inline.

**Severity:** `Low` (`maintainability — highest-complexity function in the tree, with its riskiest arithmetic untestable`)

## What moved, and what deliberately did not

The probe already had a seam: the `pread(2)`, the O_DIRECT alignment dance and every log line are I/O and request state, while the decision itself is arithmetic over the bytes that read returned. Only the arithmetic moved.

The handler still owns:

* the `of.size < 4` rejection and its `too small to be a zstd frame` line
* the directio-aligned `ngx_pmemalign()` probe buffer and the `directio_alignment` geometry
* the `n < 4` short-read split, which logs at `NGX_LOG_ERR` under directio and `NGX_LOG_CRIT` otherwise
* all four remaining `ngx_log_error()` calls, verbatim — same level, same format string, same arguments

The helper returns `FRAME_OK`, `FRAME_NOT_ZSTD`, `FRAME_TRUNCATED` or `FRAME_WINDOW_BIG`, writing the declared window through an out-param only in the last case. It is guarded by `#if !(NGX_WIN32) && (NGX_HAVE_PREAD)` to match its only call site, so a platform without `pread(2)` does not get an unused-function warning.

Nothing else in the file was touched. The other seams the audit item mentioned — response construction and the directio path — are entangled with `r->headers_out`, the buffer chain and `ngx_http_send_header()`'s return contract, so they stayed put. A refactor of those is not a lift, and this PR is not the place to find that out.

```
ngx_http_zstd_static_handler   265 NLOC / CCN 57  ->  227 NLOC / CCN 49
ngx_http_zstd_static_probe_frame                      48 NLOC / CCN 12
```

## Why bother — the probe is now testable

This is the actual payoff, and it is worth more than the eight points of complexity.

The risk in this code is not the magic-number compare. It is the four separate "did I get enough bytes for this layout" bounds, because a `.zst` frame header is variable-length: a `Frame_Header_Descriptor` selects a 0, 1, 2 or 4-byte dictionary ID and then a 1, 2, 4 or 8-byte content size, so the field the window check reads sits anywhere from offset 5 to offset 16 in an 18-byte buffer. Every one of those bounds is invisible to an end-to-end test, because a test that serves a real file always feeds the probe a complete header.

`ci/tests/unit/test_static_probe.c` adds 42 checks that state those boundaries directly — no nginx process, no filesystem, sub-second:

* each content-size width, plus a fixture one byte short of it
* the dictionary-ID offset table, with content-size bytes placed so that misreading the ID changes the verdict by orders of magnitude
* the widest layout (4-byte ID + 8-byte size, ending at offset 16) complete at 17 bytes and truncated at 16
* `Window_Descriptor` exponent and mantissa arithmetic, including the inclusive 8 MB cap and `0xFF` (a 2 TB window) not wrapping to something small enough to pass
* all 16 skippable magics, which must skip the window check entirely
* magic near-misses one bit and one nibble off

Checks run against a buffer padded with `0xA5` guard bytes, so a read past `n` lands on a defined wrong value rather than a zero that might accidentally be correct.

Like the parser suite, it links the *shipped* function body through a new `ci/fuzz/extract_static_probe.sh` rather than a hand-copy, so the test cannot drift from production. `extract_parser.sh` and `extract_dcz.sh` produce byte-identical output after this change — the new helper's name is outside both their match sets.

## Testing

**Differential against the pre-refactor code.** The old inlined body was transcribed verbatim, with each `ngx_log_error()`+`return NGX_DECLINED` pair replaced by the matching verdict, and run against the extracted helper over:

* every `(n, descriptor, next-byte)` triple for `n = 4..18` with a valid magic — exhaustive, 983,040 cases
* 20,000,000 random buffers, half forced to a real magic

**20,983,040 inputs, 0 mismatches** on both verdict and reported window.

That number means nothing without a live oracle, so: narrowing the `n < 6` guard to `n < 5` — a single off-by-one — produces **366,889 mismatches**, and the same mutation turns 2 of the 42 unit checks red (`a 5-byte streaming frame ... is TRUNCATED`, `window is untouched on TRUNCATED`). Reverted, both are green again.

**Full `ci/t/` suite:** 1750 assertions before, 1750 after. `01-static.t`, which is the load-bearing file for this path, is 459 both times. Run against a freshly rebuilt `ngx_http_zstd_static_module.so` on nginx 1.31.4.

**Unit suites:** 24/24 Accept-Encoding (unchanged) + 42/42 frame probe.

**Lint:** `review-lint.sh --branch origin/master` — all 17 lenses ran, none absent, no coverage-gap block. The two remaining findings on the touched file are pre-existing: `codespell` on `r->exten` (an actual nginx field name) and `lizard` on the handler's CCN, which this PR lowers rather than introduces.

One thing that pass did catch, worth naming because it is the failure mode the roster exists for: the test first included its generated slice via `-I`, and `clang-tidy` could not resolve it, so it silently skipped the entire translation unit and reported nothing — which reads exactly like a clean result. Including by relative path, the way `test_accept_encoding.c` already does and says why, made the file actually get analysed.

## CI

`ci/tests/unit/run.sh` is already wired into `build-test.yml`, so the new suite runs remotely without a new job. Its step name and comment were updated, since the runner now covers two suites rather than only the parser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of Zstandard-compressed responses, including truncated headers, unsupported frame types, oversized windows, and skippable frames.
  - Preserved fallback behavior when compressed content cannot be safely validated.
  - Added more specific error reporting for invalid or incomplete Zstandard headers.

- **Tests**
  - Expanded automated coverage for content-encoding parsing and Zstandard frame-header validation to improve release reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->