### PR TITLE
docs: note that zstd_min_length cannot apply to chunked responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,19 @@ Sets the minimum response size (in bytes) required for compression to apply. The
 > **Note:** The built-in default is `1024` bytes. Smaller responses often lose
 > their savings to zstd frame overhead while still consuming compression CPU.
 
+> **Caveat — chunked and proxied responses bypass this directive entirely.**
+> The threshold can only be applied when the body length is known up front, so
+> the check is skipped whenever `Content-Length` is absent — which is the normal
+> case for chunked transfer encoding and for most proxied upstreams. Such
+> responses are compressed regardless of how small they turn out to be, and a
+> body below the threshold can come out *larger* than the original: a 47-byte
+> chunked body under `zstd_min_length 1024` is returned as 56 bytes with
+> `Content-Encoding: zstd`. Enforcing the threshold on a streaming body would
+> require buffering the response until the threshold is decided, which changes
+> when headers may be sent; the directive deliberately does not do this. If a
+> small-response floor matters for an upstream, ensure the upstream sets
+> `Content-Length`, or disable compression for that location.
+
 **Example:**
 
 ```nginx


### PR DESCRIPTION
## What

Documents that `zstd_min_length` cannot be enforced on chunked or proxied
responses, and says what to do instead.

## Why

The threshold check in the header filter is guarded on
`r->headers_out.content_length_n != -1`. When the body length is not known up
front — chunked transfer encoding, and most proxied upstreams — the guard is
false and the check is skipped entirely. Those responses are compressed no
matter how small they are.

The user-visible consequence is that the response can grow: a 47-byte chunked
body served under `zstd_min_length 1024` comes back at **56 bytes** with
`Content-Encoding: zstd`.

## Why documentation rather than a fix

Applying the threshold to a streaming body requires holding the response until
enough of it has arrived to decide, which changes when headers may be sent.
That is a deliberate design decision about the module's buffering contract, not
a one-line gate change, so it is not made here. The README now states the
limitation plainly and gives the two available workarounds (have the upstream
set `Content-Length`, or disable compression for that location).

## Scope

README only. No code, no behaviour change.
