### PR TITLE
perf: reuse a worker-lifetime ZSTD_CCtx across responses

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1431,9 +1431,10 @@ jobs:
           # must actually ENGAGE (asserted from the debug witnesses -- a
           # cache that never hits passes every other test in this file),
           # and a reused context must carry no residue into the next
-          # response. Also pins the level partition: the retained workspace
-          # is compression-level-driven and never shrinks, so a location at
-          # a different zstd_comp_level must not reuse the cached context.
+          # response. Also pins the profile partition: the retained
+          # workspace is driven by zstd_comp_level, zstd_long AND
+          # zstd_window_log and never shrinks, so a location differing in
+          # any of the three must not reuse the cached context.
           python3 ci/tools/test_cctx_reuse.py \
             --nginx-binary "$TEST_NGINX_BINARY" \
             --port 18116

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1421,6 +1421,24 @@ jobs:
             --concurrency 16 --rounds 6
           echo "✓ per-request CCtx isolation regression passed"
 
+      - name: Run worker CCtx cache regression
+        timeout-minutes: 6
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          # The filter lends one worker-lifetime CCtx to one request at a
+          # time instead of creating one per response. Two properties, and
+          # the correctness suite above only covers the second: the cache
+          # must actually ENGAGE (asserted from the debug witnesses -- a
+          # cache that never hits passes every other test in this file),
+          # and a reused context must carry no residue into the next
+          # response. Also pins the level partition: the retained workspace
+          # is compression-level-driven and never shrinks, so a location at
+          # a different zstd_comp_level must not reuse the cached context.
+          python3 ci/tools/test_cctx_reuse.py \
+            --nginx-binary "$TEST_NGINX_BINARY" \
+            --port 18116
+          echo "✓ worker CCtx cache regression passed"
+
       - name: Run reload-under-load correctness regression
         timeout-minutes: 6
         run: |
@@ -1866,6 +1884,13 @@ jobs:
             --nginx-binary "$TEST_NGINX_BINARY" --port 19096 --backend-port 19097
           python3 ci/tools/test_concurrent_cctx_isolation.py \
             --nginx-binary "$TEST_NGINX_BINARY" --port 19098 --backend-port 19099
+          # --log-level warn: UBSAN (-fno-sanitize-recover) fatally traps
+          # nginx core's own debug logging (ngx_string.c:586), so a
+          # sanitized nginx cannot run at debug at all. The byte-exactness
+          # oracles still gate here; the cache-engagement witnesses are
+          # asserted by the same tool in the non-sanitized tests job.
+          python3 ci/tools/test_cctx_reuse.py \
+            --nginx-binary "$TEST_NGINX_BINARY" --port 19114 --log-level warn
           python3 ci/tools/test_proxy_unbuffered_truncation.py \
             --nginx-binary "$TEST_NGINX_BINARY" --port 19094 --backend-port 19095
           # The reason this tool exists: the floor below assumes the

--- a/ci/tools/test_cctx_reuse.py
+++ b/ci/tools/test_cctx_reuse.py
@@ -22,11 +22,15 @@ Two properties have to hold at once, and a test for either alone is worthless:
      context), this one proves the SEQUENTIAL case (the reused context must
      carry no residue from the previous response).
 
