### PR TITLE
perf: drop the unread request pointer from the filter context

### DIFF
--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -164,7 +164,6 @@ typedef struct {
     ZSTD_inBuffer                buffer_in;
     ZSTD_outBuffer               buffer_out;
 
-    ngx_http_request_t          *request;
     ZSTD_CCtx                   *cctx;
 
     /* dictionary negotiated for this response via Available-Dictionary;
@@ -767,7 +766,6 @@ ngx_http_zstd_header_filter(ngx_http_request_t *r)
 
     ngx_http_set_ctx(r, ctx, ngx_http_zstd_filter_module);
 
-    ctx->request = r;
     ctx->last_out = &ctx->out;
     ctx->dcz_dict = dcz;
 


### PR DESCRIPTION
> First code change from the G1 batch in `memory/labs/http-zstd/TODO.md`. The companion repack row from the same batch was measured and refuted; see below.

## TL;DR

The module keeps a small record of state for each response it compresses. One field in that record was filled in but never once looked at, anywhere. Removing it makes the record smaller and saves a little work on every compressed response.

`ngx_http_zstd_ctx_t.request` was assigned at `ngx_http_zstd_filter_module.c:770` and read nowhere in the tree; deleting it takes the struct from 168 to 160 bytes.

**Severity:** `Low` (`dead field — one pointer of pool memory and one store per compressed response`)

## Evidence

`grep` over `src/` finds exactly one occurrence, the assignment itself. Layout confirmed against the built object rather than by inspection:

```
pahole -F dwarf -C ngx_http_zstd_ctx_t \
  .build/nginx-1.31.4/objs/addon/src/ngx_http_zstd_filter_module.o
```

before: `size: 168, cachelines: 3` · after: `size: 160, cachelines: 3`

Query is by typedef, not by a `_s` struct tag — this struct is anonymous, so the usual tag-based invocation finds nothing here.

The type is TU-private (declared in the `.c`), so no ABI constraint applies.

## What is deliberately NOT in this PR

The adjacent TODO row proposed repacking the struct by hotness, moving the action selector and seven state bits out of the third cacheline. It was implemented and measured, then reverted.

The layout change worked as described — `action` and the state bits moved from offsets 156/152 to 56/60, into the first cacheline beside `in_buf`/`out_buf`. The throughput did not follow. `ab_bench.py`, 3 interleaved rounds, both arms built from the same tree:

| conc | body | before rps | after rps | delta |
|---|---|---|---|---|
| 8 | 8kb | 5078.3 | 5215.0 | +2.7% |
| 8 | 64kb | 4150.9 | 4188.4 | +0.9% |
| 32 | 8kb | 9234.9 | 9210.6 | -0.3% |
| 32 | 64kb | 7611.6 | 7553.6 | -0.8% |
| 128 | 8kb | 9848.9 | 10069.6 | +2.2% |
| 128 | 64kb | 8121.6 | 8184.1 | +0.8% |

Three of six cells are negative and the spread straddles zero — noise, not a win. The row's Done criterion is "verify size **and** cache-miss/throughput change", and a size drop alone does not justify reordering a struct whose field comments carry correctness history (the `cctx_ready` comment documents a real truncation bug). Recorded as refuted in TODO.md; reopen only with a `perf stat` counter delta showing a genuine cache-miss reduction.

## Testing

- `review-lint.sh --diff HEAD`: flawfinder, cppcheck, clang-tidy, semgrep, ast-grep, gitleaks, trufflehog, codespell clean; no coverage gap. Pre-existing complexity warnings are on functions this diff does not touch.
- Builds clean against nginx 1.31.4; `pahole` output above is from that build.
- Full remote CI on this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused internal request-tracking data.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->