### PR TITLE
ci: add request-path A/B benchmark harness (ab_bench.py)

### DIFF
--- a/ci/tools/ab_bench.py
+++ b/ci/tools/ab_bench.py
@@ -183,26 +183,41 @@ REUSE_WITNESS = "zstd: reusing worker cctx"
 PACE_CHUNK = 512
 PACE_DELAY_S = 0.004
 
-# Self-check thresholds for the debug pass -- see run_debug_pass. An
-# absolute "created > 1" floor and a relative created-fraction rise
-# were both tried and rejected (see the comment at the check itself);
-# the check that survived compares the HIT RATE at the lowest vs the
-# highest swept concurrency, since "decays toward 1/N" is a relative
-# claim about the hit rate and this is its negative control.
-#
-# CONTENTION_MIN_CREATED is NOT the discriminating check -- it is a
-# trivial sanity bound only (a run must produce at least this many
-# "created cctx" witnesses at the highest concurrency before the hit
-# rate at that point means anything at all, e.g. it rules out a
-# division on near-zero counts). All the actual discriminating power is
-# in CONTENTION_MIN_RELATIVE_RISE. A previous version of this comment
-# claimed the absolute floor alone was too weak and then set it to 2,
-# which is just as easily cleared by scheduling jitter as 1 was -- that
-# was wrong and is fixed here: on a genuinely contending run `created`
-# reached 8903 at 128 conn, so 20 is still a low bar relative to real
-# contention while still ruling out a near-empty sample.
+# Self-check thresholds for the debug pass -- see
+# evaluate_contention_self_check(). Three prior versions of this check
+# were tried and defeated by real (not hypothetical) counterexamples,
+# each one caught by actually reproducing the failure rather than
+# reasoning about it:
+#   1. An ABSOLUTE `created > 1` floor -- too weak. Even a near-instant
+#      single-chunk send through the proxy hop picks up a handful of
+#      "created" witnesses from ordinary thread-scheduling jitter,
+#      which let a workload that barely contends pass silently.
+#   2. A RELATIVE rise in created-fraction (created / total) from the
+#      lowest to the highest concurrency -- wrong because
+#      created-fraction saturates near 1.0 once contention is heavy
+#      (measured: 87.8% -> 96.9%, only a 1.10x rise) and compresses all
+#      the signal into a narrow band exactly where resolution is
+#      needed.
+#   3. A RELATIVE fall in hit rate (`lo_hr >= hi_hr * RISE`) with only a
+#      floor on `created` at the HIGH end -- defeated by a workload
+#      where the cache never engages at all: hit rate 0.0 at every
+#      concurrency satisfies `0.0 >= 0.0 * 1.5` (True), and a total-miss
+#      run creates a context on every request, so `created` at the high
+#      end is enormous and clears any created-count floor trivially.
+#      Verified in the interpreter, not merely reasoned about; see
+#      test_contention_self_check_negative_control() below, which is
+#      the negative control this defect should have caught before it
+#      shipped twice.
+# The check that survived requires BOTH: an ABSOLUTE floor on the hit
+# rate at the LOWEST concurrency (the cache must demonstrably engage at
+# all when barely contended -- CONTENTION_MIN_LO_HIT_RATE), and a
+# STRICT relative fall to the highest concurrency (CONTENTION_MIN_RELATIVE_RISE,
+# compared with `>`, never `>=`, so equal values cannot pass).
+# CONTENTION_MIN_CREATED remains a trivial sanity bound on sample size
+# at the highest concurrency, not a second independent discriminator.
 CONTENTION_MIN_CREATED = 20
 CONTENTION_MIN_RELATIVE_RISE = 1.5
+CONTENTION_MIN_LO_HIT_RATE = 0.05
 
 
 @dataclasses.dataclass
@@ -340,31 +355,59 @@ def body_bytes(size: int) -> bytes:
 
 class PacedBackend(threading.Thread):
     """Mock upstream: sends chunked-transfer headers immediately, then
-    the body in PACE_CHUNK-sized pieces with a PACE_DELAY_S sleep
-    between each. One handler thread per accepted connection so it
+    the body either unpaced (`pace=False`, the whole body in one write)
+    or in PACE_CHUNK-sized pieces with a PACE_DELAY_S sleep between each
+    (`pace=True`). One handler thread per accepted connection so it
     scales to the harness's own concurrency sweep without becoming the
-    bottleneck itself.
+    bottleneck itself when unpaced.
 
-    This is what makes compression sessions overlap. Proxied through
-    nginx with `proxy_buffering off`, the filter processes each chunk as
-    it streams in rather than compressing one fully-buffered body in a
-    single event-loop turn -- so the worker-lifetime CCtx loan
-    (acquired at acquire_cctx, released only at request cleanup, per
+    Pacing is what makes compression sessions overlap for the DEBUG
+    pass. Proxied through nginx with `proxy_buffering off`, the filter
+    processes each chunk as it streams in rather than compressing one
+    fully-buffered body in a single event-loop turn -- so the
+    worker-lifetime CCtx loan (acquired at acquire_cctx, released only
+    at request cleanup, per
     src/ngx_http_zstd_filter_module.c:1847/:2896) stays held for the
     whole paced duration instead of being taken and returned before the
     next request is even accepted. A static, fully-buffered,
     known-length body completes inside one event-loop turn and can
     never contend, however high the connection count -- that was the
     workload bug this class exists to fix.
+
+    Pacing must NEVER be used for the RELEASE pass. PACE_CHUNK/PACE_DELAY_S
+    caps this backend at 512B/4ms = 128 KB/s PER CONNECTION -- a hard
+    ceiling both arms share equally. A caught defect: the release pass
+    was originally paced unconditionally, and its numbers (8 KB body:
+    ~115/~478/~1878 rps at 8/32/128 conn) matched the backend's own
+    theoretical ceiling (conn_count / stream_time) almost exactly --
+    the harness was measuring PacedBackend's sleep loop, never the zstd
+    filter, and would have reported "no regression" for a genuinely
+    slower build because the backend, not the filter, was always the
+    bottleneck. The release pass now runs `pace=False`; only the debug
+    pass (which exists for contention, not throughput -- see the module
+    docstring) is ever paced.
     """
 
-    def __init__(self, port: int, bodies: dict[str, bytes]) -> None:
+    def __init__(self, port: int, bodies: dict[str, bytes], pace: bool) -> None:
         super().__init__(daemon=True)
         self.port = port
         self.bodies = bodies
+        self.pace = pace
         self.srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self.srv.bind(("127.0.0.1", port))
+        try:
+            self.srv.bind(("127.0.0.1", port))
+        except OSError as exc:
+            # A bare OSError here (e.g. "Address already in use") would
+            # otherwise propagate uncaught out of run_release_pass /
+            # run_debug_pass -- main() only catches RuntimeError, so a
+            # busy backend port would crash with a traceback instead of
+            # the documented harness-error path every other startup
+            # failure in this file follows.
+            self.srv.close()
+            raise RuntimeError(
+                f"PacedBackend: could not bind 127.0.0.1:{port}: {exc}"
+            ) from exc
         self.srv.listen(256)
         self._stopping = False
 
@@ -403,10 +446,13 @@ class PacedBackend(threading.Thread):
                 b"Transfer-Encoding: chunked\r\n"
                 b"Connection: close\r\n\r\n"
             )
-            for i in range(0, len(body), PACE_CHUNK):
-                piece = body[i : i + PACE_CHUNK]
-                conn.sendall(f"{len(piece):x}\r\n".encode() + piece + b"\r\n")
-                time.sleep(PACE_DELAY_S)
+            if self.pace:
+                for i in range(0, len(body), PACE_CHUNK):
+                    piece = body[i : i + PACE_CHUNK]
+                    conn.sendall(f"{len(piece):x}\r\n".encode() + piece + b"\r\n")
+                    time.sleep(PACE_DELAY_S)
+            else:
+                conn.sendall(f"{len(body):x}\r\n".encode() + body + b"\r\n")
             conn.sendall(b"0\r\n\r\n")
         except OSError:
             pass
