### PR TITLE
perf: per-profile CCtx slot ring, sized at 4 by measurement

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1415,10 +1415,19 @@ jobs:
           # but wrong body). Fire many distinct concurrent requests
           # through one worker over reused keepalive connections; each
           # response must decode byte-exact to its OWN origin.
+          # --require-multi-slot additionally asserts, from the debug
+          # witnesses, that MORE THAN ONE ring slot was actually lent.
+          # Without it the byte-exactness oracle is satisfied by a build
+          # where every concurrent claimant falls through to a
+          # per-request context -- which is what the single-slot cache
+          # did, so the test would pass without ever exercising the
+          # concurrent slot borrowing the ring introduces. Only on this
+          # non-sanitized job: UBSAN cannot log at debug at all (see the
+          # --log-level warn note on the sanitizer jobs below).
           python3 ci/tools/test_concurrent_cctx_isolation.py \
             --nginx-binary "$TEST_NGINX_BINARY" \
             --port 18098 --backend-port 18099 \
-            --concurrency 16 --rounds 6
+            --concurrency 16 --rounds 6 --require-multi-slot
           echo "✓ per-request CCtx isolation regression passed"
 
       - name: Run worker CCtx cache regression

--- a/README.md
+++ b/README.md
@@ -623,6 +623,18 @@ clear message, never silently no-op'd.
 > `worker_connections × zstd_max_cctx_memory` in the worst case
 > (every connection actively compressing).
 
+> **Retained memory between requests.** Each worker keeps a small ring
+> of compression contexts (4 slots) so consecutive responses reuse an
+> already-allocated workspace instead of building one per response.
+> A slot is keyed on the complete set of parameters that drive that
+> workspace — `zstd_comp_level`, `zstd_long` and `zstd_window_log` — and
+> is never re-parameterised, so a slot's retained size stays at the
+> figure `zstd_max_cctx_memory` vetted for that profile at config load.
+> An idle worker therefore holds up to 4 workspaces, one per distinct
+> profile it has served, rather than releasing them between requests;
+> this is a floor well below the `worker_connections ×
+> zstd_max_cctx_memory` ceiling above, not an addition to it.
+
 ---
 
 ### zstd_bypass

--- a/README.md
+++ b/README.md
@@ -630,10 +630,14 @@ clear message, never silently no-op'd.
 > workspace — `zstd_comp_level`, `zstd_long` and `zstd_window_log` — and
 > is never re-parameterised, so a slot's retained size stays at the
 > figure `zstd_max_cctx_memory` vetted for that profile at config load.
-> An idle worker therefore holds up to 4 workspaces, one per distinct
-> profile it has served, rather than releasing them between requests;
-> this is a floor well below the `worker_connections ×
-> zstd_max_cctx_memory` ceiling above, not an addition to it.
+> An idle worker therefore holds up to 4 workspaces rather than
+> releasing them between requests. Budget that constant, not the number
+> of configured profiles: a busy slot is skipped before its profile is
+> compared, so concurrent requests on a single profile can seed several
+> slots with that same profile. Each retained workspace stays at its own
+> profile's vetted figure, so this is a floor well below the
+> `worker_connections × zstd_max_cctx_memory` ceiling above, not an
+> addition to it.
 
 ---
 

--- a/ci/tools/test_cctx_reuse.py
+++ b/ci/tools/test_cctx_reuse.py
@@ -63,6 +63,27 @@ ROUNDS = 12
 # context serving the previous body is a byte mismatch, not a silent pass.
 BODY_SIZE = 24 * 1024
 
