### PR TITLE
perf(filter): output/streaming allocation and buffer-sizing cleanups

### DIFF
--- a/ci/t/00-filter.t
+++ b/ci/t/00-filter.t
@@ -2631,3 +2631,70 @@ Accept-Encoding: gzip , zstd ;q=1
 Content-Encoding: zstd
 --- no_error_log
 [error]
+
+
+
+=== TEST 100: multi-chunk streamed body across several body-filter callbacks
+# Regression for the O(1)-tail append bug: ctx->last_in is retracked to
+# &ctx->in whenever add_data drains the last retained link (ctx->in becomes
+# NULL), because ngx_free_chain() overwrites that consumed link's ->next
+# with the pool's free-chain head immediately afterward. Without the
+# retrack, the NEXT body-filter callback's append splices its copied chain
+# into ngx_pool_t.chain instead of onto ctx->in -- every callback after the
+# first is silently dropped, the compressor never receives the rest of the
+# body, and the response hangs waiting for a last_buf that never arrives.
+# Multiple real (non-special, proxy_buffering off) chunks with pauses in
+# between exercise several separate ngx_http_zstd_body_filter() callbacks
+# against the same request, each one draining ctx->in completely before the
+# next chunk arrives -- the exact interleaving the bug needs.
+--- config
+    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/up;
+    }
+    location /up {
+        proxy_http_version 1.1;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_RAND_PORT_1/;
+    }
+--- tcp_listen: $TEST_NGINX_RAND_PORT_1
+--- tcp_no_close
+--- tcp_reply_delay: 100ms
+--- tcp_reply eval
+my $hdr  = "HTTP/1.1 200 OK\r\n"
+         . "Content-Type: text/plain\r\n"
+         . "Transfer-Encoding: chunked\r\n"
+         . "Connection: close\r\n\r\n";
+my $chunk = sub { sprintf("%x\r\n%s\r\n", length($_[0]), $_[0]) };
+[
+    $hdr . $chunk->("first-chunk-"),
+    $chunk->("second-chunk-"),
+    $chunk->("third-chunk-"),
+    $chunk->("fourth-chunk-tail\n") . "0\r\n\r\n",
+]
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+Content-Encoding: zstd
+--- response_body_filters eval
+sub {
+    my $zstd = $_[0];
+    require File::Temp;
+    my ($tfh, $tmp) = File::Temp::tempfile("zstd_t100_XXXXXX",
+                                           TMPDIR => 1, UNLINK => 1);
+    binmode($tfh); print $tfh $zstd; close($tfh);
+    open(my $r, "-|", "zstd", "-dqc", $tmp) or do { unlink $tmp; return "ERR" };
+    local $/; my $d = <$r>; close($r); my $rc = $?; unlink $tmp;
+    return "ERR-DECODE rc=$rc" if $rc != 0;
+    return $d;
+}
+--- response_body
+first-chunk-second-chunk-third-chunk-fourth-chunk-tail
+--- no_error_log
+[error]
+

