### PR TITLE
perf: pass zlcf to ngx_http_zstd_filter_get_buf() instead of re-fetching

### DIFF
--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -289,7 +289,8 @@ static ngx_int_t ngx_http_zstd_body_filter(ngx_http_request_t *r,
 static ngx_int_t ngx_http_zstd_filter_add_data(ngx_http_request_t *r,
     ngx_http_zstd_ctx_t *ctx);
 static ngx_int_t ngx_http_zstd_filter_get_buf(ngx_http_request_t *r,
-    ngx_http_zstd_ctx_t *ctx);
+    ngx_http_zstd_ctx_t *ctx,
+    ngx_http_zstd_loc_conf_t *zlcf);
 static ngx_int_t ngx_http_zstd_set_param(ngx_http_request_t *r,
     ZSTD_CCtx *cctx, ZSTD_cParameter param, int value, const char *name);
 static ngx_int_t ngx_http_zstd_filter_init_cctx(ngx_http_request_t *r,
@@ -1150,7 +1151,7 @@ ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
                 goto failed;
             }
 
-            rc = ngx_http_zstd_filter_get_buf(r, ctx);
+            rc = ngx_http_zstd_filter_get_buf(r, ctx, zlcf);
 
             if (rc == NGX_ERROR) {
                 goto failed;
@@ -1531,10 +1532,10 @@ ngx_http_zstd_filter_add_data(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
 
 
 static ngx_int_t
-ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
+ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
+    ngx_http_zstd_loc_conf_t *zlcf)
 {
-    ngx_chain_t               *cl;
-    ngx_http_zstd_loc_conf_t  *zlcf;
+    ngx_chain_t  *cl;
 
     /*
      * Keep using the current output buffer only if it still exists AND has
@@ -1553,8 +1554,6 @@ ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
     if (ctx->out_buf != NULL && ctx->buffer_out.pos < ctx->buffer_out.size) {
         return NGX_OK;
     }
-
-    zlcf = ngx_http_get_module_loc_conf(r, ngx_http_zstd_filter_module);
 
     if (ctx->free) {
         cl = ctx->free;


### PR DESCRIPTION
## TL;DR

Remove redundant `ngx_http_get_module_loc_conf()` call in `get_buf()`. The location config is fetched once at line 1042 in `body_filter()` and is now passed as a parameter instead of being re-fetched inside `get_buf()`, which is called per buffer acquisition in the hot loop.

**Severity:** `Low` (`performance — avoidable per-request FFI overhead`)

## Testing

* Unit tests pass (ci/tests/unit/run.sh): 24/24 accept_encoding checks + 42/42 static_probe checks
* Build succeeds with 1.31.4 (ci/tools/ci-build.sh): both dynamic modules compile without warnings
* Lint pre-pass clean (review-lint.sh --branch master): all linters pass, no findings