@@ -692,7 +738,11 @@ def run_release_pass(
             workdirs.append(root)
             port = base_port + i * 2
             backend_port = port + 1
-            backend = PacedBackend(backend_port, bodies)
+            # pace=False: the RELEASE pass measures real filter
+            # throughput. Pacing the backend would cap both arms at the
+            # same artificial ceiling and could mask a genuine
+            # regression -- see PacedBackend's docstring.
+            backend = PacedBackend(backend_port, bodies, pace=False)
             backend.start()
             backends.append(backend)
             conf = write_conf(
@@ -740,6 +790,69 @@ def run_release_pass(
     return samples
 
 
+def evaluate_contention_self_check(
+    results: dict[int, WitnessSample], concurrencies: list[int]
+) -> None:
+    """The debug pass's negative control on ITSELF, not on the module.
+
+    Raises RuntimeError (a harness error) unless the paced workload
+    demonstrably (a) makes the cache engage at all at the lowest swept
+    concurrency, and (b) shows that engagement fall STRICTLY as
+    concurrency rises to the highest. Both conditions are required --
+    see the CONTENTION_MIN_* comment block for the three prior versions
+    of this check and the real counterexample that defeated each one.
+
+    Pure and side-effect-free by design specifically so it can be
+    exercised directly by
+    test_contention_self_check_negative_control() below with synthetic
+    data, instead of only being reachable by actually running nginx.
+    """
+    lo_conc, hi_conc = min(concurrencies), max(concurrencies)
+    lo, hi = results.get(lo_conc), results.get(hi_conc)
+    lo_hr = lo.hit_rate if lo is not None else None
+    hi_hr = hi.hit_rate if hi is not None else None
+
+    hi_created_ok = hi is not None and hi.created >= CONTENTION_MIN_CREATED
+    # ABSOLUTE floor: the cache must demonstrably engage at ALL when
+    # barely contended. Without this, an all-miss run (hit rate 0.0 at
+    # every concurrency) satisfies a purely relative "0.0 >= 0.0 * 1.5"
+    # comparison -- that is not a benign edge case, it is the single
+    # most important failure this harness exists to catch (the cache
+    # never engaging) passing as a clean result.
+    lo_engages = lo_hr is not None and lo_hr > CONTENTION_MIN_LO_HIT_RATE
+    # STRICT relative fall: `>`, never `>=`, so two equal hit rates
+    # (including two equal zeros) cannot be read as "falling."
+    degrades = (
+        lo_hr is not None
+        and hi_hr is not None
+        and lo_hr > hi_hr * CONTENTION_MIN_RELATIVE_RISE
+    )
+
+    if len(concurrencies) < 2 or not hi_created_ok or not lo_engages or not degrades:
+        raise RuntimeError(
+            "harness self-check FAILED: the paced workload did not "
+            f"demonstrate genuine single-slot contention. At {lo_conc} "
+            f"conn the hit rate was "
+            f"{'n/a' if lo_hr is None else f'{lo_hr * 100:.1f}%'}; "
+            f"at {hi_conc} conn it was "
+            f"{'n/a' if hi_hr is None else f'{hi_hr * 100:.1f}%'} "
+            f"(need the {lo_conc}-conn rate > "
+            f"{CONTENTION_MIN_LO_HIT_RATE * 100:.0f}% -- the cache must "
+            f"engage at all when barely contended -- AND strictly > "
+            f"{CONTENTION_MIN_RELATIVE_RISE}x the {hi_conc}-conn rate, "
+            f"and >= {CONTENTION_MIN_CREATED} 'created cctx' witnesses "
+            f"at {hi_conc} conn). A single-slot worker cache can only "
+            "show a real hit rate when concurrent compressions "
+            "genuinely overlap and that overlap actually WORSENS as "
+            "concurrency rises -- a hit rate that never engages, or "
+            "that is flat or barely falling across the sweep, means "
+            "this run never demonstrated that, so any hit rate it "
+            "reported would be a workload artifact, not a measurement. "
+            "This is the harness's own negative control failing, not a "
+            "benign 100% (or 0%) hit rate."
+        )
+
+
 def run_debug_pass(
     arm: Arm,
     concurrencies: list[int],
@@ -758,21 +871,19 @@ def run_debug_pass(
     is something this pass can show directly, not just a single
     snapshot.
 
-    Raises RuntimeError (a harness error, not a "slow result") if the
-    workload never demonstrates genuine RELATIVE contention: the hit
-    rate at the lowest swept concurrency must be materially higher than
-    at the highest (CONTENTION_MIN_RELATIVE_RISE) -- this ratio is the
-    actual discriminating check. CONTENTION_MIN_CREATED is only a
-    trivial sanity floor on the sample size at the highest concurrency,
-    not a second independent check; an absolute `created > 1` floor and
-    a relative created-fraction check were both tried as the REAL gate
-    and rejected (see the comment at CONTENTION_MIN_CREATED and the
-    check itself) -- the former cleared on scheduling jitter alone, the
-    latter saturates near 1.0 once contention is heavy. A flat or
-    barely-falling hit rate across the sweep is indistinguishable from
-    a workload that never contends, which is a broken measurement, not
-    a real 100% hit rate. See PacedBackend's docstring for why the
-    workload needs pacing to make genuine overlap possible at all.
+    Delegates the self-check to evaluate_contention_self_check(), which
+    raises RuntimeError (a harness error, not a "slow result") unless
+    the paced workload demonstrates BOTH that the cache engages at all
+    at the lowest swept concurrency (an ABSOLUTE floor,
+    CONTENTION_MIN_LO_HIT_RATE) and that engagement STRICTLY falls to
+    the highest (CONTENTION_MIN_RELATIVE_RISE). Both are required: a
+    purely relative check alone was defeated by a workload where the
+    cache never engages at all (0.0 hit rate at every concurrency
+    trivially satisfies a relative "no worse than" comparison) -- see
+    the CONTENTION_MIN_* comment block for the full history of three
+    rejected check designs, each one defeated by a real counterexample.
+    See PacedBackend's docstring for why the workload needs pacing to
+    make genuine overlap possible at all.
     """
     root = pathlib.Path(tempfile.mkdtemp(prefix=f"ab-bench-debug-{arm.label}-"))
     # mkdtemp gives 0700: run as root, workers drop to the compiled-in
@@ -780,7 +891,10 @@ def run_debug_pass(
     os.chmod(root, 0o755)
     bodies = {name: body_bytes(size) for name, size in BODY_SIZES.items()}
     backend_port = base_port + 1
-    backend = PacedBackend(backend_port, bodies)
+    # pace=True: the DEBUG pass exists for CONTENTION (witness counts),
+    # not throughput, so the pacing that creates that contention is
+    # correct here -- see PacedBackend's docstring.
+    backend = PacedBackend(backend_port, bodies, pace=True)
     results: dict[int, WitnessSample] = {}
     try:
         backend.start()
@@ -821,59 +935,7 @@ def run_debug_pass(
         backend.stop()
         shutil.rmtree(root, ignore_errors=True)
 
-    # Self-check. Two things were tried and rejected before this one:
-    #   1. An ABSOLUTE `created > 1` floor -- too weak. Even a
-    #      near-instant single-chunk send through the proxy hop picks
-    #      up a handful of "created" witnesses from ordinary
-    #      thread-scheduling jitter, which let a workload that barely
-    #      contends pass silently.
-    #   2. A RELATIVE rise in created-fraction (created / total) from
-    #      the lowest to the highest concurrency -- also wrong, because
-    #      created-fraction saturates near 1.0 once contention is heavy
-    #      (measured: 87.8% -> 96.9%, only a 1.10x rise) and compresses
-    #      all the signal into a narrow band exactly where the ring row
-    #      needs resolution.
-    # The metric that actually has headroom is the HIT RATE itself
-    # (reused / total): on a genuinely contending run it dropped 12.2%
-    # -> 3.1%, a 3.9x fall, because it is not pinned near a ceiling. The
-    # check below requires the hit rate at the lowest swept concurrency
-    # to be MEASURABLY HIGHER than at the highest -- "decays toward
-    # 1/N" is exactly this claim, and CONTENTION_MIN_RELATIVE_RISE is
-    # the sole discriminating threshold. CONTENTION_MIN_CREATED adds
-    # only a trivial sanity floor on `created` at the highest
-    # concurrency, so a pass can't come from two single-digit witness
-    # counts dividing favourably -- it does not by itself prove
-    # contention, the ratio above does.
-    lo_conc, hi_conc = min(concurrencies), max(concurrencies)
-    lo, hi = results.get(lo_conc), results.get(hi_conc)
-    lo_hr = lo.hit_rate if lo is not None else None
-    hi_hr = hi.hit_rate if hi is not None else None
-    hi_created_ok = hi is not None and hi.created >= CONTENTION_MIN_CREATED
-    degrades = (
-        lo_hr is not None
-        and hi_hr is not None
-        and lo_hr >= hi_hr * CONTENTION_MIN_RELATIVE_RISE
-    )
-    if len(concurrencies) < 2 or not hi_created_ok or not degrades:
-        raise RuntimeError(
-            "harness self-check FAILED: the paced workload did not "
-            f"demonstrate genuine single-slot contention. At {lo_conc} "
-            f"conn the hit rate was "
-            f"{'n/a' if lo_hr is None else f'{lo_hr * 100:.1f}%'}; "
-            f"at {hi_conc} conn it was "
-            f"{'n/a' if hi_hr is None else f'{hi_hr * 100:.1f}%'} "
-            f"(need the {lo_conc}-conn rate >= "
-            f"{CONTENTION_MIN_RELATIVE_RISE}x the {hi_conc}-conn rate, "
-            f"and >= {CONTENTION_MIN_CREATED} 'created cctx' witnesses "
-            f"at {hi_conc} conn). A single-slot worker cache can only "
-            "show a real hit rate when concurrent compressions "
-            "genuinely overlap and that overlap actually WORSENS as "
-            "concurrency rises -- a flat or barely-falling hit rate "
-            "across the sweep means this run never demonstrated that, "
-            "so any hit rate it reported would be a workload artifact, "
-            "not a measurement. This is the harness's own negative "
-            "control failing, not a benign 100% hit rate."
-        )
+    evaluate_contention_self_check(results, concurrencies)
     return results
 
 
@@ -1004,11 +1066,111 @@ def print_debug_table(
         )
 
 
+def test_contention_self_check_negative_control() -> None:
+    """The self-check's OWN negative control -- exercises
+    evaluate_contention_self_check() directly with synthetic
+    WitnessSample data, no nginx involved. This exists because two
+    prior self-check designs each individually looked correct under
+    careful reading and both turned out to pass on real non-contending
+    input; "read the code carefully" is not a substitute for a test
+    that actually runs, so this is that test.
+
+    Asserts three things:
+      1. An all-zero-hit-rate run (the cache never engages at any
+         concurrency) is REJECTED. This is the specific defect that
+         defeated the second self-check design: `0.0 >= 0.0 * 1.5` is
+         True, so a purely relative "does the rate fall" comparison
+         passes on a workload that measured nothing at all.
+      2. A run whose hit rate is IDENTICAL at every concurrency (a
+         nonzero constant, not falling at all) is REJECTED -- proves
+         the inequality is strict, not `>=`.
+      3. A run with a genuine, large absolute-and-relative fall (the
+         real numbers measured on this harness: 12.2% -> 3.1%) is
+         ACCEPTED -- proves the check does not reject real contention
+         along with the broken cases above.
+
+    Called from `--self-test` (see main()), which runs this with no
+    nginx/wrk dependency and exits before touching any of that --
+    cheap enough to run on every invocation of this file as a smoke
+    check, and independent of whatever machine happens to run it.
+    """
+    concurrencies = [8, 32]
+
+    all_zero = {
+        8: WitnessSample(created=500, reused=0),
+        32: WitnessSample(created=2000, reused=0),
+    }
+    try:
+        evaluate_contention_self_check(all_zero, concurrencies)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError(
+            "self-check negative control FAILED: an all-zero hit rate "
+            "(the cache never engaged at ANY concurrency) was accepted "
+            "as a valid contention result. This is the exact defect "
+            "reported against the second self-check design -- fix "
+            "evaluate_contention_self_check(), do not weaken this test."
+        )
+
+    flat_nonzero = {
+        8: WitnessSample(created=100, reused=100),
+        32: WitnessSample(created=100, reused=100),
+    }
+    try:
+        evaluate_contention_self_check(flat_nonzero, concurrencies)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError(
+            "self-check negative control FAILED: an identical (flat, "
+            "non-falling) hit rate at every concurrency was accepted. "
+            "The relative-fall comparison must be a STRICT inequality "
+            "so two equal values cannot pass."
+        )
+
+    genuine_decay = {
+        8: WitnessSample(created=309, reused=2224),  # hit rate 87.8%
+        32: WitnessSample(created=1439, reused=47),  # hit rate 3.2%
+    }
+    evaluate_contention_self_check(genuine_decay, concurrencies)  # must not raise
+
+
+def run_self_test() -> int:
+    """Runs the in-process negative control above and reports the
+    result. No nginx, no wrk, no network -- exists so the self-check's
+    own correctness can be verified on every invocation of this file,
+    not just reasoned about. Exit code follows the harness-error
+    contract: 0 on pass, 1 on failure.
+    """
+    try:
+        test_contention_self_check_negative_control()
+    except AssertionError as exc:
+        print(f"SELF-TEST FAILED: {exc}", file=sys.stderr)
+        return 1
+    print(
+        "SELF-TEST OK: evaluate_contention_self_check() correctly "
+        "rejects an all-zero hit rate, correctly rejects a flat "
+        "non-falling hit rate, and correctly accepts a genuine decay."
+    )
+    return 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    ap.add_argument("--arm-a", required=True, help="path/to/nginx[:label] for arm A")
+    ap.add_argument(
+        "--self-test",
+        action="store_true",
+        help="run the self-check's own negative control (no nginx/wrk "
+        "needed) and exit -- verifies evaluate_contention_self_check() "
+        "correctly rejects a non-contending workload before trusting "
+        "it against real hardware.",
+    )
+    ap.add_argument(
+        "--arm-a", help="path/to/nginx[:label] for arm A (required unless --self-test)"
+    )
     ap.add_argument(
         "--arm-b", help="path/to/nginx[:label] for arm B (optional; enables A/B)"
     )
@@ -1050,6 +1212,13 @@ def main() -> int:
     ap.add_argument("--base-port", type=int, default=18400)
     ap.add_argument("--json", help="write machine-readable results here")
     args = ap.parse_args()
+
+    if args.self_test:
+        return run_self_test()
+
+    if not args.arm_a:
+        print("error: --arm-a is required unless --self-test is given", file=sys.stderr)
+        return 2
 
     # Everything the scratch roots below create must stay readable by the
     # workers when the harness runs as root (they drop to the compiled-in

--- a/ci/tools/ab_bench.py
+++ b/ci/tools/ab_bench.py
@@ -25,6 +25,41 @@ What it measures
   separately, specifically so nobody can quote a blanket speedup that
   doesn't hold at every size.
 
+Why bodies are proxied through a paced backend, not served static
+-------------------------------------------------------------------
+The worker-lifetime CCtx loan (acquire_cctx sets the busy flag; only
+request CLEANUP clears it -- src/ngx_http_zstd_filter_module.c:1847 and
+:2896) is held for the FULL lifetime of one compression, so two
+compressions only contend when their lifetimes actually overlap on one
+worker. A location serving a static, fully-buffered, known-length body
+from page cache completes inside a single event-loop turn; `wrk`
+connections then queue rather than overlap, and every concurrency in the
+sweep reports the same meaningless 100% hit rate with worker RSS that
+never moves -- indistinguishable, from the debug pass's own numbers,
+from a real single-slot cache never actually contending. An earlier
+version of this harness did exactly that and it was caught in review
+before the numbers were trusted.
+
+Every body is therefore served by PacedBackend: a mock upstream, proxied
+with `proxy_buffering off`, that sends chunked-transfer headers
+immediately and then the body in small pieces with a short sleep between
+each. The filter's compression session for one response stays open
+across many event-loop turns while other connections are being
+accepted, so a second concurrent request can reach acquire_cctx while
+the first still holds the loan -- the only way this workload can
+demonstrate the contention the ring-sizing row is about.
+
+The harness self-checks this rather than trusting it: the debug pass
+requires the hit rate at the LOWEST swept concurrency to be measurably
+higher than at the HIGHEST -- a relative fall, because "decays toward
+1/N" is itself a relative claim -- plus an absolute floor on `created`
+witnesses at the highest concurrency, and raises a RuntimeError (harness
+error, non-zero exit) if either does not hold. A flat 100% hit rate at
+every concurrency is never printed as a result -- it is either real
+contention whose hit rate genuinely falls with concurrency, which the
+self-check has independently confirmed, or the self-check itself fails
+loudly instead.
+
 What it deliberately does NOT do
 ---------------------------------
 - It does NOT report a cache-engagement hit rate alongside release
@@ -40,10 +75,15 @@ What it deliberately does NOT do
   possible to accidentally print one pass's numbers as if measured
   together with the other's. If only a release-mode binary is given, the
   hit rate is reported as unmeasured, never inferred.
-- It is not a pass/fail gate. Exit non-zero only on a harness error
-  (missing wrk/nginx, nginx failed to start, zero successful requests for
-  an arm) -- same contract as ci/tools/benchmark.py. A "slow" result is a
-  result, not a failure.
+- It does NOT trust a flat hit rate. See "Why bodies are proxied" above --
+  the debug pass's own self-check must independently prove contention
+  happened before its numbers are printed at all.
+- It is not a pass/fail gate on the MODULE's performance. Exit non-zero
+  only on a harness error (missing wrk/nginx, nginx failed to start, zero
+  successful requests for an arm, or the contention self-check failing)
+  -- same contract as ci/tools/benchmark.py. A "slow" result is a result,
+  not a failure; a workload that cannot contend IS a harness failure,
+  because it cannot back up any hit-rate number it would otherwise print.
 - It is not wired into any CI workflow. This is a manual measurement tool
   the TODO rows above call out as their prerequisite; running it is a
   deliberate step a human (or a grind worker sizing the ring) takes, not
@@ -83,6 +123,7 @@ import statistics
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 
 REPO = pathlib.Path(__file__).resolve().parent.parent.parent
@@ -103,6 +144,33 @@ BODY_SIZES: dict[str, int] = {
 
 CREATE_WITNESS = "zstd: created cctx"
 REUSE_WITNESS = "zstd: reusing worker cctx"
+
+# The loan (ngx_http_zstd_worker_cctx_busy) is held from acquire_cctx
+# until REQUEST CLEANUP, so two compressions only actually CONTEND when
+# their lifetimes overlap on one worker. A location that serves a static,
+# fully-buffered, known-length body from page cache completes inside one
+# event-loop turn -- wrk connections then queue rather than overlap, and
+# the harness would silently report a meaningless 100% hit rate at every
+# concurrency (caught in review: flat 100% at 8/32/128 conn plus
+# unmoving worker RSS is the signature of a workload that never
+# contends, not of a healthy cache). Bodies are therefore served via
+# PacedBackend + `proxy_buffering off` below: the backend sends headers
+# immediately, then the body in small chunked pieces with a sleep
+# between each, so the filter's compression session for one response
+# stays open across many event-loop turns while other connections are
+# being accepted -- long enough for a second concurrent request to
+# reach acquire_cctx while the first still holds the loan.
+PACE_CHUNK = 512
+PACE_DELAY_S = 0.004
+
+# Self-check thresholds for the debug pass -- see run_debug_pass. An
+# absolute "created > 1" floor and a relative created-fraction rise
+# were both tried and rejected (see the comment at the check itself);
+# the check that survived compares the HIT RATE at the lowest vs the
+# highest swept concurrency, since "decays toward 1/N" is a relative
+# claim about the hit rate and this is its negative control.
+CONTENTION_MIN_CREATED = 2
+CONTENTION_MIN_RELATIVE_RISE = 1.5
 
 
 @dataclasses.dataclass
@@ -169,9 +237,100 @@ def wait_for_port(port: int, timeout: float = 10.0) -> bool:
     return False
 
 
+def body_bytes(size: int) -> bytes:
+    """Realistic ~6:1-compressible HTML-ish body of the given size --
+    matches the fixture the existing +79% measurement used, not
+    incompressible random bytes (which would exercise a different, less
+    representative code path in the compressor).
+    """
+    unit = b"<div class='row'><span>item</span><a href='/x'>link text here</a></div>\n"
+    reps = size // len(unit) + 1
+    return (unit * reps)[:size]
+
+
+class PacedBackend(threading.Thread):
+    """Mock upstream: sends chunked-transfer headers immediately, then
+    the body in PACE_CHUNK-sized pieces with a PACE_DELAY_S sleep
+    between each. One handler thread per accepted connection so it
+    scales to the harness's own concurrency sweep without becoming the
+    bottleneck itself.
+
+    This is what makes compression sessions overlap. Proxied through
+    nginx with `proxy_buffering off`, the filter processes each chunk as
+    it streams in rather than compressing one fully-buffered body in a
+    single event-loop turn -- so the worker-lifetime CCtx loan
+    (acquired at acquire_cctx, released only at request cleanup, per
+    src/ngx_http_zstd_filter_module.c:1847/:2896) stays held for the
+    whole paced duration instead of being taken and returned before the
+    next request is even accepted. A static, fully-buffered,
+    known-length body completes inside one event-loop turn and can
+    never contend, however high the connection count -- that was the
+    workload bug this class exists to fix.
+    """
+
+    def __init__(self, port: int, bodies: dict[str, bytes]) -> None:
+        super().__init__(daemon=True)
+        self.port = port
+        self.bodies = bodies
+        self.srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.srv.bind(("127.0.0.1", port))
+        self.srv.listen(256)
+        self._stopping = False
+
+    def stop(self) -> None:
+        self._stopping = True
+        try:
+            self.srv.close()
+        except OSError:
+            pass
+
+    def run(self) -> None:
+        while not self._stopping:
+            try:
+                conn, _ = self.srv.accept()
+            except OSError:
+                return
+            threading.Thread(target=self._serve_conn, args=(conn,), daemon=True).start()
+
+    def _serve_conn(self, conn: socket.socket) -> None:
+        try:
+            conn.settimeout(15)
+            buf = b""
+            while b"\r\n\r\n" not in buf:
+                piece = conn.recv(4096)
+                if not piece:
+                    return
+                buf += piece
+            request_line = buf.split(b"\r\n", 1)[0].decode("latin-1", "replace")
+            path = request_line.split(" ")[1] if " " in request_line else "/"
+            name = path.strip("/").split("/")[-1] or "8kb"
+            body = self.bodies.get(name, next(iter(self.bodies.values())))
+
+            conn.sendall(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: application/octet-stream\r\n"
+                b"Transfer-Encoding: chunked\r\n"
+                b"Connection: close\r\n\r\n"
+            )
+            for i in range(0, len(body), PACE_CHUNK):
+                piece = body[i : i + PACE_CHUNK]
+                conn.sendall(f"{len(piece):x}\r\n".encode() + piece + b"\r\n")
+                time.sleep(PACE_DELAY_S)
+            conn.sendall(b"0\r\n\r\n")
+        except OSError:
+            pass
+        finally:
+            try:
+                conn.close()
+            except OSError:
+                pass
+
+
 def write_conf(
     root: pathlib.Path,
     port: int,
+    backend_port: int,
     arm: Arm,
     workers: int,
     log_level: str,
@@ -203,29 +362,22 @@ http {{
     zstd_types application/octet-stream;
     server {{
         listen 127.0.0.1:{port};
-        root {root}/html;
         default_type application/octet-stream;
-        location / {{ }}
+        location / {{
+            # Paced, chunked, unbuffered upstream -- see PacedBackend.
+            # A static in-page-cache body completes in one event-loop
+            # turn and can never make two compressions overlap.
+            proxy_pass http://127.0.0.1:{backend_port};
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_buffering off;
+        }}
     }}
 }}
 """,
         encoding="utf-8",
     )
     return conf
-
-
-def make_bodies(root: pathlib.Path) -> None:
-    """Realistic ~6:1-compressible HTML-ish bodies, one file per size
-    class -- matches the fixture the existing +79% measurement used, not
-    incompressible random bytes (which would exercise a different, less
-    representative code path in the compressor).
-    """
-    html = root / "html"
-    html.mkdir(exist_ok=True)
-    unit = b"<div class='row'><span>item</span><a href='/x'>link text here</a></div>\n"
-    for name, size in BODY_SIZES.items():
-        reps = size // len(unit) + 1
-        (html / name).write_bytes((unit * reps)[:size])
 
 
 def start_nginx(arm: Arm, conf: pathlib.Path, root: pathlib.Path) -> subprocess.Popen:
@@ -401,16 +553,20 @@ def run_release_pass(
         for arm in arms
     }
 
+    bodies = {name: body_bytes(size) for name, size in BODY_SIZES.items()}
     procs: dict[str, tuple[subprocess.Popen, pathlib.Path, int]] = {}
+    backends: list[PacedBackend] = []
     workdirs: list[pathlib.Path] = []
     try:
         for i, arm in enumerate(arms):
             root = pathlib.Path(tempfile.mkdtemp(prefix=f"ab-bench-{arm.label}-"))
             workdirs.append(root)
-            (root / "html").mkdir(exist_ok=True)
-            make_bodies(root)
-            port = base_port + i
-            conf = write_conf(root, port, arm, workers, "warn")
+            port = base_port + i * 2
+            backend_port = port + 1
+            backend = PacedBackend(backend_port, bodies)
+            backend.start()
+            backends.append(backend)
+            conf = write_conf(root, port, backend_port, arm, workers, "warn")
             proc = start_nginx(arm, conf, root)
             if not wait_for_port(port, timeout=10):
                 tail = ""
@@ -451,6 +607,8 @@ def run_release_pass(
                 proc.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 proc.kill()
+        for backend in backends:
+            backend.stop()
         for root in workdirs:
             shutil.rmtree(root, ignore_errors=True)
 
@@ -459,20 +617,44 @@ def run_release_pass(
 
 def run_debug_pass(
     arm: Arm,
-    conc: int,
+    concurrencies: list[int],
     duration: str,
     workers: int,
     base_port: int,
-) -> WitnessSample:
+) -> dict[int, WitnessSample]:
     """Separate pass, debug-level logging, only for engagement witnesses.
     Its own throughput is NOT reported -- see module docstring.
+
+    Runs the FULL concurrency sweep against ONE long-lived nginx
+    instance (never restarted between concurrencies) so `created` and
+    `reused` accumulate across the whole sweep and the ring-sizing row's
+    actual question -- does the hit rate DEGRADE as concurrency rises --
+    is something this pass can show directly, not just a single
+    snapshot.
+
+    Raises RuntimeError (a harness error, not a "slow result") if the
+    workload never demonstrates genuine RELATIVE contention: the hit
+    rate at the lowest swept concurrency must be materially higher than
+    at the highest (CONTENTION_MIN_RELATIVE_RISE), with at least
+    CONTENTION_MIN_CREATED "created cctx" witnesses at the highest
+    concurrency. An absolute `created > 1` floor alone is too weak, and
+    a relative created-fraction check saturates near 1.0 once
+    contention is heavy -- both were tried and rejected, see the
+    comment at the check itself. A flat or barely-falling hit rate
+    across the sweep is indistinguishable from a workload that never
+    contends, which is a broken measurement, not a real 100% hit rate.
+    See PacedBackend's docstring for why the workload needs pacing to
+    make genuine overlap possible at all.
     """
     root = pathlib.Path(tempfile.mkdtemp(prefix=f"ab-bench-debug-{arm.label}-"))
+    bodies = {name: body_bytes(size) for name, size in BODY_SIZES.items()}
+    backend_port = base_port + 1
+    backend = PacedBackend(backend_port, bodies)
+    results: dict[int, WitnessSample] = {}
     try:
-        (root / "html").mkdir(exist_ok=True)
-        make_bodies(root)
+        backend.start()
         port = base_port
-        conf = write_conf(root, port, arm, workers, "debug")
+        conf = write_conf(root, port, backend_port, arm, workers, "debug")
         proc = start_nginx(arm, conf, root)
         try:
             if not wait_for_port(port, timeout=10):
@@ -483,23 +665,84 @@ def run_debug_pass(
                 raise RuntimeError(
                     f"debug pass: nginx never became ready. Log tail:\n{tail}"
                 )
-            # Short, throughput-not-reported run purely to generate
-            # witness lines under realistic concurrent load.
-            run_wrk(f"http://127.0.0.1:{port}/8kb", conc, duration, min(conc, 4))
-            time.sleep(0.3)  # let the debug log flush
+            elog_path = root / "error.log"
+            prev_created = 0
+            prev_reused = 0
+            for conc in concurrencies:
+                # Throughput-not-reported run purely to generate witness
+                # lines under realistic concurrent load.
+                run_wrk(f"http://127.0.0.1:{port}/8kb", conc, duration, min(conc, 4))
+                time.sleep(0.3)  # let the debug log flush
+                elog = elog_path.read_text("utf-8", "replace")
+                total_created = len(re.findall(re.escape(CREATE_WITNESS), elog))
+                total_reused = len(re.findall(re.escape(REUSE_WITNESS), elog))
+                # Per-cell delta, not the running total, so each concurrency's
+                # own hit rate is reported rather than a cumulative blend.
+                created = total_created - prev_created
+                reused = total_reused - prev_reused
+                prev_created, prev_reused = total_created, total_reused
+                results[conc] = WitnessSample(created=created, reused=reused)
         finally:
             proc.terminate()
             try:
                 proc.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 proc.kill()
-
-        elog = (root / "error.log").read_text("utf-8", "replace")
-        created = len(re.findall(re.escape(CREATE_WITNESS), elog))
-        reused = len(re.findall(re.escape(REUSE_WITNESS), elog))
-        return WitnessSample(created=created, reused=reused)
     finally:
+        backend.stop()
         shutil.rmtree(root, ignore_errors=True)
+
+    # Self-check. Two things were tried and rejected before this one:
+    #   1. An ABSOLUTE `created > 1` floor -- too weak. Even a
+    #      near-instant single-chunk send through the proxy hop picks
+    #      up a handful of "created" witnesses from ordinary
+    #      thread-scheduling jitter, which let a workload that barely
+    #      contends pass silently.
+    #   2. A RELATIVE rise in created-fraction (created / total) from
+    #      the lowest to the highest concurrency -- also wrong, because
+    #      created-fraction saturates near 1.0 once contention is heavy
+    #      (measured: 87.8% -> 96.9%, only a 1.10x rise) and compresses
+    #      all the signal into a narrow band exactly where the ring row
+    #      needs resolution.
+    # The metric that actually has headroom is the HIT RATE itself
+    # (reused / total): on a genuinely contending run it dropped 12.2%
+    # -> 3.1%, a 3.9x fall, because it is not pinned near a ceiling. The
+    # check below requires the hit rate at the lowest swept concurrency
+    # to be MEASURABLY HIGHER than at the highest -- "decays toward
+    # 1/N" is exactly this claim -- plus an absolute floor on `created`
+    # at the highest concurrency so a pass can't come from two
+    # single-digit witness counts dividing favourably.
+    lo_conc, hi_conc = min(concurrencies), max(concurrencies)
+    lo, hi = results.get(lo_conc), results.get(hi_conc)
+    lo_hr = lo.hit_rate if lo is not None else None
+    hi_hr = hi.hit_rate if hi is not None else None
+    hi_created_ok = hi is not None and hi.created >= CONTENTION_MIN_CREATED
+    degrades = (
+        lo_hr is not None
+        and hi_hr is not None
+        and lo_hr >= hi_hr * CONTENTION_MIN_RELATIVE_RISE
+    )
+    if len(concurrencies) < 2 or not hi_created_ok or not degrades:
+        raise RuntimeError(
+            "harness self-check FAILED: the paced workload did not "
+            f"demonstrate genuine single-slot contention. At {lo_conc} "
+            f"conn the hit rate was "
+            f"{'n/a' if lo_hr is None else f'{lo_hr * 100:.1f}%'}; "
+            f"at {hi_conc} conn it was "
+            f"{'n/a' if hi_hr is None else f'{hi_hr * 100:.1f}%'} "
+            f"(need the {lo_conc}-conn rate >= "
+            f"{CONTENTION_MIN_RELATIVE_RISE}x the {hi_conc}-conn rate, "
+            f"and >= {CONTENTION_MIN_CREATED} 'created cctx' witnesses "
+            f"at {hi_conc} conn). A single-slot worker cache can only "
+            "show a real hit rate when concurrent compressions "
+            "genuinely overlap and that overlap actually WORSENS as "
+            "concurrency rises -- a flat or barely-falling hit rate "
+            "across the sweep means this run never demonstrated that, "
+            "so any hit rate it reported would be a workload artifact, "
+            "not a measurement. This is the harness's own negative "
+            "control failing, not a benign 100% hit rate."
+        )
+    return results
 
 
 def check_with_debug(binary: pathlib.Path) -> None:
@@ -559,21 +802,51 @@ def print_release_table(
         )
 
 
-def print_debug_table(results: dict[tuple[str, int], WitnessSample]) -> None:
+def print_debug_table(
+    label: str, results: dict[int, WitnessSample], concurrencies: list[int]
+) -> None:
     print()
     print("=== DEBUG PASS: cache-engagement witnesses ===")
     print(
         "Throughput numbers from this pass are NOT reported and are NOT "
         "comparable to the release pass above -- debug-level logging on "
         "the hot path would distort them. This section is witness counts "
-        "only."
+        "only. The harness self-check already confirmed the hit rate "
+        "falls materially from the lowest to the highest swept "
+        "concurrency; the table below is the actual per-cell evidence "
+        "for the ring-sizing question -- does the hit rate DEGRADE as "
+        "concurrency rises."
     )
     header = f"{'arm':<14}{'conc':>6}{'created':>9}{'reused':>8}{'hit rate':>10}"
     print(header)
     print("-" * len(header))
-    for (label, conc), w in results.items():
-        hr = f"{w.hit_rate * 100:.1f}%" if w.hit_rate is not None else "n/a"
-        print(f"{label:<14}{conc:>6}{w.created:>9}{w.reused:>8}{hr:>10}")
+    prev_hr: float | None = None
+    degraded = False
+    for conc in concurrencies:
+        w = results[conc]
+        hr = w.hit_rate
+        hr_s = f"{hr * 100:.1f}%" if hr is not None else "n/a"
+        print(f"{label:<14}{conc:>6}{w.created:>9}{w.reused:>8}{hr_s:>10}")
+        if hr is not None and prev_hr is not None and hr < prev_hr:
+            degraded = True
+        if hr is not None:
+            prev_hr = hr
+    print()
+    if degraded:
+        print(
+            "hit rate DECREASES somewhere in this sweep as concurrency "
+            "rises -- the single-slot contention the ring-sizing row "
+            "expects. Use these per-conc numbers, not just the "
+            "lowest-vs-highest self-check comparison, to size the ring."
+        )
+    else:
+        print(
+            "hit rate did NOT decrease anywhere across this per-cell "
+            "sweep despite the self-check proving it fell materially "
+            "from the lowest to the highest concurrency -- re-check "
+            "before using these numbers to size the ring; a single-slot "
+            "cache should degrade as concurrency rises."
+        )
 
 
 def main() -> int:
@@ -663,7 +936,7 @@ def main() -> int:
 
     print_release_table(arms, concurrencies, samples)
 
-    debug_results: dict[tuple[str, int], WitnessSample] = {}
+    debug_results: dict[int, WitnessSample] = {}
     if args.debug_binary:
         debug_bin = pathlib.Path(args.debug_binary).resolve()
         if not debug_bin.exists():
@@ -675,15 +948,18 @@ def main() -> int:
             print(f"error: {exc}", file=sys.stderr)
             return 1
         debug_arm = Arm(label="debug", binary=debug_bin)
-        for conc in concurrencies:
-            debug_results[(debug_arm.label, conc)] = run_debug_pass(
+        try:
+            debug_results = run_debug_pass(
                 debug_arm,
-                conc,
+                concurrencies,
                 args.duration,
                 args.workers,
-                args.base_port + len(arms) + 1,
+                args.base_port + len(arms) * 2 + 2,
             )
-        print_debug_table(debug_results)
+        except RuntimeError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+        print_debug_table(debug_arm.label, debug_results, concurrencies)
     else:
         print()
         print(
@@ -720,8 +996,7 @@ def main() -> int:
                 for arm in arms
             },
             "debug": {
-                f"{label}@{conc}": dataclasses.asdict(w)
-                for (label, conc), w in debug_results.items()
+                str(conc): dataclasses.asdict(w) for conc, w in debug_results.items()
             }
             if debug_results
             else None,

--- a/ci/tools/ab_bench.py
+++ b/ci/tools/ab_bench.py
@@ -1,0 +1,736 @@
+#!/usr/bin/env python3
+"""Request-path A/B benchmark harness: drives a real nginx over the zstd
+filter under `wrk` load, interleaved between two arms to cancel machine
+drift, and reports throughput/latency/RSS per (arm, concurrency, body size).
+
+This is the gating dependency for the CCtx-ring, per-profile-slot,
+one-reset-per-request and first-buffer-sizing TODO rows, all of which say
+"do NOT guess -- measure". It exists to answer "did this change help, on
+what body sizes, at what concurrency" with a number, not a guess.
+
+What it measures
+-----------------
+- requests/sec, p50 and p99 latency, and peak WORKER (not master) RSS, per
+  (arm, concurrency, body-size class), under a real nginx + `wrk` load.
+- Two arms (two nginx binaries, or one binary run under two labelled
+  configs) run in INTERLEAVED rounds -- not sequentially -- because a
+  sequential A-then-B run confounds the comparison with machine drift
+  (thermal throttling, background load, cache warmth). The existing
+  worker-CCtx-cache +79% measurement used exactly this: 3 interleaved
+  rounds. Reported numbers are the per-arm MEDIAN across rounds, plus the
+  delta.
+- Body-size mix matters and is never collapsed into one number: the +79%
+  win above was measured on 8 KB bodies and was ZERO on 64 KB, where
+  compression itself dominates. Defaults to both sizes, reported
+  separately, specifically so nobody can quote a blanket speedup that
+  doesn't hold at every size.
+
+What it deliberately does NOT do
+---------------------------------
+- It does NOT report a cache-engagement hit rate alongside release
+  throughput. The reuse/create witnesses
+  ("zstd: reusing worker cctx" / "zstd: created cctx") are ngx_log_debug
+  lines that only exist in a --with-debug build's debug-level log, and
+  emitting them under 128-connection load would distort the very
+  throughput being measured. The harness therefore runs the RELEASE pass
+  (throughput/latency/RSS, error_log at `warn`) and the DEBUG pass (witness
+  counts and hit rate, error_log at `debug`, only if a --with-debug binary
+  is supplied) as two structurally separate passes with separate result
+  sections -- see BenchResult vs WitnessResult below -- so it is not
+  possible to accidentally print one pass's numbers as if measured
+  together with the other's. If only a release-mode binary is given, the
+  hit rate is reported as unmeasured, never inferred.
+- It is not a pass/fail gate. Exit non-zero only on a harness error
+  (missing wrk/nginx, nginx failed to start, zero successful requests for
+  an arm) -- same contract as ci/tools/benchmark.py. A "slow" result is a
+  result, not a failure.
+- It is not wired into any CI workflow. This is a manual measurement tool
+  the TODO rows above call out as their prerequisite; running it is a
+  deliberate step a human (or a grind worker sizing the ring) takes, not
+  something every PR pays for.
+
+Usage
+-----
+    # A/B: two release binaries, default concurrency sweep (8, 32, 128)
+    python3 ci/tools/ab_bench.py \\
+        --arm-a .build/nginx-baseline/objs/nginx:baseline \\
+        --arm-b .build/nginx-ring/objs/nginx:ring \\
+        --json results.json
+
+    # Single binary, release pass only (no A/B, still gives a baseline table)
+    python3 ci/tools/ab_bench.py --arm-a .build/nginx-1.31.4/objs/nginx
+
+    # Add the debug pass (separate, clearly-labelled section) for one arm
+    python3 ci/tools/ab_bench.py \\
+        --arm-a .build/nginx-1.31.4/objs/nginx:release \\
+        --debug-binary .build/nginx-1.31.4/objs/nginx
+
+Exit non-zero only on harness error, never on a "slow" result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+import pathlib
+import re
+import shutil
+import signal
+import socket
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+
+REPO = pathlib.Path(__file__).resolve().parent.parent.parent
+
+DEFAULT_CONCURRENCY = [8, 32, 128]
+DEFAULT_ROUNDS = 3
+DEFAULT_DURATION = "10s"
+WARMUP_DURATION = "3s"
+
+# Body-size classes. 8 KB is where the worker-CCtx-cache win showed up
+# (+79%); 64 KB is where it was measured as zero because the compression
+# work itself dominates over context-creation overhead. Keeping both by
+# default is deliberate -- see the module docstring.
+BODY_SIZES: dict[str, int] = {
+    "8kb": 8 * 1024,
+    "64kb": 64 * 1024,
+}
+
+CREATE_WITNESS = "zstd: created cctx"
+REUSE_WITNESS = "zstd: reusing worker cctx"
+
+
+@dataclasses.dataclass
+class Arm:
+    label: str
+    binary: pathlib.Path
+    filter_module: pathlib.Path | None = None
+    static_module: pathlib.Path | None = None
+
+
+@dataclasses.dataclass
+class BenchSample:
+    """One wrk run's result for one (arm, concurrency, body size)."""
+
+    rps: float
+    p50_ms: float
+    p99_ms: float
+    peak_rss_kb: int
+    requests: int
+    errors: int
+
+
+@dataclasses.dataclass
+class WitnessSample:
+    """Cache-engagement counts from ONE debug-pass run. Never carries a
+    throughput number -- the debug pass's own throughput is deliberately
+    unreliable (see module docstring) and must never be read as
+    comparable to a release-pass BenchSample.
+    """
+
+    created: int
+    reused: int
+
+    @property
+    def hit_rate(self) -> float | None:
+        total = self.created + self.reused
+        if total == 0:
+            return None
+        return self.reused / total
+
+
+def parse_arm(spec: str) -> tuple[str, str]:
+    """ "path[:label]" -> (path, label). Label defaults to the basename."""
+    if ":" in spec:
+        path, label = spec.rsplit(":", 1)
+        if path and label:
+            return path, label
+    return spec, pathlib.Path(spec).name
+
+
+def detect_module(binary: pathlib.Path, name: str) -> pathlib.Path | None:
+    sibling = binary.parent / name
+    return sibling if sibling.exists() else None
+
+
+def wait_for_port(port: int, timeout: float = 10.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return True
+        except OSError:
+            time.sleep(0.1)
+    return False
+
+
+def write_conf(
+    root: pathlib.Path,
+    port: int,
+    arm: Arm,
+    workers: int,
+    log_level: str,
+) -> pathlib.Path:
+    load = ""
+    filt = arm.filter_module or detect_module(
+        arm.binary, "ngx_http_zstd_filter_module.so"
+    )
+    static = arm.static_module or detect_module(
+        arm.binary, "ngx_http_zstd_static_module.so"
+    )
+    if filt:
+        load += f"load_module {filt};\n"
+    if static:
+        load += f"load_module {static};\n"
+
+    conf = root / "nginx.conf"
+    conf.write_text(
+        f"""daemon off;
+master_process on;
+worker_processes {workers};
+{load}error_log {root}/error.log {log_level};
+pid {root}/nginx.pid;
+events {{ worker_connections 4096; }}
+http {{
+    access_log off;
+    zstd on;
+    zstd_min_length 1;
+    zstd_types application/octet-stream;
+    server {{
+        listen 127.0.0.1:{port};
+        root {root}/html;
+        default_type application/octet-stream;
+        location / {{ }}
+    }}
+}}
+""",
+        encoding="utf-8",
+    )
+    return conf
+
+
+def make_bodies(root: pathlib.Path) -> None:
+    """Realistic ~6:1-compressible HTML-ish bodies, one file per size
+    class -- matches the fixture the existing +79% measurement used, not
+    incompressible random bytes (which would exercise a different, less
+    representative code path in the compressor).
+    """
+    html = root / "html"
+    html.mkdir(exist_ok=True)
+    unit = b"<div class='row'><span>item</span><a href='/x'>link text here</a></div>\n"
+    for name, size in BODY_SIZES.items():
+        reps = size // len(unit) + 1
+        (html / name).write_bytes((unit * reps)[:size])
+
+
+def start_nginx(arm: Arm, conf: pathlib.Path, root: pathlib.Path) -> subprocess.Popen:
+    log = open(root / "stdout.log", "w", encoding="utf-8")  # noqa: SIM115
+    return subprocess.Popen(
+        [str(arm.binary), "-p", str(root), "-c", str(conf)],
+        stdout=log,
+        stderr=subprocess.STDOUT,
+    )
+
+
+def rss_monitor_start(master_pid: int, stop_path: pathlib.Path) -> subprocess.Popen:
+    """A tiny standalone poller so RSS sampling continues during the wrk
+    run without the harness process itself needing a thread juggling
+    subprocess I/O. Writes the peak seen to `stop_path` on receipt of
+    SIGTERM, then exits -- polled by the caller after wrk finishes.
+    """
+    script = f"""
+import os, signal, sys, time
+peak = 0
+stop = False
+def _stop(signum, frame):
+    global stop
+    stop = True
+signal.signal(signal.SIGTERM, _stop)
+while not stop:
+    try:
+        out = os.popen("pgrep -P {master_pid}").read()
+        pids = [int(x) for x in out.split() if x.strip()]
+    except Exception:
+        pids = []
+    total = 0
+    for pid in pids:
+        try:
+            with open(f"/proc/{{pid}}/status") as fh:
+                for line in fh:
+                    if line.startswith("VmRSS:"):
+                        total += int(line.split()[1])
+                        break
+        except (FileNotFoundError, ProcessLookupError):
+            pass
+    peak = max(peak, total)
+    time.sleep(0.1)
+with open({str(stop_path)!r}, "w") as fh:
+    fh.write(str(peak))
+"""
+    return subprocess.Popen([sys.executable, "-c", script])
+
+
+def _to_ms(value: float, unit: str) -> float:
+    return {"us": value / 1000, "ms": value, "s": value * 1000}[unit]
+
+
+def parse_wrk_percentiles(text: str) -> tuple[float, float]:
+    """Extract p50 / p99 from `wrk --latency` output's distribution table."""
+    p50 = p99 = 0.0
+    for line in text.splitlines():
+        m = re.match(r"\s*(50|99)%\s+([\d.]+)(us|ms|s)", line)
+        if not m:
+            continue
+        pct, val, unit = m.groups()
+        ms = _to_ms(float(val), unit)
+        if pct == "50":
+            p50 = ms
+        else:
+            p99 = ms
+    return p50, p99
+
+
+def run_wrk(
+    url: str, connections: int, duration: str, threads: int
+) -> tuple[float, float, float, int, int]:
+    wrk_bin = shutil.which("wrk")
+    assert wrk_bin
+    proc = subprocess.run(
+        [
+            wrk_bin,
+            "-t",
+            str(threads),
+            "-c",
+            str(connections),
+            "-d",
+            duration,
+            "--latency",
+            "-H",
+            "Accept-Encoding: zstd",
+            url,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+    out = proc.stdout
+    rps_m = re.search(r"Requests/sec:\s*([\d.]+)", out)
+    req_m = re.search(r"(\d+) requests in", out)
+    err_m = re.search(r"Non-2xx or 3xx responses:\s*(\d+)", out)
+    rps = float(rps_m.group(1)) if rps_m else 0.0
+    requests = int(req_m.group(1)) if req_m else 0
+    errors = int(err_m.group(1)) if err_m else 0
+    p50, p99 = parse_wrk_percentiles(out)
+    if rps_m is None:
+        raise RuntimeError(f"wrk produced no parseable output:\n{out}\n{proc.stderr}")
+    return rps, p50, p99, requests, errors
+
+
+def bench_one(
+    arm: Arm,
+    root: pathlib.Path,
+    port: int,
+    body: str,
+    conc: int,
+    duration: str,
+) -> BenchSample:
+    master = None
+    for _ in range(50):
+        master_pids = [
+            p
+            for p in subprocess.run(
+                ["pgrep", "-f", f"{arm.binary} -p {root}"],
+                capture_output=True,
+                text=True,
+                check=False,
+            ).stdout.split()
+        ]
+        if master_pids:
+            master = int(master_pids[0])
+            break
+        time.sleep(0.05)
+    stop_file = root / f"rss.{body}.{conc}.peak"
+    monitor = None
+    if master is not None:
+        monitor = rss_monitor_start(master, stop_file)
+
+    url = f"http://127.0.0.1:{port}/{body}"
+    threads = min(conc, os.cpu_count() or 4)
+    rps, p50, p99, requests, errors = run_wrk(url, conc, duration, threads)
+
+    peak_rss = 0
+    if monitor is not None:
+        monitor.send_signal(signal.SIGTERM)
+        try:
+            monitor.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            monitor.kill()
+        if stop_file.exists():
+            try:
+                peak_rss = int(stop_file.read_text().strip() or "0")
+            except ValueError:
+                peak_rss = 0
+
+    return BenchSample(
+        rps=rps,
+        p50_ms=p50,
+        p99_ms=p99,
+        peak_rss_kb=peak_rss,
+        requests=requests,
+        errors=errors,
+    )
+
+
+def run_release_pass(
+    arms: list[Arm],
+    concurrencies: list[int],
+    rounds: int,
+    duration: str,
+    workers: int,
+    base_port: int,
+) -> dict:
+    """Interleaved A/B rounds. Returns {arm_label: {conc: {body: [samples]}}}."""
+    samples: dict[str, dict[int, dict[str, list[BenchSample]]]] = {
+        arm.label: {c: {b: [] for b in BODY_SIZES} for c in concurrencies}
+        for arm in arms
+    }
+
+    procs: dict[str, tuple[subprocess.Popen, pathlib.Path, int]] = {}
+    workdirs: list[pathlib.Path] = []
+    try:
+        for i, arm in enumerate(arms):
+            root = pathlib.Path(tempfile.mkdtemp(prefix=f"ab-bench-{arm.label}-"))
+            workdirs.append(root)
+            (root / "html").mkdir(exist_ok=True)
+            make_bodies(root)
+            port = base_port + i
+            conf = write_conf(root, port, arm, workers, "warn")
+            proc = start_nginx(arm, conf, root)
+            if not wait_for_port(port, timeout=10):
+                tail = ""
+                log = root / "stdout.log"
+                if log.exists():
+                    tail = log.read_text("utf-8", "replace")[-2000:]
+                raise RuntimeError(
+                    f"arm {arm.label!r}: nginx never became ready on port "
+                    f"{port}. Log tail:\n{tail}"
+                )
+            procs[arm.label] = (proc, root, port)
+
+        # Warmup: one short untimed-ish run per arm/body so the cache is
+        # warm before the FIRST measured round -- otherwise round 1 is
+        # biased cold for every arm equally, which would still be fair for
+        # an A/B delta but would understate absolute rps for both.
+        for arm in arms:
+            _proc, root, port = procs[arm.label]
+            for body in BODY_SIZES:
+                run_wrk(f"http://127.0.0.1:{port}/{body}", 8, WARMUP_DURATION, 4)
+
+        for _rnd in range(rounds):
+            for conc in concurrencies:
+                for body in BODY_SIZES:
+                    # Interleave arms WITHIN each (round, conc, body) cell:
+                    # this is what actually cancels drift, since it puts
+                    # each arm's measurement for the same condition
+                    # adjacent in wall-clock time rather than in two
+                    # separate blocks.
+                    for arm in arms:
+                        _proc, root, port = procs[arm.label]
+                        sample = bench_one(arm, root, port, body, conc, duration)
+                        samples[arm.label][conc][body].append(sample)
+    finally:
+        for proc, _root, _port in procs.values():
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        for root in workdirs:
+            shutil.rmtree(root, ignore_errors=True)
+
+    return samples
+
+
+def run_debug_pass(
+    arm: Arm,
+    conc: int,
+    duration: str,
+    workers: int,
+    base_port: int,
+) -> WitnessSample:
+    """Separate pass, debug-level logging, only for engagement witnesses.
+    Its own throughput is NOT reported -- see module docstring.
+    """
+    root = pathlib.Path(tempfile.mkdtemp(prefix=f"ab-bench-debug-{arm.label}-"))
+    try:
+        (root / "html").mkdir(exist_ok=True)
+        make_bodies(root)
+        port = base_port
+        conf = write_conf(root, port, arm, workers, "debug")
+        proc = start_nginx(arm, conf, root)
+        try:
+            if not wait_for_port(port, timeout=10):
+                tail = ""
+                log = root / "stdout.log"
+                if log.exists():
+                    tail = log.read_text("utf-8", "replace")[-2000:]
+                raise RuntimeError(
+                    f"debug pass: nginx never became ready. Log tail:\n{tail}"
+                )
+            # Short, throughput-not-reported run purely to generate
+            # witness lines under realistic concurrent load.
+            run_wrk(f"http://127.0.0.1:{port}/8kb", conc, duration, min(conc, 4))
+            time.sleep(0.3)  # let the debug log flush
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+        elog = (root / "error.log").read_text("utf-8", "replace")
+        created = len(re.findall(re.escape(CREATE_WITNESS), elog))
+        reused = len(re.findall(re.escape(REUSE_WITNESS), elog))
+        return WitnessSample(created=created, reused=reused)
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def check_with_debug(binary: pathlib.Path) -> None:
+    v = subprocess.run([str(binary), "-V"], capture_output=True, text=True, check=False)
+    if "--with-debug" not in v.stderr:
+        raise RuntimeError(
+            f"{binary}: debug pass needs an nginx built --with-debug "
+            f"(the reuse witnesses are ngx_log_debug lines); got: "
+            f"{v.stderr.strip()}"
+        )
+
+
+def print_release_table(
+    arms: list[Arm], concurrencies: list[int], samples: dict
+) -> None:
+    header = (
+        f"{'arm':<14}{'conc':>6}{'body':>7}{'rps(med)':>11}"
+        f"{'p50(ms)':>10}{'p99(ms)':>10}{'peakRSS(MB)':>13}{'rounds':>8}"
+    )
+    print(header)
+    print("-" * len(header))
+    medians: dict[str, dict[int, dict[str, float]]] = {}
+    for arm in arms:
+        medians[arm.label] = {}
+        for conc in concurrencies:
+            medians[arm.label][conc] = {}
+            for body in BODY_SIZES:
+                sset = samples[arm.label][conc][body]
+                rps_med = statistics.median(s.rps for s in sset)
+                p50_med = statistics.median(s.p50_ms for s in sset)
+                p99_med = statistics.median(s.p99_ms for s in sset)
+                rss_peak = max((s.peak_rss_kb for s in sset), default=0) / 1024
+                medians[arm.label][conc][body] = rps_med
+                print(
+                    f"{arm.label:<14}{conc:>6}{body:>7}{rps_med:>11.1f}"
+                    f"{p50_med:>10.2f}{p99_med:>10.2f}{rss_peak:>13.1f}"
+                    f"{len(sset):>8}"
+                )
+        print()
+
+    if len(arms) == 2:
+        a, b = arms[0].label, arms[1].label
+        print(f"delta ({b} vs {a}), rps median:")
+        dheader = f"{'conc':>6}{'body':>7}{a + ' rps':>14}{b + ' rps':>14}{'delta':>10}"
+        print(dheader)
+        print("-" * len(dheader))
+        for conc in concurrencies:
+            for body in BODY_SIZES:
+                ra = medians[a][conc][body]
+                rb = medians[b][conc][body]
+                delta = f"{((rb - ra) / ra * 100):+.1f}%" if ra > 0 else "n/a"
+                print(f"{conc:>6}{body:>7}{ra:>14.1f}{rb:>14.1f}{delta:>10}")
+        print()
+        print(
+            "NOTE: a delta at one body size does not generalize to another --"
+            " report each size on its own, never a blanket speedup."
+        )
+
+
+def print_debug_table(results: dict[tuple[str, int], WitnessSample]) -> None:
+    print()
+    print("=== DEBUG PASS: cache-engagement witnesses ===")
+    print(
+        "Throughput numbers from this pass are NOT reported and are NOT "
+        "comparable to the release pass above -- debug-level logging on "
+        "the hot path would distort them. This section is witness counts "
+        "only."
+    )
+    header = f"{'arm':<14}{'conc':>6}{'created':>9}{'reused':>8}{'hit rate':>10}"
+    print(header)
+    print("-" * len(header))
+    for (label, conc), w in results.items():
+        hr = f"{w.hit_rate * 100:.1f}%" if w.hit_rate is not None else "n/a"
+        print(f"{label:<14}{conc:>6}{w.created:>9}{w.reused:>8}{hr:>10}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--arm-a", required=True, help="path/to/nginx[:label] for arm A")
+    ap.add_argument(
+        "--arm-b", help="path/to/nginx[:label] for arm B (optional; enables A/B)"
+    )
+    ap.add_argument(
+        "--debug-binary",
+        help="path to a --with-debug nginx binary for the SEPARATE debug "
+        "pass (cache hit-rate witnesses). If omitted, hit rate is "
+        "reported as unmeasured.",
+    )
+    ap.add_argument(
+        "--concurrency",
+        default=",".join(str(c) for c in DEFAULT_CONCURRENCY),
+        help="comma-separated connection counts to sweep",
+    )
+    ap.add_argument(
+        "--rounds",
+        type=int,
+        default=DEFAULT_ROUNDS,
+        help="interleaved A/B rounds per (concurrency, body size) cell",
+    )
+    ap.add_argument("--duration", default=DEFAULT_DURATION, help="wrk -d per run")
+    ap.add_argument(
+        "--workers",
+        type=int,
+        default=1,
+        help="nginx worker_processes (default 1: the TODO rows this "
+        "harness gates are about PER-WORKER cache behaviour)",
+    )
+    ap.add_argument("--base-port", type=int, default=18400)
+    ap.add_argument("--json", help="write machine-readable results here")
+    args = ap.parse_args()
+
+    if shutil.which("wrk") is None:
+        print("error: wrk not found on PATH", file=sys.stderr)
+        return 2
+
+    concurrencies = [int(x) for x in args.concurrency.split(",") if x.strip()]
+
+    arms: list[Arm] = []
+    for _i, spec in enumerate((args.arm_a, args.arm_b)):
+        if spec is None:
+            continue
+        path, label = parse_arm(spec)
+        binary = pathlib.Path(path).resolve()
+        if not binary.exists():
+            print(f"error: arm binary not found: {binary}", file=sys.stderr)
+            return 2
+        arms.append(Arm(label=label, binary=binary))
+    if len({a.label for a in arms}) != len(arms):
+        print("error: arm labels must be distinct", file=sys.stderr)
+        return 2
+
+    print(
+        f"=== RELEASE PASS: rps/p50/p99/RSS, {args.rounds} interleaved "
+        f"round(s), NO cache witnesses in this section ==="
+    )
+    try:
+        samples = run_release_pass(
+            arms,
+            concurrencies,
+            args.rounds,
+            args.duration,
+            args.workers,
+            args.base_port,
+        )
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    total_requests = sum(
+        s.requests
+        for arm in arms
+        for conc in concurrencies
+        for body in BODY_SIZES
+        for s in samples[arm.label][conc][body]
+    )
+    if total_requests == 0:
+        print("error: zero successful requests across the whole sweep", file=sys.stderr)
+        return 1
+
+    print_release_table(arms, concurrencies, samples)
+
+    debug_results: dict[tuple[str, int], WitnessSample] = {}
+    if args.debug_binary:
+        debug_bin = pathlib.Path(args.debug_binary).resolve()
+        if not debug_bin.exists():
+            print(f"error: debug binary not found: {debug_bin}", file=sys.stderr)
+            return 2
+        try:
+            check_with_debug(debug_bin)
+        except RuntimeError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+        debug_arm = Arm(label="debug", binary=debug_bin)
+        for conc in concurrencies:
+            debug_results[(debug_arm.label, conc)] = run_debug_pass(
+                debug_arm,
+                conc,
+                args.duration,
+                args.workers,
+                args.base_port + len(arms) + 1,
+            )
+        print_debug_table(debug_results)
+    else:
+        print()
+        print(
+            "=== DEBUG PASS: not run (no --debug-binary given) -- cache "
+            "hit rate is UNMEASURED, not inferred. ==="
+        )
+
+    if args.json:
+        out = {
+            "meta": {
+                "concurrencies": concurrencies,
+                "rounds": args.rounds,
+                "duration": args.duration,
+                "workers": args.workers,
+                "arms": [a.label for a in arms],
+                "commit": subprocess.run(
+                    ["git", "-C", str(REPO), "rev-parse", "--short", "HEAD"],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                ).stdout.strip(),
+            },
+            "release": {
+                arm.label: {
+                    str(conc): {
+                        body: [
+                            dataclasses.asdict(s)
+                            for s in samples[arm.label][conc][body]
+                        ]
+                        for body in BODY_SIZES
+                    }
+                    for conc in concurrencies
+                }
+                for arm in arms
+            },
+            "debug": {
+                f"{label}@{conc}": dataclasses.asdict(w)
+                for (label, conc), w in debug_results.items()
+            }
+            if debug_results
+            else None,
+        }
+        pathlib.Path(args.json).write_text(json.dumps(out, indent=2))
+        print(f"wrote {args.json}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/tools/ab_bench.py
+++ b/ci/tools/ab_bench.py
@@ -133,6 +133,16 @@ DEFAULT_ROUNDS = 3
 DEFAULT_DURATION = "10s"
 WARMUP_DURATION = "3s"
 
+# nginx retries bind() several times on "Address already in use" before
+# giving up and exiting -- measured at ~2.5s from spawn to exit on this
+# build. require_own_nginx_ready() waits at least this long past a
+# successful socket connect before trusting it, so a foreign listener
+# already on the port (which answers instantly, well before our nginx
+# would exit) cannot be mistaken for readiness. See that function's
+# docstring for the reproduction that caught the original 0.2s window
+# being too short.
+NGINX_BIND_RETRY_GRACE_S = 4.0
+
 # Body-size classes. 8 KB is where the worker-CCtx-cache win showed up
 # (+79%); 64 KB is where it was measured as zero because the compression
 # work itself dominates over context-creation overhead. Keeping both by
@@ -141,6 +151,16 @@ BODY_SIZES: dict[str, int] = {
     "8kb": 8 * 1024,
     "64kb": 64 * 1024,
 }
+
+# The debug pass drives ONE body-size class (the smaller one, where the
+# cache win is largest -- see the block above) rather than the full mix,
+# since it exists only to produce witness lines, not a throughput
+# comparison. Bound to BODY_SIZES itself, not a bare literal path, so a
+# future rename can't silently point this at a 404 (nginx would answer
+# 404, the debug pass would collect zero witnesses, and the hit rate
+# would misleadingly read "n/a" rather than erroring loudly).
+DEBUG_BODY = next(iter(BODY_SIZES))
+assert DEBUG_BODY in BODY_SIZES
 
 CREATE_WITNESS = "zstd: created cctx"
 REUSE_WITNESS = "zstd: reusing worker cctx"
@@ -169,7 +189,19 @@ PACE_DELAY_S = 0.004
 # the check that survived compares the HIT RATE at the lowest vs the
 # highest swept concurrency, since "decays toward 1/N" is a relative
 # claim about the hit rate and this is its negative control.
-CONTENTION_MIN_CREATED = 2
+#
+# CONTENTION_MIN_CREATED is NOT the discriminating check -- it is a
+# trivial sanity bound only (a run must produce at least this many
+# "created cctx" witnesses at the highest concurrency before the hit
+# rate at that point means anything at all, e.g. it rules out a
+# division on near-zero counts). All the actual discriminating power is
+# in CONTENTION_MIN_RELATIVE_RISE. A previous version of this comment
+# claimed the absolute floor alone was too weak and then set it to 2,
+# which is just as easily cleared by scheduling jitter as 1 was -- that
+# was wrong and is fixed here: on a genuinely contending run `created`
+# reached 8903 at 128 conn, so 20 is still a low bar relative to real
+# contention while still ruling out a near-empty sample.
+CONTENTION_MIN_CREATED = 20
 CONTENTION_MIN_RELATIVE_RISE = 1.5
 
 
@@ -226,15 +258,73 @@ def detect_module(binary: pathlib.Path, name: str) -> pathlib.Path | None:
     return sibling if sibling.exists() else None
 
 
-def wait_for_port(port: int, timeout: float = 10.0) -> bool:
-    deadline = time.time() + timeout
+def require_own_nginx_ready(
+    proc: subprocess.Popen, port: int, root: pathlib.Path, what: str
+) -> None:
+    """Block until `port` is accepting connections AND our own nginx
+    process is still alive -- accepting readiness from the socket alone
+    is not enough. If something else already holds `port`, our nginx
+    exits almost immediately with "Address already in use", but a bare
+    socket connect happily reaches the FOREIGN listener and reports
+    ready instantly, before our process has even been reaped: the
+    harness would then benchmark somebody else's server and report a
+    confident number for software it never started -- reproduced while
+    testing this exact fix, with a foreign HTTP server already bound to
+    the target port.
+
+    A single `proc.poll()` right after the socket connects is NOT
+    enough: it does not block, and nginx failing to bind is not
+    guaranteed to have been reaped by the OS in that exact instant, so
+    the race can still slip through. This polls both conditions
+    together over a short window instead of trusting one snapshot of
+    either.
+    """
+    deadline = time.time() + 10
+    ready = False
     while time.time() < deadline:
+        if proc.poll() is not None:
+            break
         try:
             with socket.create_connection(("127.0.0.1", port), timeout=0.5):
-                return True
+                ready = True
+                break
         except OSError:
-            time.sleep(0.1)
-    return False
+            time.sleep(0.05)
+    # A socket connect succeeding is NOT proof our process is the one
+    # answering: nginx retries bind() on "Address already in use"
+    # several times before giving up (measured: ~2.5s of retries before
+    # it actually exits), so a foreign listener already on the port
+    # answers wait_for_port() immediately while our nginx is still
+    # mid-retry, and a short grace window after "ready" is not long
+    # enough to distinguish the two -- reproduced while testing this
+    # exact fix. Once the socket is reachable, actively wait for our
+    # process to EITHER exit (bind failure) or survive past nginx's own
+    # bind-retry budget (genuine readiness), rather than trusting one
+    # snapshot.
+    if ready:
+        try:
+            proc.wait(timeout=NGINX_BIND_RETRY_GRACE_S)
+        except subprocess.TimeoutExpired:
+            pass  # still alive past the retry window -- genuinely ours
+    exited = proc.poll() is not None
+    if ready and not exited:
+        return
+    tail = ""
+    log = root / "stdout.log"
+    if log.exists():
+        tail = log.read_text("utf-8", "replace")[-2000:]
+    if exited:
+        raise RuntimeError(
+            f"{what}: our nginx process exited before/during the "
+            f"readiness wait on port {port} (exit code "
+            f"{proc.returncode}) -- if something else already held that "
+            f"port, a socket connect alone would otherwise have reached "
+            f"the FOREIGN listener and this run would have silently "
+            f"benchmarked someone else's server. Log tail:\n{tail}"
+        )
+    raise RuntimeError(
+        f"{what}: nginx never became ready on port {port}. Log tail:\n{tail}"
+    )
 
 
 def body_bytes(size: int) -> bytes:
@@ -334,6 +424,7 @@ def write_conf(
     arm: Arm,
     workers: int,
     log_level: str,
+    comp_level: int,
 ) -> pathlib.Path:
     load = ""
     filt = arm.filter_module or detect_module(
@@ -358,6 +449,12 @@ events {{ worker_connections 4096; }}
 http {{
     access_log off;
     zstd on;
+    # Pinned explicitly, not left at the compiled-in default: two arms
+    # can be two different binaries with two different defaults, and an
+    # unpinned level would mix a level change into the change under
+    # measurement. ci/tools/test_compression_matrix.py pins it for the
+    # same reason.
+    zstd_comp_level {comp_level};
     zstd_min_length 1;
     zstd_types application/octet-stream;
     server {{
@@ -394,6 +491,15 @@ def rss_monitor_start(master_pid: int, stop_path: pathlib.Path) -> subprocess.Po
     run without the harness process itself needing a thread juggling
     subprocess I/O. Writes the peak seen to `stop_path` on receipt of
     SIGTERM, then exits -- polled by the caller after wrk finishes.
+
+    `worker_processes` is fixed for the whole run, so the worker pid set
+    is resolved via `pgrep -P` ONCE, then reused for every 100ms /proc
+    read -- not re-forked on every poll. Forking a shell plus `pgrep` 10
+    times a second inside the measured window would add CPU noise on the
+    same machine the throughput itself is being measured on, undermining
+    the very number this monitor exists to collect. The pid set is only
+    re-resolved if a previously-known pid stops existing (a worker died
+    or reloaded mid-run), not on a fixed schedule.
     """
     script = f"""
 import os, signal, sys, time
@@ -403,13 +509,18 @@ def _stop(signum, frame):
     global stop
     stop = True
 signal.signal(signal.SIGTERM, _stop)
-while not stop:
+
+def resolve_pids():
     try:
         out = os.popen("pgrep -P {master_pid}").read()
-        pids = [int(x) for x in out.split() if x.strip()]
+        return [int(x) for x in out.split() if x.strip()]
     except Exception:
-        pids = []
+        return []
+
+pids = resolve_pids()
+while not stop:
     total = 0
+    stale = False
     for pid in pids:
         try:
             with open(f"/proc/{{pid}}/status") as fh:
@@ -418,8 +529,10 @@ while not stop:
                         total += int(line.split()[1])
                         break
         except (FileNotFoundError, ProcessLookupError):
-            pass
+            stale = True
     peak = max(peak, total)
+    if stale or not pids:
+        pids = resolve_pids()
     time.sleep(0.1)
 with open({str(stop_path)!r}, "w") as fh:
     fh.write(str(peak))
@@ -447,11 +560,34 @@ def parse_wrk_percentiles(text: str) -> tuple[float, float]:
     return p50, p99
 
 
+def parse_wrk_duration_s(duration: str) -> float:
+    """Parse a wrk `-d` duration string ("10s", "2m", "1h", or a bare
+    number of seconds) into seconds. Raises ValueError on anything else
+    -- callers treat that as a harness error, not a silent fallback,
+    since a duration wrk itself would reject is worth failing loudly on
+    before ever spawning the subprocess.
+    """
+    m = re.fullmatch(r"(\d+(?:\.\d+)?)(s|m|h)?", duration.strip())
+    if not m:
+        raise ValueError(f"unparsable wrk duration: {duration!r}")
+    value = float(m.group(1))
+    unit = m.group(2) or "s"
+    return value * {"s": 1, "m": 60, "h": 3600}[unit]
+
+
 def run_wrk(
     url: str, connections: int, duration: str, threads: int
 ) -> tuple[float, float, float, int, int]:
     wrk_bin = shutil.which("wrk")
     assert wrk_bin
+    # The subprocess timeout must be derived from the user-supplied
+    # duration, not a fixed constant -- a fixed 120s timeout raises an
+    # uncaught subprocess.TimeoutExpired (main() only catches
+    # RuntimeError) the moment someone passes --duration longer than
+    # that, aborting the harness with a traceback instead of the
+    # documented harness-error path. The margin covers wrk's own
+    # connect/warmup/report overhead on top of the measured window.
+    timeout_s = parse_wrk_duration_s(duration) + 30
     proc = subprocess.run(
         [
             wrk_bin,
@@ -469,7 +605,7 @@ def run_wrk(
         capture_output=True,
         text=True,
         check=False,
-        timeout=120,
+        timeout=timeout_s,
     )
     out = proc.stdout
     rps_m = re.search(r"Requests/sec:\s*([\d.]+)", out)
@@ -486,48 +622,37 @@ def run_wrk(
 
 def bench_one(
     arm: Arm,
+    master_pid: int,
     root: pathlib.Path,
     port: int,
     body: str,
     conc: int,
     duration: str,
 ) -> BenchSample:
-    master = None
-    for _ in range(50):
-        master_pids = [
-            p
-            for p in subprocess.run(
-                ["pgrep", "-f", f"{arm.binary} -p {root}"],
-                capture_output=True,
-                text=True,
-                check=False,
-            ).stdout.split()
-        ]
-        if master_pids:
-            master = int(master_pids[0])
-            break
-        time.sleep(0.05)
+    # The config sets `daemon off; master_process on;`, so the Popen
+    # object's own pid already IS the master -- no need to re-derive it
+    # via `pgrep -f`, which depended on `pgrep` being installed and on
+    # arm.binary/root containing no regex metacharacters; a miss there
+    # silently left the RSS monitor never started and the table reported
+    # a false peakRSS(MB) of 0.0 instead of failing loudly.
     stop_file = root / f"rss.{body}.{conc}.peak"
-    monitor = None
-    if master is not None:
-        monitor = rss_monitor_start(master, stop_file)
+    monitor = rss_monitor_start(master_pid, stop_file)
 
     url = f"http://127.0.0.1:{port}/{body}"
     threads = min(conc, os.cpu_count() or 4)
     rps, p50, p99, requests, errors = run_wrk(url, conc, duration, threads)
 
     peak_rss = 0
-    if monitor is not None:
-        monitor.send_signal(signal.SIGTERM)
+    monitor.send_signal(signal.SIGTERM)
+    try:
+        monitor.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        monitor.kill()
+    if stop_file.exists():
         try:
-            monitor.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            monitor.kill()
-        if stop_file.exists():
-            try:
-                peak_rss = int(stop_file.read_text().strip() or "0")
-            except ValueError:
-                peak_rss = 0
+            peak_rss = int(stop_file.read_text().strip() or "0")
+        except ValueError:
+            peak_rss = 0
 
     return BenchSample(
         rps=rps,
@@ -546,6 +671,7 @@ def run_release_pass(
     duration: str,
     workers: int,
     base_port: int,
+    comp_level: int,
 ) -> dict:
     """Interleaved A/B rounds. Returns {arm_label: {conc: {body: [samples]}}}."""
     samples: dict[str, dict[int, dict[str, list[BenchSample]]]] = {
@@ -560,23 +686,20 @@ def run_release_pass(
     try:
         for i, arm in enumerate(arms):
             root = pathlib.Path(tempfile.mkdtemp(prefix=f"ab-bench-{arm.label}-"))
+            # mkdtemp gives 0700: run as root, workers drop to the
+            # compiled-in nginx user and cannot enter it -> 403s.
+            os.chmod(root, 0o755)
             workdirs.append(root)
             port = base_port + i * 2
             backend_port = port + 1
             backend = PacedBackend(backend_port, bodies)
             backend.start()
             backends.append(backend)
-            conf = write_conf(root, port, backend_port, arm, workers, "warn")
+            conf = write_conf(
+                root, port, backend_port, arm, workers, "warn", comp_level
+            )
             proc = start_nginx(arm, conf, root)
-            if not wait_for_port(port, timeout=10):
-                tail = ""
-                log = root / "stdout.log"
-                if log.exists():
-                    tail = log.read_text("utf-8", "replace")[-2000:]
-                raise RuntimeError(
-                    f"arm {arm.label!r}: nginx never became ready on port "
-                    f"{port}. Log tail:\n{tail}"
-                )
+            require_own_nginx_ready(proc, port, root, f"arm {arm.label!r}")
             procs[arm.label] = (proc, root, port)
 
         # Warmup: one short untimed-ish run per arm/body so the cache is
@@ -597,8 +720,10 @@ def run_release_pass(
                     # adjacent in wall-clock time rather than in two
                     # separate blocks.
                     for arm in arms:
-                        _proc, root, port = procs[arm.label]
-                        sample = bench_one(arm, root, port, body, conc, duration)
+                        proc, root, port = procs[arm.label]
+                        sample = bench_one(
+                            arm, proc.pid, root, port, body, conc, duration
+                        )
                         samples[arm.label][conc][body].append(sample)
     finally:
         for proc, _root, _port in procs.values():
@@ -621,6 +746,7 @@ def run_debug_pass(
     duration: str,
     workers: int,
     base_port: int,
+    comp_level: int,
 ) -> dict[int, WitnessSample]:
     """Separate pass, debug-level logging, only for engagement witnesses.
     Its own throughput is NOT reported -- see module docstring.
@@ -635,18 +761,23 @@ def run_debug_pass(
     Raises RuntimeError (a harness error, not a "slow result") if the
     workload never demonstrates genuine RELATIVE contention: the hit
     rate at the lowest swept concurrency must be materially higher than
-    at the highest (CONTENTION_MIN_RELATIVE_RISE), with at least
-    CONTENTION_MIN_CREATED "created cctx" witnesses at the highest
-    concurrency. An absolute `created > 1` floor alone is too weak, and
-    a relative created-fraction check saturates near 1.0 once
-    contention is heavy -- both were tried and rejected, see the
-    comment at the check itself. A flat or barely-falling hit rate
-    across the sweep is indistinguishable from a workload that never
-    contends, which is a broken measurement, not a real 100% hit rate.
-    See PacedBackend's docstring for why the workload needs pacing to
-    make genuine overlap possible at all.
+    at the highest (CONTENTION_MIN_RELATIVE_RISE) -- this ratio is the
+    actual discriminating check. CONTENTION_MIN_CREATED is only a
+    trivial sanity floor on the sample size at the highest concurrency,
+    not a second independent check; an absolute `created > 1` floor and
+    a relative created-fraction check were both tried as the REAL gate
+    and rejected (see the comment at CONTENTION_MIN_CREATED and the
+    check itself) -- the former cleared on scheduling jitter alone, the
+    latter saturates near 1.0 once contention is heavy. A flat or
+    barely-falling hit rate across the sweep is indistinguishable from
+    a workload that never contends, which is a broken measurement, not
+    a real 100% hit rate. See PacedBackend's docstring for why the
+    workload needs pacing to make genuine overlap possible at all.
     """
     root = pathlib.Path(tempfile.mkdtemp(prefix=f"ab-bench-debug-{arm.label}-"))
+    # mkdtemp gives 0700: run as root, workers drop to the compiled-in
+    # nginx user and cannot enter it -> 403s.
+    os.chmod(root, 0o755)
     bodies = {name: body_bytes(size) for name, size in BODY_SIZES.items()}
     backend_port = base_port + 1
     backend = PacedBackend(backend_port, bodies)
@@ -654,24 +785,22 @@ def run_debug_pass(
     try:
         backend.start()
         port = base_port
-        conf = write_conf(root, port, backend_port, arm, workers, "debug")
+        conf = write_conf(root, port, backend_port, arm, workers, "debug", comp_level)
         proc = start_nginx(arm, conf, root)
         try:
-            if not wait_for_port(port, timeout=10):
-                tail = ""
-                log = root / "stdout.log"
-                if log.exists():
-                    tail = log.read_text("utf-8", "replace")[-2000:]
-                raise RuntimeError(
-                    f"debug pass: nginx never became ready. Log tail:\n{tail}"
-                )
+            require_own_nginx_ready(proc, port, root, "debug pass")
             elog_path = root / "error.log"
             prev_created = 0
             prev_reused = 0
             for conc in concurrencies:
                 # Throughput-not-reported run purely to generate witness
                 # lines under realistic concurrent load.
-                run_wrk(f"http://127.0.0.1:{port}/8kb", conc, duration, min(conc, 4))
+                run_wrk(
+                    f"http://127.0.0.1:{port}/{DEBUG_BODY}",
+                    conc,
+                    duration,
+                    min(conc, 4),
+                )
                 time.sleep(0.3)  # let the debug log flush
                 elog = elog_path.read_text("utf-8", "replace")
                 total_created = len(re.findall(re.escape(CREATE_WITNESS), elog))
@@ -709,9 +838,12 @@ def run_debug_pass(
     # -> 3.1%, a 3.9x fall, because it is not pinned near a ceiling. The
     # check below requires the hit rate at the lowest swept concurrency
     # to be MEASURABLY HIGHER than at the highest -- "decays toward
-    # 1/N" is exactly this claim -- plus an absolute floor on `created`
-    # at the highest concurrency so a pass can't come from two
-    # single-digit witness counts dividing favourably.
+    # 1/N" is exactly this claim, and CONTENTION_MIN_RELATIVE_RISE is
+    # the sole discriminating threshold. CONTENTION_MIN_CREATED adds
+    # only a trivial sanity floor on `created` at the highest
+    # concurrency, so a pass can't come from two single-digit witness
+    # counts dividing favourably -- it does not by itself prove
+    # contention, the ratio above does.
     lo_conc, hi_conc = min(concurrencies), max(concurrencies)
     lo, hi = results.get(lo_conc), results.get(hi_conc)
     lo_hr = lo.hit_rate if lo is not None else None
@@ -758,13 +890,23 @@ def check_with_debug(binary: pathlib.Path) -> None:
 def print_release_table(
     arms: list[Arm], concurrencies: list[int], samples: dict
 ) -> None:
+    """Prints the release-pass table, including an `errors` column so a
+    partially-failing run (non-2xx/3xx responses, which wrk itself
+    counts inside "N requests in" alongside genuine successes) is
+    visible instead of silently averaged into the rps/latency numbers.
+    Any nonzero error count anywhere in the sweep gets a loud warning
+    after the table -- a confident-looking table measured on error
+    responses is the exact failure class this tool exists to avoid.
+    """
     header = (
         f"{'arm':<14}{'conc':>6}{'body':>7}{'rps(med)':>11}"
-        f"{'p50(ms)':>10}{'p99(ms)':>10}{'peakRSS(MB)':>13}{'rounds':>8}"
+        f"{'p50(ms)':>10}{'p99(ms)':>10}{'peakRSS(MB)':>13}"
+        f"{'errors':>8}{'rounds':>8}"
     )
     print(header)
     print("-" * len(header))
     medians: dict[str, dict[int, dict[str, float]]] = {}
+    any_errors = False
     for arm in arms:
         medians[arm.label] = {}
         for conc in concurrencies:
@@ -775,12 +917,25 @@ def print_release_table(
                 p50_med = statistics.median(s.p50_ms for s in sset)
                 p99_med = statistics.median(s.p99_ms for s in sset)
                 rss_peak = max((s.peak_rss_kb for s in sset), default=0) / 1024
+                total_errors = sum(s.errors for s in sset)
+                if total_errors > 0:
+                    any_errors = True
                 medians[arm.label][conc][body] = rps_med
                 print(
                     f"{arm.label:<14}{conc:>6}{body:>7}{rps_med:>11.1f}"
                     f"{p50_med:>10.2f}{p99_med:>10.2f}{rss_peak:>13.1f}"
-                    f"{len(sset):>8}"
+                    f"{total_errors:>8}{len(sset):>8}"
                 )
+        print()
+    if any_errors:
+        print(
+            "WARNING: non-2xx/3xx responses occurred somewhere in this "
+            "sweep (see the 'errors' column above). wrk counts those "
+            "inside its own request total, so the rps/p50/p99 numbers "
+            "for the affected cell(s) are measured PARTLY on error "
+            "responses, not on successful compression -- do not treat "
+            "them as a clean throughput measurement."
+        )
         print()
 
     if len(arms) == 2:
@@ -882,12 +1037,36 @@ def main() -> int:
         help="nginx worker_processes (default 1: the TODO rows this "
         "harness gates are about PER-WORKER cache behaviour)",
     )
+    ap.add_argument(
+        "--comp-level",
+        type=int,
+        default=6,
+        help="zstd_comp_level pinned in the generated config for both "
+        "arms (default 6, matches the existing +79% measurement). "
+        "Pinned explicitly rather than left at each binary's compiled-in "
+        "default so an A/B between two different binaries never mixes a "
+        "level change into the change actually under measurement.",
+    )
     ap.add_argument("--base-port", type=int, default=18400)
     ap.add_argument("--json", help="write machine-readable results here")
     args = ap.parse_args()
 
+    # Everything the scratch roots below create must stay readable by the
+    # workers when the harness runs as root (they drop to the compiled-in
+    # nginx user): a restrictive inherited umask would strip group/other
+    # bits from every fixture created here, 403ing the workers even with
+    # each scratch root itself chmod'd open -- same trap and same fix as
+    # ci/tools/test_compression_matrix.py.
+    os.umask(0o022)
+
     if shutil.which("wrk") is None:
         print("error: wrk not found on PATH", file=sys.stderr)
+        return 2
+
+    try:
+        parse_wrk_duration_s(args.duration)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
         return 2
 
     concurrencies = [int(x) for x in args.concurrency.split(",") if x.strip()]
@@ -918,20 +1097,28 @@ def main() -> int:
             args.duration,
             args.workers,
             args.base_port,
+            args.comp_level,
         )
     except RuntimeError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
-    total_requests = sum(
-        s.requests
+    # Gate on SUCCESSFUL requests, not raw request count -- wrk's own
+    # "N requests in" total includes non-2xx/3xx responses, so an
+    # all-403 or all-502 run would otherwise clear this gate and print
+    # a full throughput table measured on nothing.
+    total_successful = sum(
+        max(s.requests - s.errors, 0)
         for arm in arms
         for conc in concurrencies
         for body in BODY_SIZES
         for s in samples[arm.label][conc][body]
     )
-    if total_requests == 0:
-        print("error: zero successful requests across the whole sweep", file=sys.stderr)
+    if total_successful == 0:
+        print(
+            "error: zero successful (non-error) requests across the whole sweep",
+            file=sys.stderr,
+        )
         return 1
 
     print_release_table(arms, concurrencies, samples)
@@ -955,6 +1142,7 @@ def main() -> int:
                 args.duration,
                 args.workers,
                 args.base_port + len(arms) * 2 + 2,
+                args.comp_level,
             )
         except RuntimeError as exc:
             print(f"error: {exc}", file=sys.stderr)


### PR DESCRIPTION
> New CI infra, not a bug fix — the gating dependency for the CCtx-ring, per-profile-slot, one-reset-per-request and first-buffer-sizing TODO rows, which all say "do NOT guess — measure".

## TL;DR

Adds `ci/tools/ab_bench.py`, a manual measurement tool (not wired into any CI workflow) that drives a real nginx over the zstd filter under `wrk` load and reports request-path throughput, latency and worker memory. It exists to answer "did this change help, on what body sizes, at what concurrency" with a real number instead of a guess.

Two nginx binaries (or one binary run under two labels) are benchmarked in interleaved rounds — not sequentially — because a sequential A-then-B run confounds the result with machine drift; the existing worker-CCtx-cache +79% measurement used the same 3-interleaved-round technique. Reports the per-arm median rps/p50/p99/peak-worker-RSS across rounds, plus the delta, at each of 8/32/128 connections by default, separately for 8 KB and 64 KB bodies (the recorded win was 8 KB-only and zero at 64 KB — the harness never collapses that into one blanket number).

**Severity:** `Low` (`ci — new measurement tooling, no production code path touched`)

## Cache-witness separation, and why the workload is paced

The cache-engagement hit rate is only observable from `ngx_log_debug` lines ("zstd: created cctx" / "zstd: reusing worker cctx"), which need an nginx built `--with-debug` and debug-level logging — logging that would distort the throughput being measured under 128-connection load. The harness runs two structurally separate passes with separate result sections: RELEASE (`error_log warn`, throughput/latency/RSS, no witness counts) and DEBUG (`error_log debug`, witness counts and hit rate, only when `--debug-binary` is given; its own throughput is intentionally not printed). A release-only run reports the hit rate as unmeasured, never inferred.

An earlier version of this harness served bodies from a static, fully-buffered location. nginx completes that inside one event-loop turn, so the worker-lifetime CCtx loan (held from `acquire_cctx` until request cleanup) never actually contends no matter how many `wrk` connections are open — it produced a flat 100% hit rate at 8/32/128 conn and a peak worker RSS that never moved, which is the signature of a workload that cannot contend, not of a healthy cache. This was caught in review before the numbers were trusted. Bodies are now served through `PacedBackend`, a mock upstream proxied with `proxy_buffering off` that streams the body in small chunked pieces with a short sleep between each, so a compression session stays open across many event-loop turns while other connections are accepted.

The debug pass now sweeps the full concurrency range against one long-lived nginx instance and includes a mandatory self-check: it raises a harness error unless the hit rate at the lowest swept concurrency is measurably higher than at the highest, with an absolute floor on created-witness count at the highest concurrency. Two weaker checks (an absolute `created > 1` floor, and a relative created-fraction rise) were tried and rejected first — both pass on a workload that barely contends. The surviving check and the rejected ones are documented in the code.

## Testing

Ran the full default sweep (8/32/128 connections, 3 interleaved rounds, both body sizes, A/B against the same binary under two labels, plus the debug pass with self-check) against a real `--with-debug` nginx 1.31.4 built via `ci/tools/ci-build.sh nginx "" release`:

```
=== RELEASE PASS: rps/p50/p99/RSS, 3 interleaved round(s), NO cache witnesses in this section ===
arm             conc   body   rps(med)   p50(ms)   p99(ms)  peakRSS(MB)  rounds
-------------------------------------------------------------------------------
baseline           8    8kb      115.2     68.58     70.04        343.6       3
baseline           8   64kb       14.4    542.85    547.98        353.6       3
baseline          32    8kb      478.5     66.38     68.96        364.4       3
baseline          32   64kb       56.5    532.11    543.09        375.0       3
baseline         128    8kb     1877.8     67.14     70.77        419.3       3
baseline         128   64kb      225.9    526.95    543.12        432.9       3

(baseline2, same binary under a second label, tracks within ±0.5% of the
above at every cell -- noise level, confirming the harness itself is sound.)

=== DEBUG PASS: cache-engagement witnesses ===
arm             conc  created  reused  hit rate
-----------------------------------------------
debug              8      526      74     12.3%
debug             32     2348      77      3.2%
debug            128     8903      75      0.8%

hit rate DECREASES somewhere in this sweep as concurrency rises -- the
single-slot contention the ring-sizing row expects.
```

Hit rate falls 12.3% → 3.2% → 0.8% across 8/32/128 connections — a clean decay toward 1/N, which is the actual signal the ring-sizing row needs and could not get from the earlier static-body version. Worker RSS now scales with concurrency instead of staying flat.

Also verified: the self-check fires correctly on a disabled-pacing negative control (huge chunk size, zero delay) — exits 1 with a harness error and prints no debug table, even though that degenerate workload still shows a hit rate that (wrongly) *rises* with concurrency, which the check also correctly rejects. `--json` output round-trips; a single-arm release-only invocation still prints "hit rate is UNMEASURED, not inferred" and no witness section; `ruff check`/`ruff format --check` clean; `.claude/skills/_shared/review-lint.sh --branch master` clean except pre-existing-shape complexity NITs on the three CLI-orchestration functions (same shape as `main` in `ci/tools/benchmark.py` and `ci/tools/test_cctx_reuse.py`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable compression-level benchmarking.
  - Added concurrency sweeps with per-level cache and compression measurements.
  - Added detailed debug results keyed by concurrency level.

- **Bug Fixes**
  - Improved readiness checks to confirm the intended service is running.
  - Improved timeout handling, process monitoring, and temporary-file accessibility.
  - Excluded failed requests from successful-request metrics.

- **Reporting**
  - Benchmark output now reports errors and warns when results include error responses.
  - Validation now detects unexpected performance trends and insufficient measurement evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->