### PR TITLE
fix(ab_bench): escape the literal percent in --comp-level help

### DIFF
--- a/ci/tools/ab_bench.py
+++ b/ci/tools/ab_bench.py
@@ -1204,7 +1204,7 @@ def main() -> int:
         type=int,
         default=6,
         help="zstd_comp_level pinned in the generated config for both "
-        "arms (default 6, matches the existing +79% measurement). "
+        "arms (default 6, matches the existing +79%% measurement). "
         "Pinned explicitly rather than left at each binary's compiled-in "
         "default so an A/B between two different binaries never mixes a "
         "level change into the change actually under measurement.",


### PR DESCRIPTION
`argparse` %-formats every help string it prints, so the literal `+79%` in the `--comp-level` help text aborted `--help` with

```
ValueError: unsupported format character 'm' (0x6d) at index 99
```

before printing a single line. Every flag of the A/B harness was undiscoverable from the CLI — you had to read the source to find them.

Escaped to `%%`, which argparse renders as one `%`.

## Verification

- `ab_bench.py --help` now renders all 145 lines; the text reads `+79%`, not `+79%%`.
- `ab_bench.py --self-test` still passes, so `evaluate_contention_self_check()` — the oracle's own negative control — is unaffected.
- Lint pre-pass `--branch master`: no coverage gap; the only semgrep hits are the pre-existing deliberate `0o755` scratch-root perms from #151 (0700 makes privilege-dropped workers 403 everything), untouched here.

Found while running the harness for the G3(a) CCtx-ring sizing measurement.