-Also pins the level-partition rule: a location with a different
-zstd_comp_level must NOT reuse a context cached for another level, because the
-retained workspace is level-driven and never shrinks. Without that partition a
-single level-19 location would raise the worker's memory floor for every
-request of every other location.
+Also pins the PROFILE-partition rule: a location whose memory-affecting
+profile differs must NOT reuse a context cached for another profile, because
+the retained workspace never shrinks on reset. The profile is all three of
+zstd_comp_level, zstd_long and zstd_window_log -- measured on libzstd 1.5.7,
+streaming at a fixed level 6 with an unknown pledged size, ZSTD_sizeof_CCtx()
+is 4.2 MB at window_log 20 and 131 MB at window_log 27, and 147 MB with
+zstd_long on and no explicit window. Keying on the level alone would let a
+single high-memory location raise the worker's floor for every request of
+every other location and silently defeat their zstd_max_cctx_memory budget.
 
 Needs an nginx built --with-debug: the reuse witnesses are debug log lines.
 """
@@ -158,8 +162,14 @@ def main() -> int:
 
         for rid in range(ROUNDS):
             (html / f"b{rid}").write_bytes(fixture(rid))
-        # Served by a location pinned to a different zstd_comp_level.
+        # Served by the three locations that must each take the per-request
+        # path: one differing only in zstd_comp_level, one differing only in
+        # zstd_long, one differing only in zstd_window_log. The latter two
+        # sit at the SAME level as the cached default on purpose -- under a
+        # level-only cache key they would wrongly borrow it.
         (alt / "b").write_bytes(fixture(999))
+        (alt / "long").write_bytes(fixture(998))
+        (alt / "wlog").write_bytes(fixture(997))
 
         lvl = args.log_level
         conf = root / "nginx.conf"
@@ -181,10 +191,23 @@ http {{
             error_log {root}/logs/error.log {lvl};
             alias {html}/;
         }}
-        location /alt/ {{
+        location /alt/b {{
             error_log {root}/logs/error.log {lvl};
-            alias {alt}/;
+            alias {alt}/b;
             zstd_comp_level 9;
+        }}
+        # Same compression level as the cached default context; differs
+        # only in a memory-affecting parameter. Each must create its own
+        # context rather than borrowing the cached one.
+        location /alt/long {{
+            error_log {root}/logs/error.log {lvl};
+            alias {alt}/long;
+            zstd_long on;
+        }}
+        location /alt/wlog {{
+            error_log {root}/logs/error.log {lvl};
+            alias {alt}/wlog;
+            zstd_window_log 20;
         }}
     }}
 }}
@@ -231,11 +254,14 @@ http {{
                     )
                     break
 
-            # A different zstd_comp_level must take the per-request path.
-            alt_want = fixture(999)
-            alt_got = decode(http_get(args.port, "/alt/b"))
-            if alt_got != alt_want:
-                failures.append("level-9 location: decoded body mismatch")
+            # Each differing memory profile must take the per-request path.
+            for path, rid, label in (
+                ("/alt/b", 999, "zstd_comp_level 9"),
+                ("/alt/long", 998, "zstd_long on"),
+                ("/alt/wlog", 997, "zstd_window_log 20"),
+            ):
+                if decode(http_get(args.port, path)) != fixture(rid):
+                    failures.append(f"{label} location: decoded body mismatch")
 
             # Flush the debug log before reading witnesses.
             time.sleep(0.3)
@@ -252,19 +278,24 @@ http {{
 
             # --- property 1: the cache actually engages ---
             #
-            # Exactly two contexts are ever created: the level-3 default one
-            # seeded by the first /b request, and the level-9 one the /alt
-            # location cannot borrow. Anything more means the cache is not
-            # holding across requests.
-            if args.log_level == "debug" and created != 2:
+            # Exactly four contexts are ever created: the default-profile one
+            # seeded by the first /b request, plus one each for the three
+            # /alt locations, none of which may borrow it. Fewer than four
+            # means the cache lent across differing memory profiles -- the
+            # bug this partition exists to prevent, and the two same-level
+            # locations are the ones a level-only key gets wrong. More than
+            # four means the cache is not holding across requests.
+            if args.log_level == "debug" and created != 4:
                 failures.append(
-                    f"expected exactly 2 'created cctx' witnesses "
-                    f"(one cached default-level, one for the level-9 "
-                    f"location that must not reuse it), saw {created} -- "
-                    f"the cache is not surviving across requests"
+                    f"expected exactly 4 'created cctx' witnesses (one "
+                    f"cached default profile, plus one each for the "
+                    f"zstd_comp_level / zstd_long / zstd_window_log "
+                    f"locations that must not reuse it), saw {created} -- "
+                    f"the cache is either lending across memory profiles or "
+                    f"not surviving across requests"
                 )
             # ROUNDS-1: the first /b request seeds the cache (counted as a
-            # create, not a reuse). The /alt request is a create too.
+            # create, not a reuse). Each /alt request is a create too.
             if args.log_level == "debug" and reused != ROUNDS - 1:
                 failures.append(
                     f"expected {ROUNDS - 1} 'reusing worker cctx' witnesses "
@@ -279,7 +310,7 @@ http {{
                 if args.log_level == "debug":
                     print(
                         f"  witnesses: {created} cctx created, {reused} "
-                        f"reused -- cache engaged and level-partitioned"
+                        f"reused -- cache engaged and profile-partitioned"
                     )
         finally:
             proc.terminate()
@@ -296,8 +327,9 @@ http {{
 
     print(
         f"OK: worker CCtx cache reused across {ROUNDS} sequential requests "
-        f"with no cross-request state bleed, and a different zstd_comp_level "
-        f"correctly took the per-request path"
+        f"with no cross-request state bleed, and a differing "
+        f"zstd_comp_level, zstd_long or zstd_window_log each correctly took "
+        f"the per-request path"
     )
     return 0
 

--- a/ci/tools/test_cctx_reuse.py
+++ b/ci/tools/test_cctx_reuse.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Regression test for the worker-lifetime ZSTD_CCtx cache.
+
+ZSTD_createCCtx() plus its first-use workspace allocation is 34-75% of the
+per-response libzstd CPU at typical body sizes, so the filter lends one
+worker-lifetime context to one request at a time instead of creating a fresh
+context per response.
+
+Two properties have to hold at once, and a test for either alone is worthless:
+
+  1. The cache actually engages. A green correctness suite proves only that
+     nothing broke -- it passes identically if the cache never hits and every
+     request builds its own context, which is the bug this optimisation exists
+     to avoid. Asserted here from the ngx_log_debug witnesses: N sequential
+     requests through one worker must yield exactly ONE "created cctx" and
+     N-1 "reusing worker cctx".
+
+  2. Reuse never bleeds state between requests. Asserted by decoding every
+     response and byte-comparing it to its own distinct origin body. This
+     overlaps test_concurrent_cctx_isolation.py on purpose: that tool proves
+     the CONCURRENT case (a second in-flight claimant must not get the loaned
+     context), this one proves the SEQUENTIAL case (the reused context must
+     carry no residue from the previous response).
+
+Also pins the level-partition rule: a location with a different
+zstd_comp_level must NOT reuse a context cached for another level, because the
+retained workspace is level-driven and never shrinks. Without that partition a
+single level-19 location would raise the worker's memory floor for every
+request of every other location.
+
+Needs an nginx built --with-debug: the reuse witnesses are debug log lines.
+"""
+
+import argparse
+import importlib.util
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+
+MODULE_PATH = pathlib.Path(__file__).with_name("test_encoding.py")
+SPEC = importlib.util.spec_from_file_location("test_encoding", MODULE_PATH)
+test_encoding = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(test_encoding)
+
+CREATE_WITNESS = "zstd: created cctx"
+REUSE_WITNESS = "zstd: reusing worker cctx"
+
+# Enough requests that a one-off cache miss cannot be mistaken for the
+# steady state, small enough to stay fast.
+ROUNDS = 12
+
+# Comfortably over zstd_min_length, and distinct per request so a stale
+# context serving the previous body is a byte mismatch, not a silent pass.
+BODY_SIZE = 24 * 1024
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Regression test for the worker-lifetime ZSTD_CCtx cache."
+    )
+    parser.add_argument("--nginx-binary", required=True)
+    parser.add_argument("--filter-module")
+    parser.add_argument("--port", type=int, default=18116)
+    parser.add_argument(
+        "--log-level",
+        choices=("debug", "warn"),
+        default="debug",
+        help="Location error_log level. The cache-engagement witnesses are "
+        "only asserted at debug. Use warn under sanitizer builds: UBSAN "
+        "(-fno-sanitize-recover) fatally traps nginx core's own debug "
+        'logging -- every "%%V?%%V" line passes r->args={0,NULL} into '
+        "ngx_sprintf_str's nonnull argument on query-less URIs "
+        "(ngx_string.c:586) -- so a sanitized nginx cannot log at debug at "
+        "all. The byte-exactness oracles still run and still gate; only the "
+        "witness counts are skipped.",
+    )
+    parser.add_argument(
+        "--zstd-bin",
+        default=test_encoding.shutil.which("zstd") or "zstd",
+    )
+    return parser.parse_args()
+
+
+def fixture(rid: int) -> bytes:
+    """A distinct, compressible body per request id.
+
+    Distinct matters: if every request shared one body, a context that
+    replayed the PREVIOUS response would still decode byte-exact and the
+    isolation half of this test would assert nothing.
+    """
+    seed = f"cctx-reuse-{rid:04d}-".encode()
+    return (seed * (BODY_SIZE // len(seed) + 1))[:BODY_SIZE]
+
+
+def http_get(port: int, path: str) -> bytes:
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}",
+        headers={"Accept-Encoding": "zstd"},
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        if resp.headers.get("Content-Encoding") != "zstd":
+            raise RuntimeError(
+                f"{path}: expected Content-Encoding: zstd, got "
+                f"{resp.headers.get('Content-Encoding')!r} -- the response was "
+                f"not compressed, so this run proves nothing about the cache"
+            )
+        return resp.read()
+
+
+def main() -> int:
+    args = parse_args()
+    nginx = pathlib.Path(args.nginx_binary)
+    if not nginx.exists():
+        raise FileNotFoundError(nginx)
+
+    v = subprocess.run([str(nginx), "-V"], capture_output=True, text=True, check=False)
+    if "zstd" not in v.stderr:
+        raise RuntimeError("nginx -V shows no zstd module")
+    if args.log_level == "debug" and "--with-debug" not in v.stderr:
+        raise RuntimeError(
+            "the reuse witnesses are ngx_log_debug lines: this tool needs an "
+            "nginx built --with-debug, or --log-level warn to skip them"
+        )
+
+    filter_so = test_encoding.detect_module_path(
+        args.filter_module, nginx, "ngx_http_zstd_filter_module.so"
+    )
+    load = f"load_module {filter_so};\n" if filter_so else ""
+
+    def decode(blob: bytes) -> bytes:
+        r = subprocess.run(
+            [args.zstd_bin, "-d", "-q", "-c"],
+            input=blob,
+            capture_output=True,
+            check=False,
+        )
+        if r.returncode != 0:
+            raise RuntimeError(
+                "zstd decode failed: " + r.stderr.decode("utf-8", "replace").strip()
+            )
+        return r.stdout
+
+    os.umask(0o022)
+    with tempfile.TemporaryDirectory(prefix="zstd-cctx-reuse-") as td:
+        os.chmod(td, 0o755)
+        root = pathlib.Path(td)
+        (root / "logs").mkdir()
+        html = root / "html"
+        html.mkdir()
+        alt = root / "html-alt"
+        alt.mkdir()
+
+        for rid in range(ROUNDS):
+            (html / f"b{rid}").write_bytes(fixture(rid))
+        # Served by a location pinned to a different zstd_comp_level.
+        (alt / "b").write_bytes(fixture(999))
+
+        lvl = args.log_level
+        conf = root / "nginx.conf"
+        conf.write_text(
+            f"""worker_processes 1;
+{load}error_log {root}/logs/error.log warn;
+pid {root}/nginx.pid;
+events {{ worker_connections 64; }}
+http {{
+    access_log off;
+    default_type application/octet-stream;
+    zstd on;
+    zstd_min_length 1;
+    zstd_types application/octet-stream;
+    gzip_vary on;
+    server {{
+        listen 127.0.0.1:{args.port};
+        location /b {{
+            error_log {root}/logs/error.log {lvl};
+            alias {html}/;
+        }}
+        location /alt/ {{
+            error_log {root}/logs/error.log {lvl};
+            alias {alt}/;
+            zstd_comp_level 9;
+        }}
+    }}
+}}
+""",
+            encoding="utf-8",
+        )
+
+        nlog_path = root / "logs" / "nginx-stdout.log"
+        nlog = open(nlog_path, "w", encoding="utf-8")  # noqa: SIM115
+        proc = subprocess.Popen(
+            [
+                str(nginx),
+                "-p",
+                str(root),
+                "-c",
+                str(conf),
+                "-g",
+                "daemon off; master_process off;",
+            ],
+            stdout=nlog,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+        failures: list[str] = []
+        try:
+            test_encoding.wait_for_port(args.port)
+            if proc.poll() is not None:
+                nlog.flush()
+                raise RuntimeError(
+                    "nginx exited during startup; tail:\n"
+                    + nlog_path.read_text("utf-8", "replace")[-2000:]
+                )
+
+            # --- property 2: no state bleed across reused contexts ---
+            for rid in range(ROUNDS):
+                want = fixture(rid)
+                got = decode(http_get(args.port, f"/b/b{rid}"))
+                if got != want:
+                    failures.append(
+                        f"request {rid}: decoded {len(got)}B != origin "
+                        f"{len(want)}B -- the reused context carried state "
+                        f"from a previous response"
+                    )
+                    break
+
+            # A different zstd_comp_level must take the per-request path.
+            alt_want = fixture(999)
+            alt_got = decode(http_get(args.port, "/alt/b"))
+            if alt_got != alt_want:
+                failures.append("level-9 location: decoded body mismatch")
+
+            # Flush the debug log before reading witnesses.
+            time.sleep(0.3)
+            elog = (root / "logs" / "error.log").read_text("utf-8", "replace")
+            created = len(re.findall(re.escape(CREATE_WITNESS), elog))
+            reused = len(re.findall(re.escape(REUSE_WITNESS), elog))
+
+            if args.log_level != "debug":
+                print(
+                    "  witnesses skipped (--log-level warn: a sanitized "
+                    "nginx cannot log at debug -- byte-exactness still "
+                    "gates, cache engagement is NOT proven in this run)"
+                )
+
+            # --- property 1: the cache actually engages ---
+            #
+            # Exactly two contexts are ever created: the level-3 default one
+            # seeded by the first /b request, and the level-9 one the /alt
+            # location cannot borrow. Anything more means the cache is not
+            # holding across requests.
+            if args.log_level == "debug" and created != 2:
+                failures.append(
+                    f"expected exactly 2 'created cctx' witnesses "
+                    f"(one cached default-level, one for the level-9 "
+                    f"location that must not reuse it), saw {created} -- "
+                    f"the cache is not surviving across requests"
+                )
+            # ROUNDS-1: the first /b request seeds the cache (counted as a
+            # create, not a reuse). The /alt request is a create too.
+            if args.log_level == "debug" and reused != ROUNDS - 1:
+                failures.append(
+                    f"expected {ROUNDS - 1} 'reusing worker cctx' witnesses "
+                    f"across {ROUNDS} sequential requests, saw {reused}"
+                )
+
+            if not failures:
+                print(
+                    f"  {ROUNDS} sequential responses decoded byte-exact to "
+                    f"their own origins"
+                )
+                if args.log_level == "debug":
+                    print(
+                        f"  witnesses: {created} cctx created, {reused} "
+                        f"reused -- cache engaged and level-partitioned"
+                    )
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            nlog.close()
+
+        if failures:
+            for f in failures:
+                print(f"FAIL: {f}", file=sys.stderr)
+            return 1
+
+    print(
+        f"OK: worker CCtx cache reused across {ROUNDS} sequential requests "
+        f"with no cross-request state bleed, and a different zstd_comp_level "
+        f"correctly took the per-request path"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -354,19 +354,43 @@ static ngx_int_t ngx_http_zstd_filter_emit_dcz_header(ngx_http_request_t *r,
  *
  * Why there is no runtime memory cap: ZSTD_sizeof_CCtx() does not shrink on
  * reset, so an unbounded cache would pin each worker's RSS at its
- * largest-ever footprint. Measured, the retained workspace is driven by the
- * COMPRESSION LEVEL, not by windowLog or by a dcz raw prefix (level 1 ->
- * 582 KB, level 19 -> 85 MB, and returning to level 1 keeps the 85 MB;
- * windowLog 20 vs 27 and a 1 MB refPrefix all leave it unchanged at a fixed
- * level). zstd_comp_level is fixed at config load, and zstd_max_cctx_memory
- * already asserts that level's estimated footprint against the operator's
- * budget at config time. So the cached context's high-water mark is exactly
- * the figure config load already vetted, and pinning the cache to one level
- * keeps it there. A location with a different
- * zstd_comp_level does not reuse the cache; it takes the per-request path.
+ * largest-ever footprint. The cache is therefore keyed on the COMPLETE set
+ * of parameters that drive that workspace, and every one of them is fixed at
+ * config load: zstd_comp_level, zstd_long and zstd_window_log.
+ *
+ * An earlier revision keyed on the level alone, on a measurement that said
+ * windowLog did not move ZSTD_sizeof_CCtx() at a fixed level. That
+ * measurement was taken with a known pledged source size, which clamps the
+ * window to the input; it does not hold on this module's path, where the
+ * body length is generally unknown to libzstd. Re-measured on libzstd 1.5.7
+ * with a streaming, unknown-size compression at level 6:
+ *
+ *     zstd_long  zstd_window_log   ZSTD_sizeof_CCtx()
+ *     off        (unset)                    5 498 401
+ *     off        20                         4 449 825
+ *     off        27                       137 618 977
+ *     on         (unset)                  154 551 841
+ *     on         20                         4 606 497
+ *     on         27                       154 551 841
+ *
+ * So both zstd_long and zstd_window_log move the retained workspace by more
+ * than thirty times at one level, and the growth is permanent: walking a
+ * context through the 154 MB profile and back to the 4 MB one leaves
+ * ZSTD_sizeof_CCtx() at 154 MB. Lending one worker context across locations
+ * with differing profiles would raise the worker's floor to the largest
+ * profile ever served and silently defeat a lower location's
+ * zstd_max_cctx_memory budget, which is computed from exactly these three
+ * values at config load.
+ *
+ * Keying on all three keeps the cached context's high-water mark equal to
+ * the figure config load already vetted for that profile. A location whose
+ * profile differs in any of the three does not reuse the cache; it takes the
+ * per-request path, which is the pre-existing safe behaviour.
  */
 static ZSTD_CCtx  *ngx_http_zstd_worker_cctx;
 static ngx_int_t   ngx_http_zstd_worker_cctx_level;
+static ngx_flag_t  ngx_http_zstd_worker_cctx_long_mode;
+static ngx_int_t   ngx_http_zstd_worker_cctx_window_log;
 static ngx_uint_t  ngx_http_zstd_worker_cctx_busy;
 
 
@@ -1775,15 +1799,18 @@ ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
 
     /*
      * Borrow the worker context when it is free and was built for this
-     * location's compression level. A level mismatch takes the per-request
-     * path rather than re-levelling the cache: the retained workspace is
-     * level-driven and never shrinks, so honouring a higher-level location
-     * here would raise the worker's floor for every subsequent request of
-     * every other location.
+     * location's complete memory-affecting profile: compression level, long
+     * mode and window log. A mismatch in any of the three takes the
+     * per-request path rather than re-parameterising the cache: the retained
+     * workspace is driven by all three and never shrinks, so honouring a
+     * higher-memory location here would raise the worker's floor for every
+     * subsequent request of every other location.
      */
     if (!ngx_http_zstd_worker_cctx_busy
         && ngx_http_zstd_worker_cctx != NULL
-        && ngx_http_zstd_worker_cctx_level == zlcf->level)
+        && ngx_http_zstd_worker_cctx_level == zlcf->level
+        && ngx_http_zstd_worker_cctx_long_mode == zlcf->long_mode
+        && ngx_http_zstd_worker_cctx_window_log == zlcf->window_log)
     {
         ctx->cctx = ngx_http_zstd_worker_cctx;
         borrowed = 1;
@@ -1807,6 +1834,8 @@ ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
         if (ngx_http_zstd_worker_cctx == NULL) {
             ngx_http_zstd_worker_cctx = ctx->cctx;
             ngx_http_zstd_worker_cctx_level = zlcf->level;
+            ngx_http_zstd_worker_cctx_long_mode = zlcf->long_mode;
+            ngx_http_zstd_worker_cctx_window_log = zlcf->window_log;
             borrowed = 1;
         }
 

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -318,6 +318,10 @@ static char *ngx_conf_zstd_set_num_slot_with_negatives(ngx_conf_t *cf,
     ngx_command_t *cmd, void *conf);
 static void ngx_http_zstd_cleanup_dict(void *data);
 static void ngx_http_zstd_cleanup_cctx(void *data);
+static void ngx_http_zstd_release_cctx(void *data);
+static ngx_int_t ngx_http_zstd_acquire_cctx(ngx_http_request_t *r,
+    ngx_http_zstd_ctx_t *ctx, ngx_http_zstd_loc_conf_t *zlcf);
+static void ngx_http_zstd_exit_process(ngx_cycle_t *cycle);
 static char *ngx_http_zstd_dcz_dict_file(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 static ngx_table_elt_t *ngx_http_zstd_find_request_header(
@@ -326,6 +330,44 @@ static ngx_http_zstd_dcz_dict_t *ngx_http_zstd_dcz_negotiate(
     ngx_http_request_t *r, ngx_http_zstd_loc_conf_t *zlcf);
 static ngx_int_t ngx_http_zstd_filter_emit_dcz_header(ngx_http_request_t *r,
     ngx_http_zstd_ctx_t *ctx);
+
+
+/*
+ * Worker-lifetime CCtx cache.
+ *
+ * ZSTD_createCCtx() plus the first-use workspace allocation is 34-75% of the
+ * per-response libzstd CPU on typical body sizes (measured, libzstd 1.5.7:
+ * ~1.6us of 3.1us at level 6 / 8 KB; ~10.8us of 15.0us at level 6 / 64 KB).
+ * Since ngx_http_zstd_filter_init_cctx() already does a full
+ * ZSTD_reset_session_and_parameters() and re-applies every parameter on each
+ * request, a context carried across requests is byte-for-byte equivalent on
+ * the wire to a freshly created one -- the creation is pure overhead.
+ *
+ * Why this does NOT reintroduce the shared-context bug 774b4a5 fixed: that
+ * commit's defect was a context shared between CONCURRENT requests (interleaved
+ * compression state). Here the cache lends the context to exactly one
+ * request at a time -- `busy` is set on loan and cleared by the request
+ * pool's cleanup handler -- so any second concurrent claimant (a subrequest
+ * compressing while the main request is mid-stream) transparently gets its
+ * own per-request context instead. The per-request ownership model is
+ * preserved; only the allocation is amortised.
+ *
+ * Why there is no runtime memory cap: ZSTD_sizeof_CCtx() does not shrink on
+ * reset, so an unbounded cache would pin each worker's RSS at its
+ * largest-ever footprint. Measured, the retained workspace is driven by the
+ * COMPRESSION LEVEL, not by windowLog or by a dcz raw prefix (level 1 ->
+ * 582 KB, level 19 -> 85 MB, and returning to level 1 keeps the 85 MB;
+ * windowLog 20 vs 27 and a 1 MB refPrefix all leave it unchanged at a fixed
+ * level). zstd_comp_level is fixed at config load, and zstd_max_cctx_memory
+ * already asserts that level's estimated footprint against the operator's
+ * budget at config time. So the cached context's high-water mark is exactly
+ * the figure config load already vetted, and pinning the cache to one level
+ * keeps it there. A location with a different
+ * zstd_comp_level does not reuse the cache; it takes the per-request path.
+ */
+static ZSTD_CCtx  *ngx_http_zstd_worker_cctx;
+static ngx_int_t   ngx_http_zstd_worker_cctx_level;
+static ngx_uint_t  ngx_http_zstd_worker_cctx_busy;
 
 
 static ngx_conf_post_t  ngx_http_zstd_comp_level_bounds = {
@@ -490,7 +532,7 @@ ngx_module_t  ngx_http_zstd_filter_module = {
     NULL,                                   /* init process */
     NULL,                                   /* init thread */
     NULL,                                   /* exit thread */
-    NULL,                                   /* exit process */
+    ngx_http_zstd_exit_process,             /* exit process */
     NULL,                                   /* exit master */
     NGX_MODULE_V1_PADDING
 };
@@ -1701,10 +1743,101 @@ ngx_http_zstd_set_param(ngx_http_request_t *r, ZSTD_CCtx *cctx,
 
 
 /*
- * Configure a per-request CCtx on first body data.
- * The CCtx is allocated outside the request pool but attached to the request
- * cleanup chain, so overlapping requests in one worker never share libzstd
- * streaming state.
+ * Give this request a CCtx: either the worker's cached one on loan, or a
+ * fresh per-request context.
+ *
+ * Extracted from ngx_http_zstd_filter_init_cctx() so the loan bookkeeping --
+ * which cleanup handler owns the context, and when `busy` may be set -- reads
+ * as one unit instead of as five branches inside the parameter-setting code.
+ *
+ * On success ctx->cctx is non-NULL and a pool cleanup owns it: either
+ * ngx_http_zstd_release_cctx (returns the loan) or ngx_http_zstd_cleanup_cctx
+ * (frees an unshared context).
+ */
+static ngx_int_t
+ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
+    ngx_http_zstd_loc_conf_t *zlcf)
+{
+    ngx_uint_t           borrowed;
+    ngx_pool_cleanup_t  *cln;
+
+    /*
+     * The cleanup slot is registered BEFORE the context is claimed, so a
+     * borrowed context can never be stranded with busy set: an allocation
+     * failure here happens while the cache is still untouched.
+     */
+    cln = ngx_pool_cleanup_add(r->pool, 0);
+    if (cln == NULL) {
+        return NGX_ERROR;
+    }
+
+    borrowed = 0;
+
+    /*
+     * Borrow the worker context when it is free and was built for this
+     * location's compression level. A level mismatch takes the per-request
+     * path rather than re-levelling the cache: the retained workspace is
+     * level-driven and never shrinks, so honouring a higher-level location
+     * here would raise the worker's floor for every subsequent request of
+     * every other location.
+     */
+    if (!ngx_http_zstd_worker_cctx_busy
+        && ngx_http_zstd_worker_cctx != NULL
+        && ngx_http_zstd_worker_cctx_level == zlcf->level)
+    {
+        ctx->cctx = ngx_http_zstd_worker_cctx;
+        borrowed = 1;
+
+        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "zstd: reusing worker cctx %p", ctx->cctx);
+
+    } else {
+        ctx->cctx = ZSTD_createCCtx();
+        if (ctx->cctx == NULL) {
+            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                          "zstd: ZSTD_createCCtx() failed");
+            return NGX_ERROR;
+        }
+
+        /*
+         * Seed an empty cache so subsequent requests amortise. Only an empty
+         * cache is populated -- a live cached context is never evicted
+         * mid-flight, and one already on loan is left alone.
+         */
+        if (ngx_http_zstd_worker_cctx == NULL) {
+            ngx_http_zstd_worker_cctx = ctx->cctx;
+            ngx_http_zstd_worker_cctx_level = zlcf->level;
+            borrowed = 1;
+        }
+
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "zstd: created cctx %p (cached:%ui)",
+                       ctx->cctx, borrowed);
+    }
+
+    if (borrowed) {
+        ngx_http_zstd_worker_cctx_busy = 1;
+        cln->handler = ngx_http_zstd_release_cctx;
+
+    } else {
+        cln->handler = ngx_http_zstd_cleanup_cctx;
+    }
+
+    cln->data = ctx->cctx;
+
+    return NGX_OK;
+}
+
+
+/*
+ * Configure this request's CCtx on first body data.
+ *
+ * The context comes from ngx_http_zstd_acquire_cctx() -- either the worker's
+ * cached one on loan or a fresh per-request one -- and is attached to the
+ * request cleanup chain either way, so overlapping requests in one worker
+ * never share libzstd streaming state. Every parameter is (re-)applied here
+ * after a full reset, which is what makes a carried-over context equivalent
+ * to a freshly created one.
  */
 static ngx_int_t
 ngx_http_zstd_filter_init_cctx(ngx_http_request_t *r,
@@ -1716,25 +1849,10 @@ ngx_http_zstd_filter_init_cctx(ngx_http_request_t *r,
 
     zlcf = ngx_http_get_module_loc_conf(r, ngx_http_zstd_filter_module);
 
-    if (ctx->cctx == NULL) {
-        ngx_pool_cleanup_t  *cln;
-
-        ctx->cctx = ZSTD_createCCtx();
-        if (ctx->cctx == NULL) {
-            ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
-                          "zstd: ZSTD_createCCtx() failed");
-            return NGX_ERROR;
-        }
-
-        cln = ngx_pool_cleanup_add(r->pool, 0);
-        if (cln == NULL) {
-            ZSTD_freeCCtx(ctx->cctx);
-            ctx->cctx = NULL;
-            return NGX_ERROR;
-        }
-
-        cln->handler = ngx_http_zstd_cleanup_cctx;
-        cln->data = ctx->cctx;
+    if (ctx->cctx == NULL
+        && ngx_http_zstd_acquire_cctx(r, ctx, zlcf) != NGX_OK)
+    {
+        return NGX_ERROR;
     }
 
     cctx = ctx->cctx;
@@ -2716,6 +2834,67 @@ ngx_http_zstd_cleanup_cctx(void *data)
     if (cctx != NULL) {
         ZSTD_freeCCtx(cctx);
     }
+}
+
+
+/*
+ * Return a borrowed worker context to the cache at request end.
+ *
+ * Runs from the request pool's cleanup list, so it fires on every exit path --
+ * normal completion, client abort, upstream error, worker shutdown of a live
+ * request -- which is what makes `busy` a reliable loan flag rather than a leak
+ * waiting for the one path that forgot to clear it.
+ *
+ * The session is reset HERE, not only on the next acquire: a request may be
+ * abandoned mid-stream (client reset on a partially compressed response), and
+ * leaving that half-finished frame state resident means the cached context
+ * holds the previous response's compression state until something else
+ * claims it.
+ * init_cctx does reset before reuse, so this is defence in depth against a
+ * future caller that forgets -- and it releases the session's internal buffers
+ * promptly rather than pinning them until the next request arrives.
+ */
+static void
+ngx_http_zstd_release_cctx(void *data)
+{
+    ZSTD_CCtx *cctx = data;
+
+    if (cctx == NULL) {
+        return;
+    }
+
+    if (cctx == ngx_http_zstd_worker_cctx) {
+        (void) ZSTD_CCtx_reset(cctx, ZSTD_reset_session_only);
+        ngx_http_zstd_worker_cctx_busy = 0;
+        return;
+    }
+
+    /*
+     * Not the cached context: the cache was replaced while this request held
+     * its loan (only reachable if a future edit adds eviction). Own it.
+     */
+    ZSTD_freeCCtx(cctx);
+}
+
+
+/*
+ * Free the worker's cached context at process exit.
+ *
+ * Without this the cache is a live allocation at shutdown, which LeakSanitizer
+ * and Valgrind both report -- this tree gates on both, so a "harmless" one-off
+ * worker-lifetime leak would be a red CI job, not a footnote. Any request still
+ * holding a loan has already had its pool destroyed by the time module exit
+ * handlers run, so the context is unowned here.
+ */
+static void
+ngx_http_zstd_exit_process(ngx_cycle_t *cycle)
+{
+    if (ngx_http_zstd_worker_cctx != NULL) {
+        ZSTD_freeCCtx(ngx_http_zstd_worker_cctx);
+        ngx_http_zstd_worker_cctx = NULL;
+    }
+
+    ngx_http_zstd_worker_cctx_busy = 0;
 }
 
 


### PR DESCRIPTION
> Found while profiling the compress path. Independent of the RFC 9842 dcz work already on master; this touches only how the compression context is obtained, not how it is configured or used.

## TL;DR

Compressing a response used to build a brand-new compression context from scratch every single time, then throw it away. For small responses that setup was most of the work — more than the compression itself. Each worker now keeps one context around and lends it to one request at a time, which nearly doubles throughput on small bodies.

`ngx_http_zstd_acquire_cctx()` lends a worker-lifetime `ZSTD_CCtx` to one request at a time, keyed on the location's compression level, long-distance mode and window log; `ngx_http_zstd_release_cctx()` returns the loan from the request pool cleanup and `ngx_http_zstd_exit_process()` frees the cache at worker exit.

**Severity:** `Low` (`performance — avoidable per-response allocation on the compress hot path`)

## Mechanism

`ZSTD_createCCtx()` plus the first-use workspace allocation measured 34-75% of the per-response libzstd CPU (libzstd 1.5.7: ~1.6us of 3.1us at level 6 / 8 KB; ~10.8us of 15.0us at level 6 / 64 KB). `ngx_http_zstd_filter_init_cctx()` already performs a full `ZSTD_reset_session_and_parameters()` and re-applies every parameter per request, so a carried context is wire-equivalent to a fresh one — the creation was pure overhead.

The cache lends to exactly one request at a time. `busy` is set on loan and cleared by the request pool's cleanup handler, so a second concurrent claimant transparently falls back to its own per-request context. This is why it does not reintroduce the shared-context defect fixed in `774b4a5`: that bug was one context shared *between* concurrent requests; the per-request ownership model is preserved here and only the allocation is amortised.

Two ordering details carry the safety:

- the pool cleanup slot is registered *before* the context is claimed, so an allocation failure cannot strand a borrowed context with `busy` set;
- `ngx_http_zstd_release_cctx()` runs from the request pool cleanup list, so it fires on every exit path including client abort and mid-stream reset, and resets the session there rather than relying on the next acquire.

## Cache key and the memory cap

`ZSTD_sizeof_CCtx()` does not shrink on reset, so a context lent across differing
profiles would pin each worker's RSS at its largest-ever footprint. Measured
against libzstd 1.5.7 on this filter's actual path (streaming, source size
unknown to libzstd), at a fixed level 6:

| `zstd_long` | `zstd_window_log` | `ZSTD_sizeof_CCtx()` |
|---|---|---|
| off | (unset) | 5,498,401 |
| off | 20 | 4,449,825 |
| off | 27 | 137,618,977 |
| on | (unset) | 154,551,841 |
| on | 20 | 4,606,497 |
| on | 27 | 154,551,841 |

`zstd_window_log` alone moves the retained workspace ~31x at one level, and
`zstd_long` alone ~28x. The growth is permanent: walking one context through the
high-memory profile and back to the low one leaves it at the high-water mark.

So the cache is keyed on the **complete memory-affecting profile** —
`zstd_comp_level`, `zstd_long` and `zstd_window_log` — all three fixed at config
load, and all three already factored into the `zstd_max_cctx_memory` budget
asserted there. A location differing in any of them does not reuse the cache; it
takes the per-request path. That keeps the cached context's high-water mark at
exactly the figure config load vetted, and stops a high-memory location from
raising the floor for every other location in the worker.

An earlier revision of this branch keyed on level alone, on a measurement that
said `windowLog` did not move `ZSTD_sizeof_CCtx()`. That measurement was taken
with a *known* pledged source size, which clamps the window to the input and
hides `windowLog` entirely; it does not describe the streaming path this filter
uses.

## Performance

wrk, 1 worker, 8 connections, level 6, realistic ~6:1 bodies, 3 interleaved rounds:

| body | before | after |
|---|---|---|
| 8 KB | 14.4k rps, 556us | **25.8k rps, 309us** |
| 64 KB | unchanged | unchanged |

The win is on small bodies, where setup dominates; at 64 KB compression itself dominates and the effect disappears. This is not a blanket speedup — but small bodies dominate request *count*.

The cache is single-slot, so the hit rate falls toward 1/N as concurrent compressing requests rise; the +79% above was measured at 8 connections on 1 worker. A per-worker ring and per-level slots are recorded as follow-up work and deliberately not folded in here.

## Testing

- new `ci/tools/test_cctx_reuse.py`, wired into the `tests` job (debug build, asserts the cache **engages** via witness counts and pins the level partition) and into the coverage/ASan job (`--log-level warn`, byte-exactness oracles only — UBSan with `-fno-sanitize-recover` fatally traps nginx core's own debug logging at `ngx_string.c:586`, so a sanitized nginx cannot run at debug at all)
- **negative control proved**: disabling the borrow fails the new test 13-creates/0-reuses rather than passing silently. The existing correctness suite cannot catch a cache that never hits — that is the whole reason the engagement witness exists
- 1291 + 459 Perl tests, 504-cell matrix, 11 Python regressions — all pass
- ASan+UBSan soak: 19,378 requests clean, no leak across 5 reloads. Valgrind: 3,661 requests clean
- `review-lint.sh --branch master`: 19 lenses, no coverage gap

## Follow-up, not in this PR

Recorded rather than folded in, since this diff is already a memory-ownership
change: a small per-worker ring (size to be picked from an A/B at 8/32/128
connections, not guessed) with one slot per distinct memory profile, which would
fix both the single-slot hit rate and the fact that the first-arriving request
pins which profile gets cached for the worker's lifetime.