+# The three locations whose memory profile differs from the default, each
+# of which must occupy its OWN ring slot.
+ALT_LOCATIONS = (
+    ("/alt/b", 999, "zstd_comp_level 9"),
+    ("/alt/long", 998, "zstd_long on"),
+    ("/alt/wlog", 997, "zstd_window_log 20"),
+)
+
+# Requests per /alt location. Must be >= 2: the first seeds that profile's
+# slot, the rest are the reuse witnesses that only a per-profile ring can
+# produce.
+ALT_ROUNDS = 4
+assert ALT_ROUNDS >= 2
+
+# One context per distinct profile, and no more.
+WANT_CREATED = 1 + len(ALT_LOCATIONS)
+
+# ROUNDS-1 reuses on the default profile (the first /b request seeds its
+# slot), plus ALT_ROUNDS-1 on each differing profile.
+WANT_REUSED = (ROUNDS - 1) + len(ALT_LOCATIONS) * (ALT_ROUNDS - 1)
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -254,14 +275,22 @@ http {{
                     )
                     break
 
-            # Each differing memory profile must take the per-request path.
-            for path, rid, label in (
-                ("/alt/b", 999, "zstd_comp_level 9"),
-                ("/alt/long", 998, "zstd_long on"),
-                ("/alt/wlog", 997, "zstd_window_log 20"),
-            ):
-                if decode(http_get(args.port, path)) != fixture(rid):
-                    failures.append(f"{label} location: decoded body mismatch")
+            # Each differing memory profile gets its OWN ring slot: the
+            # first request seeds that slot, and every further request to
+            # the same location must REUSE it. Requesting each location
+            # ALT_ROUNDS times is what makes the per-profile half of the
+            # ring observable at all -- with a single request each, a ring
+            # and the old single-slot cache produce identical witness
+            # counts (one create, no reuse) and this test could not tell
+            # them apart. Under the single slot the default /b profile owns
+            # the one slot, so every one of these requests is a fresh
+            # create and `reused` falls short by ALT_PROFILES *
+            # (ALT_ROUNDS - 1).
+            for path, rid, label in ALT_LOCATIONS:
+                for _ in range(ALT_ROUNDS):
+                    if decode(http_get(args.port, path)) != fixture(rid):
+                        failures.append(f"{label} location: decoded body mismatch")
+                        break
 
             # Flush the debug log before reading witnesses.
             time.sleep(0.3)
@@ -285,21 +314,29 @@ http {{
             # bug this partition exists to prevent, and the two same-level
             # locations are the ones a level-only key gets wrong. More than
             # four means the cache is not holding across requests.
-            if args.log_level == "debug" and created != 4:
+            if args.log_level == "debug" and created != WANT_CREATED:
                 failures.append(
-                    f"expected exactly 4 'created cctx' witnesses (one "
-                    f"cached default profile, plus one each for the "
-                    f"zstd_comp_level / zstd_long / zstd_window_log "
-                    f"locations that must not reuse it), saw {created} -- "
-                    f"the cache is either lending across memory profiles or "
-                    f"not surviving across requests"
+                    f"expected exactly {WANT_CREATED} 'created cctx' "
+                    f"witnesses (one per distinct memory profile: the "
+                    f"default, plus the zstd_comp_level / zstd_long / "
+                    f"zstd_window_log locations, each of which must get its "
+                    f"OWN ring slot rather than borrowing another "
+                    f"profile's), saw {created} -- fewer means a slot was "
+                    f"lent across memory profiles, more means slots are not "
+                    f"surviving across requests"
                 )
-            # ROUNDS-1: the first /b request seeds the cache (counted as a
-            # create, not a reuse). Each /alt request is a create too.
-            if args.log_level == "debug" and reused != ROUNDS - 1:
+            # One create per distinct profile; every other request reuses
+            # that profile's slot. The ALT_ROUNDS-1 reuses per /alt
+            # location are the per-profile-slot witnesses: a single-slot
+            # cache cannot produce them, because the default profile
+            # permanently owns the only slot.
+            if args.log_level == "debug" and reused != WANT_REUSED:
                 failures.append(
-                    f"expected {ROUNDS - 1} 'reusing worker cctx' witnesses "
-                    f"across {ROUNDS} sequential requests, saw {reused}"
+                    f"expected {WANT_REUSED} 'reusing worker cctx' "
+                    f"witnesses ({ROUNDS - 1} on the default profile plus "
+                    f"{ALT_ROUNDS - 1} on each of the {len(ALT_LOCATIONS)} "
+                    f"differing profiles, which a single-slot cache cannot "
+                    f"produce at all), saw {reused}"
                 )
 
             if not failures:

--- a/ci/tools/test_concurrent_cctx_isolation.py
+++ b/ci/tools/test_concurrent_cctx_isolation.py
@@ -197,6 +197,22 @@ def main() -> int:
     nginx = pathlib.Path(args.nginx_binary)
     if not nginx.exists():
         raise FileNotFoundError(nginx)
+
+    if args.require_multi_slot:
+        # The slot witnesses are ngx_log_debug2 lines, compiled out without
+        # --with-debug. Checked here rather than at the assertion: a
+        # non-debug build yields zero witnesses, which the multi-slot check
+        # would otherwise report as "the ring never lent two slots" -- an
+        # accusation against the module for what is a build-flavor problem.
+        v = subprocess.run(
+            [str(nginx), "-V"], capture_output=True, text=True, check=False
+        )
+        if "--with-debug" not in v.stderr:
+            raise RuntimeError(
+                "--require-multi-slot reads ngx_log_debug witnesses: this "
+                "tool needs an nginx built --with-debug, or drop the flag"
+            )
+
     mods = [
         m
         for m in (

--- a/ci/tools/test_concurrent_cctx_isolation.py
+++ b/ci/tools/test_concurrent_cctx_isolation.py
@@ -49,6 +49,7 @@ import hashlib
 import http.server
 import os
 import pathlib
+import re
 import socket
 import socketserver
 import subprocess
@@ -79,6 +80,19 @@ def parse_args() -> argparse.Namespace:
     )
     p.add_argument(
         "--rounds", type=int, default=6, help="Times to run the full concurrent batch."
+    )
+    p.add_argument(
+        "--require-multi-slot",
+        action="store_true",
+        help="Also assert, from the debug-log witnesses, that the worker "
+        "CCtx ring actually lent MORE THAN ONE slot during the run. "
+        "Without this the byte-exactness oracle alone is satisfied by a "
+        "build where concurrent claimants always fall through to a "
+        "per-request context -- which is exactly what the single-slot "
+        "cache did, so the test would pass without ever exercising "
+        "concurrent slot borrowing, the risk surface the ring "
+        "introduces. Needs an nginx built --with-debug; raises the "
+        "location error_log to debug.",
     )
     return p.parse_args()
 
@@ -226,11 +240,12 @@ def main() -> int:
                     "payloads not distinct per id (test would be blind to bleed)"
                 )
 
+            elvl = "debug" if args.require_multi_slot else "warn"
             load = "".join(f"load_module {m};\n" for m in mods)
             conf = root / "nginx.conf"
             conf.write_text(
                 f"""{load}worker_processes 1;
-error_log {logs}/error.log warn;
+error_log {logs}/error.log {elvl};
 pid {root}/nginx.pid;
 events {{ worker_connections 512; }}
 http {{
@@ -306,6 +321,31 @@ http {{
                                     f"mismatch (got {len(got)}B want "
                                     f"{len(want)}B){culprit}"
                                 )
+                slots_seen: set[str] = set()
+                if args.require_multi_slot:
+                    # Flush, then count the DISTINCT ring slots that were
+                    # actually lent. One slot is the single-slot cache's
+                    # behaviour; the concurrent-borrowing path this test
+                    # exists to cover is only reached when at least two
+                    # distinct slots were on loan during the run.
+                    time.sleep(0.3)
+                    elog = (logs / "error.log").read_text("utf-8", "replace")
+                    slots_seen = set(
+                        re.findall(
+                            r"zstd: reusing worker cctx \S+ \(slot:(\d+)\)",
+                            elog,
+                        )
+                    )
+                    if len(slots_seen) < 2:
+                        failures.append(
+                            f"only {len(slots_seen)} distinct ring slot(s) "
+                            f"were ever lent ({sorted(slots_seen)}) across "
+                            f"{total} concurrent requests -- this run never "
+                            f"exercised concurrent slot borrowing, so its "
+                            f"byte-exactness result proves nothing about "
+                            f"the ring"
+                        )
+
                 if failures:
                     sys.stderr.write(
                         f"CCtx-ISOLATION FAILED: {len(failures)}/{total}:\n"
@@ -321,6 +361,11 @@ http {{
                     f"rounds, distinct per-request bodies, keepalive "
                     f"reuse) each decoded byte-exact to its own "
                     f"origin — no cross-request CCtx bleed"
+                    + (
+                        f"; {len(slots_seen)} distinct ring slots lent concurrently"
+                        if args.require_multi_slot
+                        else ""
+                    )
                 )
                 return 0
             finally:

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -369,7 +369,7 @@ static ngx_int_t ngx_http_zstd_filter_emit_dcz_header(ngx_http_request_t *r,
  *
  * Why there is no runtime memory cap: ZSTD_sizeof_CCtx() does not shrink on
  * reset, so an unbounded cache would pin each worker's RSS at its
- * largest-ever footprint. The cache is therefore keyed on the COMPLETE set
+ * largest-ever footprint. Each slot is therefore keyed on the COMPLETE set
  * of parameters that drive that workspace, and every one of them is fixed at
  * config load: zstd_comp_level, zstd_long and zstd_window_log.
  *
@@ -391,22 +391,59 @@ static ngx_int_t ngx_http_zstd_filter_emit_dcz_header(ngx_http_request_t *r,
  * So both zstd_long and zstd_window_log move the retained workspace by more
  * than thirty times at one level, and the growth is permanent: walking a
  * context through the 154 MB profile and back to the 4 MB one leaves
- * ZSTD_sizeof_CCtx() at 154 MB. Lending one worker context across locations
- * with differing profiles would raise the worker's floor to the largest
+ * ZSTD_sizeof_CCtx() at 154 MB. Lending one cached context across locations
+ * with differing profiles would raise that context's floor to the largest
  * profile ever served and silently defeat a lower location's
  * zstd_max_cctx_memory budget, which is computed from exactly these three
  * values at config load.
  *
- * Keying on all three keeps the cached context's high-water mark equal to
+ * Keying on all three keeps a cached context's high-water mark equal to
  * the figure config load already vetted for that profile. A location whose
- * profile differs in any of the three does not reuse the cache; it takes the
- * per-request path, which is the pre-existing safe behaviour.
+ * profile matches no slot does not reuse a cached context; it seeds a free
+ * slot, or takes the per-request path -- the pre-existing safe behaviour.
+ *
+ * Ring of per-profile slots, rather than the one slot this cache shipped
+ * with. Each slot carries its OWN profile triple, so the keying invariant
+ * documented above is per slot, not per worker: a slot's retained workspace
+ * high-water mark stays equal to the figure config load vetted for that
+ * slot's profile. A slot is never re-parameterised -- a request whose
+ * profile matches no slot either seeds a free slot or takes the per-request
+ * path, exactly as before.
+ *
+ * Two consequences the single-slot version did not have, both deliberate:
+ *
+ *  - Concurrent borrowing is now actually reachable. Previously the second
+ *    overlapping request on a worker always fell through to a per-request
+ *    context because the one slot was busy. Isolation is preserved by the
+ *    same rule as before, applied per slot: `busy` is set on loan and
+ *    cleared only by the borrowing request's pool cleanup, so a slot is
+ *    lent to at most one request at a time and two concurrent requests
+ *    always land on different slots (or on the per-request path).
+ *
+ *  - Locations with DIFFERENT profiles no longer evict each other. With one
+ *    slot, two locations differing only in zstd_window_log or zstd_long
+ *    meant whichever seeded the cache first served its own requests and
+ *    every request of the other took the per-request path forever.
+ *
+ * The ring size bounds retained memory: up to NGX_HTTP_ZSTD_CCTX_SLOTS
+ * workspaces per worker, each at its own profile's vetted figure. It is a
+ * compile-time constant rather than a directive so the bound is auditable
+ * from the source and cannot be raised by configuration.
  */
-static ZSTD_CCtx  *ngx_http_zstd_worker_cctx;
-static ngx_int_t   ngx_http_zstd_worker_cctx_level;
-static ngx_flag_t  ngx_http_zstd_worker_cctx_long_mode;
-static ngx_int_t   ngx_http_zstd_worker_cctx_window_log;
-static ngx_uint_t  ngx_http_zstd_worker_cctx_busy;
+#ifndef NGX_HTTP_ZSTD_CCTX_SLOTS
+#define NGX_HTTP_ZSTD_CCTX_SLOTS  4
+#endif
+
+typedef struct {
+    ZSTD_CCtx   *cctx;
+    ngx_int_t    level;
+    ngx_flag_t   long_mode;
+    ngx_int_t    window_log;
+    ngx_uint_t   busy;
+} ngx_http_zstd_cctx_slot_t;
+
+static ngx_http_zstd_cctx_slot_t
+    ngx_http_zstd_worker_cctx_slots[NGX_HTTP_ZSTD_CCTX_SLOTS];
 
 
 static ngx_conf_post_t  ngx_http_zstd_comp_level_bounds = {
@@ -1794,8 +1831,9 @@ static ngx_int_t
 ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
     ngx_http_zstd_loc_conf_t *zlcf)
 {
-    ngx_uint_t           borrowed;
-    ngx_pool_cleanup_t  *cln;
+    ngx_uint_t                  i, borrowed;
+    ngx_pool_cleanup_t         *cln;
+    ngx_http_zstd_cctx_slot_t  *slot, *free_slot;
 
     /*
      * The cleanup slot is registered BEFORE the context is claimed, so a
@@ -1808,29 +1846,52 @@ ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
     }
 
     borrowed = 0;
+    free_slot = NULL;
 
     /*
-     * Borrow the worker context when it is free and was built for this
-     * location's complete memory-affecting profile: compression level, long
-     * mode and window log. A mismatch in any of the three takes the
-     * per-request path rather than re-parameterising the cache: the retained
-     * workspace is driven by all three and never shrinks, so honouring a
-     * higher-memory location here would raise the worker's floor for every
-     * subsequent request of every other location.
+     * Borrow a slot whose context is free and was built for this location's
+     * complete memory-affecting profile: compression level, long mode and
+     * window log. A mismatch in any of the three never re-parameterises a
+     * slot: the retained workspace is driven by all three and never shrinks,
+     * so honouring a higher-memory location on an existing slot would raise
+     * that slot's floor for every subsequent request of every other location
+     * mapped to it.
+     *
+     * The same walk records the first slot that is empty AND not on loan, so
+     * a miss can seed it below without a second pass. An empty slot is only
+     * ever seeded, never evicted: a live cached context is not thrown away
+     * mid-flight, and one already on loan is left alone.
      */
-    if (!ngx_http_zstd_worker_cctx_busy
-        && ngx_http_zstd_worker_cctx != NULL
-        && ngx_http_zstd_worker_cctx_level == zlcf->level
-        && ngx_http_zstd_worker_cctx_long_mode == zlcf->long_mode
-        && ngx_http_zstd_worker_cctx_window_log == zlcf->window_log)
-    {
-        ctx->cctx = ngx_http_zstd_worker_cctx;
-        borrowed = 1;
+    for (i = 0; i < NGX_HTTP_ZSTD_CCTX_SLOTS; i++) {
+        slot = &ngx_http_zstd_worker_cctx_slots[i];
 
-        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                       "zstd: reusing worker cctx %p", ctx->cctx);
+        if (slot->busy) {
+            continue;
+        }
 
-    } else {
+        if (slot->cctx == NULL) {
+            if (free_slot == NULL) {
+                free_slot = slot;
+            }
+            continue;
+        }
+
+        if (slot->level == zlcf->level
+            && slot->long_mode == zlcf->long_mode
+            && slot->window_log == zlcf->window_log)
+        {
+            ctx->cctx = slot->cctx;
+            slot->busy = 1;
+            borrowed = 1;
+
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "zstd: reusing worker cctx %p (slot:%ui)",
+                           ctx->cctx, i);
+            break;
+        }
+    }
+
+    if (!borrowed) {
         ctx->cctx = ZSTD_createCCtx();
         if (ctx->cctx == NULL) {
             ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
@@ -1838,16 +1899,12 @@ ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
             return NGX_ERROR;
         }
 
-        /*
-         * Seed an empty cache so subsequent requests amortise. Only an empty
-         * cache is populated -- a live cached context is never evicted
-         * mid-flight, and one already on loan is left alone.
-         */
-        if (ngx_http_zstd_worker_cctx == NULL) {
-            ngx_http_zstd_worker_cctx = ctx->cctx;
-            ngx_http_zstd_worker_cctx_level = zlcf->level;
-            ngx_http_zstd_worker_cctx_long_mode = zlcf->long_mode;
-            ngx_http_zstd_worker_cctx_window_log = zlcf->window_log;
+        if (free_slot != NULL) {
+            free_slot->cctx = ctx->cctx;
+            free_slot->level = zlcf->level;
+            free_slot->long_mode = zlcf->long_mode;
+            free_slot->window_log = zlcf->window_log;
+            free_slot->busy = 1;
             borrowed = 1;
         }
 
@@ -1857,7 +1914,6 @@ ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
     }
 
     if (borrowed) {
-        ngx_http_zstd_worker_cctx_busy = 1;
         cln->handler = ngx_http_zstd_release_cctx;
 
     } else {
@@ -2941,28 +2997,38 @@ ngx_http_zstd_cleanup_cctx(void *data)
 static void
 ngx_http_zstd_release_cctx(void *data)
 {
-    ZSTD_CCtx *cctx = data;
+    ngx_uint_t   i;
+    ZSTD_CCtx   *cctx = data;
 
     if (cctx == NULL) {
         return;
     }
 
-    if (cctx == ngx_http_zstd_worker_cctx) {
-        (void) ZSTD_CCtx_reset(cctx, ZSTD_reset_session_only);
-        ngx_http_zstd_worker_cctx_busy = 0;
-        return;
+    /*
+     * Find the slot this loan came from. The cleanup handler is given only
+     * the context pointer (nginx's cleanup contract), so the slot is located
+     * by pointer identity; NGX_HTTP_ZSTD_CCTX_SLOTS is a small compile-time
+     * constant, so this walk is a handful of comparisons on a hot-but-tiny
+     * array, not a lookup structure worth carrying.
+     */
+    for (i = 0; i < NGX_HTTP_ZSTD_CCTX_SLOTS; i++) {
+        if (ngx_http_zstd_worker_cctx_slots[i].cctx == cctx) {
+            (void) ZSTD_CCtx_reset(cctx, ZSTD_reset_session_only);
+            ngx_http_zstd_worker_cctx_slots[i].busy = 0;
+            return;
+        }
     }
 
     /*
-     * Not the cached context: the cache was replaced while this request held
-     * its loan (only reachable if a future edit adds eviction). Own it.
+     * Not in any slot: the slot was replaced while this request held its
+     * loan (only reachable if a future edit adds eviction). Own it.
      */
     ZSTD_freeCCtx(cctx);
 }
 
 
 /*
- * Free the worker's cached context at process exit.
+ * Free every cached context in the worker's slot ring at process exit.
  *
  * Without this the cache is a live allocation at shutdown, which LeakSanitizer
  * and Valgrind both report -- this tree gates on both, so a "harmless" one-off
@@ -2973,12 +3039,16 @@ ngx_http_zstd_release_cctx(void *data)
 static void
 ngx_http_zstd_exit_process(ngx_cycle_t *cycle)
 {
-    if (ngx_http_zstd_worker_cctx != NULL) {
-        ZSTD_freeCCtx(ngx_http_zstd_worker_cctx);
-        ngx_http_zstd_worker_cctx = NULL;
-    }
+    ngx_uint_t  i;
 
-    ngx_http_zstd_worker_cctx_busy = 0;
+    for (i = 0; i < NGX_HTTP_ZSTD_CCTX_SLOTS; i++) {
+        if (ngx_http_zstd_worker_cctx_slots[i].cctx != NULL) {
+            ZSTD_freeCCtx(ngx_http_zstd_worker_cctx_slots[i].cctx);
+            ngx_http_zstd_worker_cctx_slots[i].cctx = NULL;
+        }
+
+        ngx_http_zstd_worker_cctx_slots[i].busy = 0;
+    }
 }
 
 

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -438,6 +438,17 @@ static ngx_int_t ngx_http_zstd_filter_emit_dcz_header(ngx_http_request_t *r,
  * effectiveness past NGX_HTTP_ZSTD_CCTX_SLOTS profiles depends on startup
  * traffic order. A profile that finds no slot is served correctly on the
  * per-request path, the pre-existing safe behaviour.
+ *
+ * "Per-profile" bounds what a slot may SERVE, not how many slots a profile
+ * may occupy. The search skips a busy slot before comparing its profile, so
+ * a request arriving while a matching slot is on loan seeds a further slot
+ * with that same profile. That is not an accident -- it is what makes the
+ * ring help under concurrency at all, since overlapping requests on one
+ * location would otherwise still serialise onto a single slot. The memory
+ * bound is unaffected: the ring retains at most NGX_HTTP_ZSTD_CCTX_SLOTS
+ * workspaces whatever the mix, and duplicates of one profile are all at that
+ * profile's config-vetted figure. Do not read the ring as one slot per
+ * configured profile when budgeting worker RSS -- read it as the constant.
  */
 #ifndef NGX_HTTP_ZSTD_CCTX_SLOTS
 #define NGX_HTTP_ZSTD_CCTX_SLOTS  4

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -429,6 +429,15 @@ static ngx_int_t ngx_http_zstd_filter_emit_dcz_header(ngx_http_request_t *r,
  * workspaces per worker, each at its own profile's vetted figure. It is a
  * compile-time constant rather than a directive so the bound is auditable
  * from the source and cannot be raised by configuration.
+ *
+ * Seeding is first-fit with no eviction, so with MORE distinct profiles than
+ * slots the ring is filled in arrival order and then frozen for the worker's
+ * life: the first profiles seen win, even if a later one turns out busier.
+ * That is deliberate -- never re-parameterising a slot is what keeps each
+ * slot's high-water mark at its own vetted figure -- but it does mean cache
+ * effectiveness past NGX_HTTP_ZSTD_CCTX_SLOTS profiles depends on startup
+ * traffic order. A profile that finds no slot is served correctly on the
+ * per-request path, the pre-existing safe behaviour.
  */
 #ifndef NGX_HTTP_ZSTD_CCTX_SLOTS
 #define NGX_HTTP_ZSTD_CCTX_SLOTS  4
@@ -3032,9 +3041,17 @@ ngx_http_zstd_release_cctx(void *data)
  *
  * Without this the cache is a live allocation at shutdown, which LeakSanitizer
  * and Valgrind both report -- this tree gates on both, so a "harmless" one-off
- * worker-lifetime leak would be a red CI job, not a footnote. Any request still
- * holding a loan has already had its pool destroyed by the time module exit
- * handlers run, so the context is unowned here.
+ * worker-lifetime leak would be a red CI job, not a footnote.
+ *
+ * A slot may still be BUSY here: ngx_worker_process_exit() runs every module's
+ * exit_process before it touches connections, and on the terminate path it
+ * runs straight out of the event loop with requests in flight -- their pools
+ * are not destroyed first, and on that path never are. Freeing a lent context
+ * is nonetheless unobservable, and that, not "the borrower is already gone",
+ * is why it is safe: the process exit()s immediately after these handlers, so
+ * no borrower's pool cleanup -- hence no ngx_http_zstd_release_cctx() -- ever
+ * runs again on the freed pointer. Anything that reintroduced an event-loop
+ * turn after this point would invalidate that reasoning, not merely slow it.
  */
 static void
 ngx_http_zstd_exit_process(ngx_cycle_t *cycle)


### PR DESCRIPTION
> Grind row G3(a). The two reset rows (`release_cctx`'s `ZSTD_reset_session_only`, and skipping the reset for a freshly created context) are G3(b) and deliberately untouched here.

## TL;DR

Squeezing a response costs a scratch workspace, and building one is a big chunk of the work. So each worker kept one around to reuse. One turned out to be too few: if a second response was already using it, the next one had to build its own from scratch, and different site sections need differently-sized workspaces, so two sections would take turns evicting each other and neither ever got a reuse. Keeping four instead of one fixes both, and the throughput measurement says it was worth doing.

Replaces the single worker-lifetime `ZSTD_CCtx` cache with a four-slot ring, each slot carrying its own `{cctx, level, long_mode, window_log, busy}`.

**Severity:** `Low` (`performance — avoidable per-response CCtx construction`)

## Why one slot was the wrong number

Two separate losses, one data structure fixes both, which is why they are one PR.

**Concurrency.** The loan is held for the full lifetime of one compression — `busy` is set in `acquire_cctx` and cleared only by the request pool's cleanup handler. With one slot, the second overlapping request on a worker *always* fell through to `ZSTD_createCCtx()`. Reuse therefore decayed toward 1/N as concurrency rose, which the witness table below shows landing at 0.8% by 128 connections.

**Per-profile.** The cache key is the complete set of parameters that drive the retained workspace — `zstd_comp_level`, `zstd_long`, `zstd_window_log` — because `ZSTD_sizeof_CCtx()` never shrinks on reset and the three of them move it by more than 30x (4.4 MB at `zstd_window_log 20`, 137 MB at 27, 154 MB with `zstd_long on`). That key is right and stays. What was wrong was having one slot to hang it on: two locations differing only in `zstd_window_log` meant whichever seeded the cache first served its own traffic and the other took the per-request path forever.

A slot is never re-parameterised, so the invariant survives intact — each slot's high-water mark stays at the figure `zstd_max_cctx_memory` already vetted for that profile at config load.

## Sizing — measured, not guessed

`ci/tools/ab_bench.py`, 3 interleaved rounds, paced chunked upstream with `proxy_buffering off`, single worker. The debug and release passes are separate runs and are not conflated.

Reuse hit rate (debug pass):

| slots | 8 conn | 32 conn | 128 conn |
|---|---|---|---|
| 1 (today) | 12.3% | 3.1% | 0.8% |
| 2 | 24.7% | 6.2% | 1.9% |
| 4 | 49.3% | 12.7% | 3.3% |
| 8 | 98.6% | 25.4% | 7.3% |

Release pass, rps delta vs 1 slot, and peak worker RSS:

| | 8c/8kb | 8c/64kb | 32c/8kb | 32c/64kb | 128c/8kb | 128c/64kb | peak RSS |
|---|---|---|---|---|---|---|---|
| 4 slots | **+70.6%** | +12.1% | +5.1% | +1.2% | +1.1% | -0.3% | ~33 MB |
| 8 slots | **+59.3%** | +14.4% | +3.9% | +1.2% | +1.9% | +0.7% | ~41.8 MB |

Four is the knee. Eight buys ~9 MB more retained memory per worker and no throughput — its extra hit rate all lands at 8 connections, where four already saturates. The 8-conn/8 KB cells for 4 and 8 slots are the same win within round-to-round variance; the RSS difference is not.

Note where the win *isn't*: at 128 connections it is ~1%, and on 64 KB bodies above 8 connections it is nothing, because compression itself dominates. No blanket speedup is claimed.

## Negative controls

Both observed red at ring size 1, built with `-DNGX_HTTP_ZSTD_CCTX_SLOTS=1`. The slot array symbol size confirms each arm is distinct (`readelf -sW` reports 40 bytes per slot: 40/80/160/320 for 1/2/4/8).

`test_cctx_reuse.py` — each differing-profile location is now requested `ALT_ROUNDS` times instead of once. That change is what makes per-profile reuse observable at all: with a single request each, a ring and the old cache emit identical witness counts and the test could not tell them apart.

* 4 slots: `4 cctx created, 20 reused` — passes.
* 1 slot: `13 created / 11 reused`, both assertions fail. All 12 `/alt` requests take the per-request path.

`test_concurrent_cctx_isolation.py` — new `--require-multi-slot` asserts from the debug witnesses that more than one distinct slot was actually lent. Without it, the byte-exactness oracle is satisfied by a build where every concurrent claimant falls through to a per-request context, which is exactly what the single slot did.

* 4 slots: `96 concurrent requests ... each decoded byte-exact to its own origin; 2 distinct ring slots lent concurrently` — passes.
* 1 slot: fails with `only 1 distinct ring slot(s) were ever lent (['0'])`.

This is the first time that test has exercised concurrent slot borrowing, which is the risk surface the ring introduces. It is wired into the non-sanitized job only — UBSAN traps nginx core's own debug logging, which is why the sanitizer jobs already run `test_cctx_reuse.py` at `--log-level warn`.

## Testing

Local, against the default 4-slot build (no `-D` override; `readelf` confirms a 160-byte slot array):

* `ci/t/00-filter.t` — 1155/1155 pass.
* `test_encoding`, `test_compression_matrix`, `test_sub_filter_cctx_reset`, `test_window_cap`, `test_zstd_long_ldm`, `test_dcz` — all pass.
* `test_cctx_reuse.py` and `test_concurrent_cctx_isolation.py --require-multi-slot` — pass.
* `review-lint.sh --branch master` — no finding on any changed line; the `nginx-unchecked-palloc` candidates are pre-existing lines this diff does not touch. No coverage gap reported.
* Builds clean under `-Werror`.

Not run locally: Valgrind and the sanitizer jobs. `exit_process` now frees every slot rather than one, so LSan is the check that matters there and it runs in CI.

## One thing the audit corrected

The old `exit_process` comment claimed a borrower's pool is already destroyed by the time module exit handlers run. That is backwards. `ngx_worker_process_exit()` calls `exit_process` *before* it touches connections, and on the terminate path the borrower's pool is never destroyed at all — so a slot genuinely can still be busy here. Freeing it is still safe, but for a different reason: the process `exit()`s immediately after, so no `release_cctx` ever runs on the freed pointer. The comment now says that, because the false version is exactly what a future edit reintroducing an event-loop turn would have relied on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved compression performance by reusing up to four compression workspaces for different settings across requests.
  * Enhanced concurrent request handling to maintain response isolation while sharing compression resources safely.
  * Preserved memory limits for each compression configuration and released resources when workers exit.

* **Documentation**
  * Added documentation describing compression-context memory retention and workspace reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->