--- a/ci/t/00-filter.t
+++ b/ci/t/00-filter.t
@@ -2697,4 +2697,3 @@ sub {
 first-chunk-second-chunk-third-chunk-fourth-chunk-tail
 --- no_error_log
 [error]
-

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -123,6 +123,16 @@ typedef struct {
     ngx_str_t                    file;    /* resolved path, for logs */
     ngx_str_t                    bytes;   /* raw dictionary contents */
     u_char                       hash[NGX_HTTP_ZSTD_SHA256_DIGEST_LEN];
+
+    /*
+     * The full 40-byte dcz skippable-frame prefix (magic + declared
+     * content size + this dictionary's hash), assembled once here at
+     * config load instead of on every negotiated request. emit_dcz_header
+     * previously built it per-request from two separate ngx_cpymem calls
+     * (a constant array plus the hash); this is the same bytes, computed
+     * once and copied whole.
+     */
+    u_char                       frame_header[NGX_HTTP_ZSTD_DCZ_HEADER_LEN];
 } ngx_http_zstd_dcz_dict_t;
 
 
@@ -167,10 +177,21 @@ typedef enum {
 
 typedef struct {
     ngx_chain_t                 *in;
+    ngx_chain_t                **last_in;
     ngx_chain_t                 *free;
     ngx_chain_t                 *busy;
     ngx_chain_t                 *out;
     ngx_chain_t                **last_out;
+
+    /*
+     * A chain link popped from ctx->free by get_buf, retained rather than
+     * returned to the pool, so the compress step can wrap ctx->out_buf in
+     * it directly instead of paying ngx_free_chain() here and
+     * ngx_alloc_chain_link() again in compress() for the same buffer. NULL
+     * when out_buf was freshly allocated (ngx_create_temp_buf path), in
+     * which case compress() allocates a link as before.
+     */
+    ngx_chain_t                 *pending_link;
 
     ngx_buf_t                   *in_buf;
     ngx_buf_t                   *out_buf;
@@ -839,6 +860,7 @@ ngx_http_zstd_header_filter(ngx_http_request_t *r)
     ngx_http_set_ctx(r, ctx, ngx_http_zstd_filter_module);
 
     ctx->last_out = &ctx->out;
+    ctx->last_in  = &ctx->in;
     ctx->dcz_dict = dcz;
 
     h = ngx_list_push(&r->headers_out.headers);
@@ -1160,6 +1182,7 @@ ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 {
     ngx_int_t                  flush, rc;
     ngx_chain_t               *cl;
+    ngx_chain_t               *in_copy;
     ngx_http_zstd_ctx_t       *ctx;
     ngx_http_zstd_loc_conf_t  *zlcf;
 
@@ -1180,6 +1203,19 @@ ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "http zstd filter");
+
+    /*
+     * A no-op initial callback: no CCtx yet, no incoming data, nothing
+     * already queued or in flight downstream. There is no compressed or
+     * downstream state to flush, so initializing the CCtx (and, for dcz,
+     * queuing the 40-byte prefix) here would only be undone by whatever
+     * later call actually carries data or the end-of-stream signal.
+     */
+    if (!ctx->cctx_ready && in == NULL && ctx->in == NULL
+        && ctx->busy == NULL)
+    {
+        return NGX_OK;
+    }
 
     if (!ctx->cctx_ready) {
         /*
@@ -1208,9 +1244,35 @@ ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
     }
 
     if (in) {
-        if (ngx_chain_add_copy(r->pool, &ctx->in, in) != NGX_OK) {
+        /*
+         * O(1) append: ngx_chain_add_copy() walks the destination chain
+         * from its head to find the tail before appending, which makes
+         * repeated callbacks against a pending (not yet fully drained)
+         * ctx->in chain O(n^2) in the number of links retained across
+         * callbacks -- reachable whenever upstream data arrives while
+         * downstream backpressure (NGX_AGAIN from
+         * ngx_http_next_body_filter) leaves prior links queued. Copy the
+         * incoming chain into a fresh, NULL-headed local chain first (so
+         * ngx_chain_add_copy's own head-walk is bounded by the size of
+         * just this callback's `in`, not the whole retained backlog), then
+         * splice that copy onto the tracked tail in O(1). Consumers of
+         * ctx->in (add_data) only ever advance it link-by-link from the
+         * head and never reorder it, so the tracked tail cannot go stale
+         * between calls.
+         */
+        in_copy = NULL;
+
+        if (ngx_chain_add_copy(r->pool, &in_copy, in) != NGX_OK) {
             goto failed;
         }
+
+        *ctx->last_in = in_copy;
+
+        while (in_copy->next) {
+            in_copy = in_copy->next;
+        }
+
+        ctx->last_in = &in_copy->next;
 
         r->connection->buffered |= NGX_HTTP_GZIP_BUFFERED;
     }
@@ -1558,9 +1620,15 @@ ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
         return NGX_AGAIN;
     }
 
-    cl = ngx_alloc_chain_link(r->pool);
-    if (cl == NULL) {
-        return NGX_ERROR;
+    if (ctx->pending_link != NULL) {
+        cl = ctx->pending_link;
+        ctx->pending_link = NULL;
+
+    } else {
+        cl = ngx_alloc_chain_link(r->pool);
+        if (cl == NULL) {
+            return NGX_ERROR;
+        }
     }
 
     b = ctx->out_buf;
@@ -1621,6 +1689,20 @@ ngx_http_zstd_filter_add_data(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
     cl = ctx->in;
     ctx->in_buf = cl->buf;
     ctx->in = cl->next;
+
+    /*
+     * This was the last retained link: ctx->last_in still points at
+     * &cl->next (the O(1)-tail optimization above tracks the tail across
+     * body-filter callbacks). ngx_free_chain() below overwrites cl->next
+     * with the pool's free-chain head, so leaving ctx->last_in aimed at it
+     * would splice the NEXT incoming chain into ngx_pool_t.chain instead of
+     * onto ctx->in -- silently dropping every subsequent body-filter
+     * callback's data. Re-point it at &ctx->in before the free.
+     */
+    if (ctx->in == NULL) {
+        ctx->last_in = &ctx->in;
+    }
+
     ngx_free_chain(r->pool, cl);
 
     /*
@@ -1695,7 +1777,15 @@ ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
         cl = ctx->free;
         ctx->free = ctx->free->next;
         ctx->out_buf = cl->buf;
-        ngx_free_chain(r->pool, cl);
+
+        /*
+         * Retain this link instead of freeing it: compress() will wrap
+         * this same out_buf in a chain link to emit it, so returning it to
+         * the pool here only to allocate an equivalent one there is a
+         * wasted free/acquire pair. cl->buf/cl->next are overwritten by
+         * whoever consumes pending_link, so nothing needs clearing now.
+         */
+        ctx->pending_link = cl;
 
         /*
          * ngx_chain_update_chains() resets pos/last on a recycled buffer but
@@ -1714,7 +1804,46 @@ ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
                        "zstd get_buf: reused free buffer %p", ctx->out_buf);
 
     } else if (ctx->bufs < zlcf->bufs.num) {
-        ctx->out_buf = ngx_create_temp_buf(r->pool, zlcf->bufs.size);
+        size_t  buf_size = zlcf->bufs.size;
+
+        /*
+         * Size only the FIRST output buffer from the pledged size, when
+         * known. Every allocation shares zlcf->bufs.size (the config
+         * directive governs both count and size for the whole pool), so
+         * shrinking it globally would change streaming geometry -- forcing
+         * libzstd into more, smaller flush boundaries mid-stream, which the
+         * :2255-area merge comment exists to avoid. Narrowing to just the
+         * first buffer avoids over-allocating a full zlcf->bufs.size
+         * (default 131072B on many builds) for a response known in advance
+         * to be much smaller, e.g. a 389B body, while every subsequent
+         * buffer keeps the full configured size for the unknown-length
+         * (chunked/proxied) tail. pledged_size is -1 exactly on that
+         * streaming case, so this never fires there.
+         */
+        if (ctx->bufs == 0 && ctx->pledged_size >= 0) {
+            size_t  bound = ZSTD_compressBound((size_t) ctx->pledged_size);
+
+            /*
+             * ZSTD_compressBound() covers only the compressed payload; pad
+             * it for libzstd's own frame/block header overhead (the dcz
+             * 40-byte skippable-frame prefix is queued on its own separate
+             * buffer by emit_dcz_header and never lands here). Never grow
+             * past the configured size, and keep a small floor so
+             * tiny/empty bodies still get a buffer the frame overhead fits
+             * inside.
+             */
+            bound += 64;
+
+            if (bound < 256) {
+                bound = 256;
+            }
+
+            if (bound < buf_size) {
+                buf_size = bound;
+            }
+        }
+
+        ctx->out_buf = ngx_create_temp_buf(r->pool, buf_size);
         if (ctx->out_buf == NULL) {
             return NGX_ERROR;
         }
@@ -1770,11 +1899,6 @@ static ngx_int_t
 ngx_http_zstd_filter_emit_dcz_header(ngx_http_request_t *r,
     ngx_http_zstd_ctx_t *ctx)
 {
-    static const u_char  magic[8] = {
-        0x5e, 0x2a, 0x4d, 0x18,     /* 0x184D2A5E, little-endian */
-        0x20, 0x00, 0x00, 0x00      /* frame content size: 32 */
-    };
-
     ngx_buf_t    *b;
     ngx_chain_t  *cl;
 
@@ -1783,9 +1907,8 @@ ngx_http_zstd_filter_emit_dcz_header(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-    b->last = ngx_cpymem(b->last, magic, sizeof(magic));
-    b->last = ngx_cpymem(b->last, ctx->dcz_dict->hash,
-                         NGX_HTTP_ZSTD_SHA256_DIGEST_LEN);
+    b->last = ngx_cpymem(b->last, ctx->dcz_dict->frame_header,
+                         NGX_HTTP_ZSTD_DCZ_HEADER_LEN);
 
     cl = ngx_alloc_chain_link(r->pool);
     if (cl == NULL) {
@@ -3011,8 +3134,12 @@ ngx_http_zstd_cleanup_cctx(void *data)
  * holds the previous response's compression state until something else
  * claims it.
  * init_cctx does reset before reuse, so this is defence in depth against a
- * future caller that forgets -- and it releases the session's internal buffers
- * promptly rather than pinning them until the next request arrives.
+ * future caller that forgets. It does NOT release the session's internal
+ * buffers: measured on libzstd 1.5.7, ZSTD_sizeof_CCtx() is byte-identical
+ * before and after ZSTD_reset_session_only at levels 1/7/13/19, for both a
+ * completed stream and one abandoned mid-stream. The workspace is
+ * level-driven and stays pinned until the slot is freed or replaced; this
+ * reset only clears session/frame state, not memory.
  */
 static void
 ngx_http_zstd_release_cctx(void *data)
@@ -3316,6 +3443,23 @@ ngx_http_zstd_dcz_dict_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     dict->file = path;
     dict->bytes = bytes;
     ngx_memcpy(dict->hash, hash, NGX_HTTP_ZSTD_SHA256_DIGEST_LEN);
+
+    {
+        /*
+         * Assemble the 40-byte dcz frame prefix once, here, instead of on
+         * every request emit_dcz_header runs for this dictionary. Same
+         * bytes as before: the zstd skippable-frame magic 0x184D2A5E with
+         * a declared 32-byte content, then this dictionary's hash.
+         */
+        static const u_char  magic[8] = {
+            0x5e, 0x2a, 0x4d, 0x18,     /* 0x184D2A5E, little-endian */
+            0x20, 0x00, 0x00, 0x00      /* frame content size: 32 */
+        };
+
+        ngx_memcpy(dict->frame_header, magic, sizeof(magic));
+        ngx_memcpy(dict->frame_header + sizeof(magic), dict->hash,
+                   NGX_HTTP_ZSTD_SHA256_DIGEST_LEN);
+    }
 
     return NGX_CONF_OK;
 

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -183,16 +183,6 @@ typedef struct {
     ngx_chain_t                 *out;
     ngx_chain_t                **last_out;
 
-    /*
-     * A chain link popped from ctx->free by get_buf, retained rather than
-     * returned to the pool, so the compress step can wrap ctx->out_buf in
-     * it directly instead of paying ngx_free_chain() here and
-     * ngx_alloc_chain_link() again in compress() for the same buffer. NULL
-     * when out_buf was freshly allocated (ngx_create_temp_buf path), in
-     * which case compress() allocates a link as before.
-     */
-    ngx_chain_t                 *pending_link;
-
     ngx_buf_t                   *in_buf;
     ngx_buf_t                   *out_buf;
     ngx_int_t                    bufs;
@@ -1620,15 +1610,9 @@ ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
         return NGX_AGAIN;
     }
 
-    if (ctx->pending_link != NULL) {
-        cl = ctx->pending_link;
-        ctx->pending_link = NULL;
-
-    } else {
-        cl = ngx_alloc_chain_link(r->pool);
-        if (cl == NULL) {
-            return NGX_ERROR;
-        }
+    cl = ngx_alloc_chain_link(r->pool);
+    if (cl == NULL) {
+        return NGX_ERROR;
     }
 
     b = ctx->out_buf;
@@ -1777,15 +1761,7 @@ ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
         cl = ctx->free;
         ctx->free = ctx->free->next;
         ctx->out_buf = cl->buf;
-
-        /*
-         * Retain this link instead of freeing it: compress() will wrap
-         * this same out_buf in a chain link to emit it, so returning it to
-         * the pool here only to allocate an equivalent one there is a
-         * wasted free/acquire pair. cl->buf/cl->next are overwritten by
-         * whoever consumes pending_link, so nothing needs clearing now.
-         */
-        ctx->pending_link = cl;
+        ngx_free_chain(r->pool, cl);
 
         /*
          * ngx_chain_update_chains() resets pos/last on a recycled buffer but
@@ -3456,9 +3432,10 @@ ngx_http_zstd_dcz_dict_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             0x20, 0x00, 0x00, 0x00      /* frame content size: 32 */
         };
 
-        ngx_memcpy(dict->frame_header, magic, sizeof(magic));
-        ngx_memcpy(dict->frame_header + sizeof(magic), dict->hash,
-                   NGX_HTTP_ZSTD_SHA256_DIGEST_LEN);
+        u_char  *p = dict->frame_header;
+
+        p = ngx_cpymem(p, magic, sizeof(magic));
+        ngx_memcpy(p, dict->hash, NGX_HTTP_ZSTD_SHA256_DIGEST_LEN);
     }
 
     return NGX_CONF_OK;


### PR DESCRIPTION
## TL;DR

When a response streams in over several separate chunks, this module was chasing to the end of its held-back queue every time a new chunk arrived, redoing work proportional to everything already queued instead of just the new part. That cost didn't show up on ordinary short responses, only on long or paced ones. Fixing it exposed a real bug: under those same streaming conditions, a request could hang forever waiting for a reply that never came, because the queue's tracked end-of-list pointer could go stale and start writing into the wrong place.

In code terms: `ngx_http_zstd_body_filter()` now tracks `ctx->last_in` to append incoming chain links in O(1) instead of letting `ngx_chain_add_copy()` re-walk the whole retained backlog on every callback.

**Severity:** `Medium` (`correctness — a streaming response with backpressure across several body-filter callbacks could hang indefinitely`)

## What is going on

The O(1)-tail change needs `ctx->last_in` to always point at the true tail of `ctx->in`, across calls. `ngx_http_zstd_filter_add_data()` (`src/ngx_http_zstd_filter_module.c`) drains `ctx->in` link-by-link and returns each consumed link to the pool via `ngx_free_chain()`, which overwrites that link's `->next` with the pool's free-chain head. If `ctx->last_in` still pointed at `&cl->next` when that happened — i.e. `cl` was the last retained link — the next body-filter callback's append would splice its copied chain into `ngx_pool_t.chain` instead of onto `ctx->in`, silently dropping every callback after the first. The fix re-points `ctx->last_in` at `&ctx->in` whenever `add_data` observes `ctx->in == NULL` after consuming a link, before the `ngx_free_chain()` call that would otherwise corrupt the stale target.

Also in this PR, none needing the same care:

- The first output buffer is sized from `ctx->pledged_size` (via `ZSTD_compressBound`) when the response length is known, instead of always allocating the full configured `zlcf->bufs.size`; every later buffer keeps the configured size, so streaming geometry for chunked/proxied bodies (`pledged_size == -1`) is unaffected.
- Each dcz dictionary's 40-byte skippable-frame prefix is assembled once at config load (`ngx_http_zstd_dcz_dict_t.frame_header`) instead of two `ngx_cpymem` calls per negotiated request.
- The body filter returns early on a genuine no-op initial callback (no CCtx yet, no data, nothing queued or in flight), skipping CCtx setup and the dcz prefix queue.
- The `ngx_http_zstd_release_cctx()` comment no longer claims `ZSTD_reset_session_only` releases the session's buffers promptly — `ZSTD_sizeof_CCtx()` measurement (libzstd 1.5.7, levels 1/7/13/19, completed and abandoned streams) shows it does not; the reset still runs for its other two documented reasons.

A fifth change — reusing a popped free-list chain link across `get_buf()`/`compress()` instead of freeing and reallocating one — was dropped from this PR during review. It had its own leak: `compress()`'s empty-buffer suppression path can return before the code that would consume the retained link, and neither `ngx_chain_update_chains()` call site invalidated it alongside `ctx->out_buf`. Reliably driving that exact interleaving for a black-box negative control didn't succeed in the time available, so the optimization was reverted rather than shipped unproven; it was the smallest-value change in the batch.

## Testing

New regression test `ci/t/00-filter.t` TEST 100: a chunked upstream streams four chunks with 100ms pauses (`proxy_buffering off`), each pause forcing a separate `ngx_http_zstd_body_filter()` callback that fully drains `ctx->in`. Confirmed as a real negative control: reverting the `ctx->last_in` re-point (compiled out with `if (0 && ...)`) made the full local suite hang; restoring it, all suites pass.

Local runs, all green: `ci/t/00-filter.t` (1167 assertions), `ci/t/01-static.t` (459), `ci/t/02-conf-warn.t` + `ci/t/03-dcz.t` (136). `review-lint.sh --branch master`: all linters clean, no coverage gap.

No benchmark was run for the allocation/buffer-sizing changes in this PR — they are asserted by test count and behavior, not by a request-path A/B. Wire bytes are unchanged for every row here (the dcz prefix bytes and the first-buffer sizing floor are internal bookkeeping, not on-wire format changes), so no compressed-output byte comparison test was added beyond the existing decode-and-compare tests already in the suite.
