### PR TITLE
security: enforce RFC 9842 secure-context before selecting dcz

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1504,7 +1504,8 @@ jobs:
           # dictionary SHA-256), decode via `zstd -d -D` capped at the
           # RFC's 8 MB client-window guarantee, byte-compare to origin,
           # and proof the dictionary engaged (dcz body < plain zstd).
-          python3 ci/tools/test_dcz.py --nginx-binary "$TEST_NGINX_BINARY" --port 18106
+          python3 ci/tools/test_dcz.py --nginx-binary "$TEST_NGINX_BINARY" \
+            --port 18106 --tls-port 18117 --insecure-port 18118
           echo "✓ RFC 9842 dcz end-to-end test passed"
 
       - name: Test summary
@@ -1678,7 +1679,7 @@ jobs:
           # config-pool memory from the request path and the 40-byte
           # frame header is hand-assembled — both lifetime/OOB classes.
           python3 ci/tools/test_dcz.py --nginx-binary "$TEST_NGINX_BINARY" \
-            --port 18089
+            --port 18089 --tls-port 18109 --insecure-port 18113
           # Baseline loaded-and-blocking control (PR2 step 22): the ASAN
           # binary is a static --add-module build, the shape this check
           # needs to prove the compiled-in `zstd on;` default is OFF.
@@ -1920,7 +1921,8 @@ jobs:
             --nginx-binary "$TEST_NGINX_BINARY" --port 19104 --backend-port 19105
           python3 ci/tools/test_zstd_long_ldm.py \
             --nginx-binary "$TEST_NGINX_BINARY" --port 19102 --backend-port 19103
-          python3 ci/tools/test_dcz.py --nginx-binary "$TEST_NGINX_BINARY" --port 19106
+          python3 ci/tools/test_dcz.py --nginx-binary "$TEST_NGINX_BINARY" \
+            --port 19106 --tls-port 19107 --insecure-port 19108
 
       - name: Capture coverage (lcov) and enforce line-coverage floor
         run: |

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,23 @@
 Changes with http-zstd
 
+    *) Security: dcz is now offered only in a secure context, as RFC 9842
+       section 8 requires. The negotiation gate checked the dictionary
+       hash, the main request, the request headers and the coding weight
+       but never consulted transport security, so a matching request over
+       plain HTTP was served as Content-Encoding: dcz. Dictionary
+       compression over cleartext gives a network attacker a length
+       oracle over content the dictionary already describes. Requests on
+       a non-TLS connection now fall back to plain zstd.
+       Deployments that terminate TLS on a proxy in front of nginx see a
+       cleartext connection here and must opt in explicitly with the new
+       zstd_dcz_assume_secure_transport directive. The module never
+       infers the client's scheme from X-Forwarded-Proto or any other
+       request header: those are client-supplied on a directly reachable
+       listener, so trusting one would let any client re-enable dcz over
+       cleartext.
+       Affects only configurations using zstd_dcz_dict_file, which is new
+       in this release, so no released version is affected.
+
     *) Security: the dcz cross-origin gate could be bypassed by a
        duplicate request header. Sec-Fetch-Site and Available-Dictionary
        are not in nginx's known-header table, so nginx chains duplicate

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This is a hardened fork: every push/PR is exercised against **nginx mainline**, 
     * [zstd_bypass_vary](#zstd_bypass_vary)
     * [zstd_dict_file](#zstd_dict_file)
     * [zstd_dcz_dict_file](#zstd_dcz_dict_file)
+    * [zstd_dcz_assume_secure_transport](#zstd_dcz_assume_secure_transport)
   * [ngx_http_zstd_static_module](#ngx_http_zstd_static_module)
     * [zstd_static](#zstd_static)
 * [Variables](#variables)
@@ -810,9 +811,9 @@ http {
 **Default:** `—`
 **Context:** `http`, `server`, `location` (repeatable)
 
-Standards-based dictionary compression per [RFC 9842](https://www.rfc-editor.org/rfc/rfc9842) (Compression Dictionary Transport). Each occurrence loads one dictionary — typically a **previous version of the resource** (delta-style) or a trained dictionary — and registers its SHA-256 as a negotiation key. When a request arrives whose `Available-Dictionary` header matches a loaded dictionary **and** whose `Accept-Encoding` lists `dcz` explicitly with a non-zero weight, the response is compressed against that dictionary and sent as `Content-Encoding: dcz`: a fixed 40-byte header (a zstd skippable frame carrying the dictionary's SHA-256) followed by an ordinary zstd frame. Chrome 130+ negotiates this automatically for same-origin resources. Every gate miss — unknown hash, no explicit `dcz` token (`*` deliberately does not match), `dcz;q=0`, a malformed `Available-Dictionary`, or `Sec-Fetch-Site` other than `same-origin`/`none` — falls back to the plain `zstd` path.
+Standards-based dictionary compression per [RFC 9842](https://www.rfc-editor.org/rfc/rfc9842) (Compression Dictionary Transport). Each occurrence loads one dictionary — typically a **previous version of the resource** (delta-style) or a trained dictionary — and registers its SHA-256 as a negotiation key. When a request arrives whose `Available-Dictionary` header matches a loaded dictionary **and** whose `Accept-Encoding` lists `dcz` explicitly with a non-zero weight, the response is compressed against that dictionary and sent as `Content-Encoding: dcz`: a fixed 40-byte header (a zstd skippable frame carrying the dictionary's SHA-256) followed by an ordinary zstd frame. Chrome 130+ negotiates this automatically for same-origin resources. Every gate miss — a non-secure context ([see below](#zstd_dcz_assume_secure_transport)), unknown hash, no explicit `dcz` token (`*` deliberately does not match), `dcz;q=0`, a malformed `Available-Dictionary`, or `Sec-Fetch-Site` other than `same-origin`/`none` — falls back to the plain `zstd` path.
 
-Unlike `zstd_dict_file`, no opt-in flag is needed: dcz is real HTTP negotiation, and only clients that advertised the dictionary ever receive it.
+Unlike `zstd_dict_file`, no opt-in flag is needed to make dcz *safe*: dcz is real HTTP negotiation, and only clients that advertised the dictionary ever receive it. One flag can still be required by your topology — RFC 9842 §8 restricts dcz to secure contexts, so a deployment where TLS is terminated *in front of* this nginx needs [zstd_dcz_assume_secure_transport](#zstd_dcz_assume_secure_transport). On a listener that terminates TLS itself, nothing extra is needed.
 
 The optional second argument supplies the dictionary's SHA-256 as 64 hex characters, trusted **verbatim** in place of hashing the file at config load — deploy tooling that generates the directive list has usually just computed every hash anyway (for deduplication), and skipping the load-time pass removes the dominant cost of `nginx -t` and reloads at hundreds of registered dictionaries. Only supply hashes for content-hashed immutable assets, from tooling that owns the config: a *stale* supplied hash keeps matching, and every client advertising it (and any shared cache serving them) gets responses compressed against the wrong dictionary. dcz frames carry a **content checksum** (XXH64 of the uncompressed content, verified by browsers' zstd decoders) precisely so this fails as a visible decode error — without it, a same-size stale dictionary decodes *successfully* to wrong bytes. Visible is still broken: the checksum bounds the damage, it does not excuse a stale hash. A self-computed hash of a changed file simply stops matching (safe fallback to plain `zstd`). Malformed values are config-load errors.
 
@@ -840,6 +841,7 @@ Operational notes:
 * **Caching.** Whenever dictionaries are configured, the module emits `Vary: Available-Dictionary` on **both** the dcz and the plain-zstd variants — which encoding a client receives depends on that request header for every client, and a shared cache that failed to key on it could serve an undecodable dcz body to a dictionary-less client. Keep `gzip_vary on` so `Vary: Accept-Encoding` is emitted alongside.
 * **Dictionary lifecycle.** Files are read once at config parse, and hashed only when no hash is supplied (`nginx -t` validates them; empty or > 10 MB files and duplicate dictionary hashes are load errors — supplied hashes are compared as declared, so with computed hashes "duplicate" means identical content). Rotate dictionaries by updating the config and reloading. A location that declares its own `zstd_dcz_dict_file` list replaces the inherited one wholesale. Hashing uses libcrypto's EVP SHA-256 when detected at build time — roughly an order of magnitude faster, which at hundreds of registered dictionaries turns seconds of `nginx -t`/reload time into a blip (`NGX_ZSTD_NO_LIBCRYPTO=1` in the configure environment opts out) — with a portable implementation built in as the fallback.
 * **Window and memory.** dcz frames never declare a window above 8 MB (the RFC's unconditional client guarantee), sized down to dictionary + expected content when smaller. An explicit `zstd_window_log` below that still wins — a dictionary does not void the memory cap. Dictionaries are referenced per request via `ZSTD_CCtx_refPrefix()` (RFC 9842 `type=raw` semantics); the per-request table build over the dictionary costs roughly milliseconds per MB of dictionary, so prefer focused dictionaries (the previous version of one resource) over giant blobs.
+* **Secure context.** RFC 9842 §8 restricts dictionary transport to secure contexts, so dcz is only negotiated over TLS. A plain-HTTP request that would otherwise match falls back to plain `zstd`. Behind a TLS-terminating proxy, see [zstd_dcz_assume_secure_transport](#zstd_dcz_assume_secure_transport).
 * **Cross-origin.** Requests with `Sec-Fetch-Site` other than `same-origin`/`none` fall back to plain zstd rather than attempting RFC 9842's CORS legs. `Dictionary-ID` is not consumed — the hash is a complete key — so omit `id=` from `Use-As-Dictionary` (clients would echo it, but nothing here needs it).
 
 **Troubleshooting:** if `Vary: Available-Dictionary` appears but dcz never negotiates for hashes you know are right, run `nginx -T | grep dcz_dict_file` and check the loaded entries are your dictionary *files* — a deploy-generated list of directives must be pulled in with `include`, not passed to `zstd_dcz_dict_file` itself (which loyally loads the list file as a one-entry dictionary that matches nothing). Also check the error log for a rejected reload: a failed `nginx -t` leaves the previous configuration running.
@@ -852,6 +854,32 @@ curl -s -H 'Accept-Encoding: zstd, dcz' \
      https://example.com/app/app-v42.js \
 | zstd -d -D app-v41.js | diff - app-v42.js && echo "byte-exact"
 ```
+
+---
+
+### zstd_dcz_assume_secure_transport
+
+**Syntax:** `zstd_dcz_assume_secure_transport on | off;`
+**Default:** `zstd_dcz_assume_secure_transport off;`
+**Context:** `http`, `server`, `location`
+
+Asserts that the client-facing hop is TLS even though this nginx sees plaintext, re-enabling [`dcz`](#zstd_dcz_dict_file) negotiation on a non-TLS connection.
+
+[RFC 9842](https://www.rfc-editor.org/rfc/rfc9842) §8 requires compression dictionary transport to be used only in a **secure context**. By default the module enforces that directly: `dcz` is negotiated only when the request arrived on a TLS connection, and a plain-HTTP request that would otherwise match falls back to plain `zstd`. That is the fail-closed direction — dictionary compression over cleartext hands a network attacker a length oracle over content the dictionary already describes.
+
+When TLS is terminated by a load balancer or CDN in front of this nginx, the connection nginx sees *is* plaintext and the check fires even though the client spoke HTTPS. Set this directive on in that deployment:
+
+```nginx
+server {
+    listen 8080;                                # behind a TLS terminator
+
+    zstd on;
+    zstd_dcz_assume_secure_transport on;        # the client hop is HTTPS
+    zstd_dcz_dict_file /var/www/releases/app-v41.js;
+}
+```
+
+The directive is an **operator acknowledgement, not a detection**. The module deliberately does not infer the client's scheme from `X-Forwarded-Proto`, `Forwarded` or any other request header: those are client-supplied on a directly reachable listener, so trusting one would let any client re-enable `dcz` over cleartext simply by sending it. Only enable this on a listener that is genuinely unreachable except through your TLS terminator — if the same listener can be hit directly over HTTP, enabling it puts those clients back in the situation §8 forbids.
 
 ---
 

--- a/ci/t/03-dcz.t
+++ b/ci/t/03-dcz.t
@@ -21,10 +21,25 @@ if (defined $ENV{'TEST_NGINX_BINARY'}) {
 
 add_block_preprocessor(sub {
     my $block = shift;
-    return if !@dynamic_modules;
 
-    my $main_config = join "\n", map { "load_module $_;" } @dynamic_modules;
-    $block->set_value("main_config", $main_config);
+    if (@dynamic_modules) {
+        my $main_config = join "\n", map { "load_module $_;" } @dynamic_modules;
+        $block->set_value("main_config", $main_config);
+    }
+
+    # RFC 9842 section 8 restricts dcz to secure contexts, and this
+    # harness speaks plain HTTP -- Test::Nginx::Socket has no TLS
+    # listener. Every block below therefore runs behind the explicit
+    # "TLS is terminated upstream" acknowledgement, which is exactly the
+    # deployment those tests model. Blocks named "secure-context:" are
+    # the tests OF that gate and are left alone so they see the
+    # compiled-in default (off) or set the flag themselves.
+    return if $block->name =~ /secure-context:/;
+
+    my $http_config = $block->http_config;
+    $http_config = '' if !defined $http_config;
+    $block->set_value("http_config",
+                      "$http_config\nzstd_dcz_assume_secure_transport on;\n");
 });
 
 # The negotiation key is the SHA-256 of the committed dictionary fixture,
@@ -657,6 +672,166 @@ Content-Encoding: zstd
 GET /t
 --- more_headers eval
 "Accept-Encoding: zstd, dcz\nAvailable-Dictionary: :$::dict_b64:\nAvailable-Dictionary: :$::dict_b64:\nSec-Fetch-Site: same-origin"
+--- response_headers
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 27: secure-context: plain HTTP falls back to zstd with no directive
+# RFC 9842 section 8: compression dictionary transport MUST only be used
+# in a secure context. This block is exempt from the suite's
+# assume-secure preprocessor, so it exercises the COMPILED-IN default
+# (zstd_dcz_assume_secure_transport off) with no directive anywhere in
+# the configuration -- a block that opted in explicitly would pass even
+# if the default were wrong. Every other dcz gate here is satisfied: the
+# only reason this is not dcz is the cleartext connection.
+--- config
+    location /t {
+        zstd on;
+        zstd_min_length 16;
+        zstd_dcz_dict_file $TEST_NGINX_PERL_PATH/suite/dcz-dict;
+        default_type text/plain;
+        return 200 "dcz negotiation body: shared-boilerplate compute render\n";
+    }
+--- request
+GET /t
+--- more_headers eval
+"Accept-Encoding: zstd, dcz\nAvailable-Dictionary: :$::dict_b64:\nSec-Fetch-Site: same-origin"
+--- response_headers
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 28: secure-context: explicit off is the same fail-closed answer
+# Pins the directive's off value rather than only its absence, so a
+# future default flip cannot silently make TEST 27 vacuous.
+--- config
+    location /t {
+        zstd on;
+        zstd_min_length 16;
+        zstd_dcz_assume_secure_transport off;
+        zstd_dcz_dict_file $TEST_NGINX_PERL_PATH/suite/dcz-dict;
+        default_type text/plain;
+        return 200 "dcz negotiation body: shared-boilerplate compute render\n";
+    }
+--- request
+GET /t
+--- more_headers eval
+"Accept-Encoding: zstd, dcz\nAvailable-Dictionary: :$::dict_b64:"
+--- response_headers
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 29: secure-context: the acknowledgement re-enables dcz over cleartext
+# The supported TLS-terminating-proxy deployment. Same request as TEST
+# 27, one directive different, opposite outcome -- so the pair isolates
+# the gate rather than some other difference.
+--- config
+    location /t {
+        zstd on;
+        zstd_min_length 16;
+        zstd_dcz_assume_secure_transport on;
+        zstd_dcz_dict_file $TEST_NGINX_PERL_PATH/suite/dcz-dict;
+        default_type text/plain;
+        return 200 "dcz negotiation body: shared-boilerplate compute render\n";
+    }
+--- request
+GET /t
+--- more_headers eval
+"Accept-Encoding: zstd, dcz\nAvailable-Dictionary: :$::dict_b64:\nSec-Fetch-Site: same-origin"
+--- response_headers
+Content-Encoding: dcz
+Vary: Available-Dictionary
+--- no_error_log
+[error]
+
+
+
+=== TEST 30: secure-context: a client-supplied scheme header does not enable dcz
+# X-Forwarded-Proto (and every sibling spelling) is settable by anyone
+# who can reach a cleartext listener. If the module inferred "secure"
+# from one, the gate would be a suggestion. Nothing here is trusted:
+# all four requests stay plain zstd.
+--- config
+    location /t {
+        zstd on;
+        zstd_min_length 16;
+        zstd_dcz_dict_file $TEST_NGINX_PERL_PATH/suite/dcz-dict;
+        default_type text/plain;
+        return 200 "dcz negotiation body: shared-boilerplate compute render\n";
+    }
+--- request eval
+["GET /t", "GET /t", "GET /t", "GET /t"]
+--- more_headers eval
+[
+    "Accept-Encoding: zstd, dcz\nAvailable-Dictionary: :$::dict_b64:\nX-Forwarded-Proto: https",
+    "Accept-Encoding: zstd, dcz\nAvailable-Dictionary: :$::dict_b64:\nForwarded: proto=https",
+    "Accept-Encoding: zstd, dcz\nAvailable-Dictionary: :$::dict_b64:\nX-Forwarded-Ssl: on",
+    "Accept-Encoding: zstd, dcz\nAvailable-Dictionary: :$::dict_b64:\nFront-End-Https: on",
+]
+--- response_headers eval
+[
+    "Content-Encoding: zstd",
+    "Content-Encoding: zstd",
+    "Content-Encoding: zstd",
+    "Content-Encoding: zstd",
+]
+--- no_error_log
+[error]
+
+
+
+=== TEST 31: secure-context: the acknowledgement inherits into locations
+# http/server/location context: set once at server level, every location
+# under it is covered. Pins the merge, which a per-location-only test
+# would leave unproven.
+--- config
+    zstd on;
+    zstd_min_length 16;
+    zstd_dcz_assume_secure_transport on;
+    zstd_dcz_dict_file $TEST_NGINX_PERL_PATH/suite/dcz-dict;
+
+    location /child {
+        default_type text/plain;
+        return 200 "dcz negotiation body: shared-boilerplate compute render\n";
+    }
+--- request
+GET /child
+--- more_headers eval
+"Accept-Encoding: zstd, dcz\nAvailable-Dictionary: :$::dict_b64:"
+--- response_headers
+Content-Encoding: dcz
+--- no_error_log
+[error]
+
+
+
+=== TEST 32: secure-context: a location can opt back out of an inherited on
+# The merge is a real inheritance, not a one-way latch: a location that
+# is reachable directly over cleartext can turn the acknowledgement off
+# again even when the server block set it.
+--- config
+    zstd on;
+    zstd_min_length 16;
+    zstd_dcz_assume_secure_transport on;
+    zstd_dcz_dict_file $TEST_NGINX_PERL_PATH/suite/dcz-dict;
+
+    location /direct {
+        zstd_dcz_assume_secure_transport off;
+        default_type text/plain;
+        return 200 "dcz negotiation body: shared-boilerplate compute render\n";
+    }
+--- request
+GET /direct
+--- more_headers eval
+"Accept-Encoding: zstd, dcz\nAvailable-Dictionary: :$::dict_b64:"
 --- response_headers
 Content-Encoding: zstd
 --- no_error_log

--- a/ci/tools/soak.sh
+++ b/ci/tools/soak.sh
@@ -67,6 +67,15 @@ http {
             zstd on;
             zstd_min_length 100;
             zstd_types text/plain;
+            # RFC 9842 section 8 restricts dcz to secure contexts, and
+            # this soak listener is plain HTTP -- the sanitizer and
+            # valgrind nginx builds it runs against have no
+            # ngx_http_ssl_module, so it cannot be anything else. The
+            # acknowledgement models the supported TLS-terminating-proxy
+            # deployment and keeps the dcz path (negotiation,
+            # ZSTD_CCtx_refPrefix, the 40-byte frame header) under the
+            # sanitizers, which is the whole point of exercising it here.
+            zstd_dcz_assume_secure_transport on;
             zstd_dcz_dict_file $WORK/html/dcz-dict;
             alias $WORK/html/dczbody;
         }

--- a/ci/tools/test_dcz.py
+++ b/ci/tools/test_dcz.py
@@ -18,6 +18,7 @@ import os
 import pathlib
 import shutil
 import socket
+import ssl
 import subprocess
 import sys
 import tempfile
@@ -56,6 +57,26 @@ def parse_args() -> argparse.Namespace:
         type=int,
         default=18106,
         help="Local TCP port for the temporary nginx instance.",
+    )
+    parser.add_argument(
+        "--tls-port",
+        type=int,
+        default=None,
+        help=(
+            "Local TCP port for the native-TLS listener "
+            "(default: --port + 1). RFC 9842 section 8 restricts dcz to "
+            "secure contexts, so the happy path is exercised here."
+        ),
+    )
+    parser.add_argument(
+        "--insecure-port",
+        type=int,
+        default=None,
+        help=(
+            "Local TCP port for a plain-HTTP listener with NO "
+            "zstd_dcz_assume_secure_transport (default: --port + 2). "
+            "Used for the fail-closed secure-context checks."
+        ),
     )
     parser.add_argument(
         "--zstd-bin",
@@ -123,10 +144,54 @@ def build_fixtures(root: pathlib.Path, lines: int) -> tuple[bytes, bytes]:
     return dict_path.read_bytes(), (root / "html" / "app.js").read_bytes()
 
 
-def write_config(root: pathlib.Path, port: int, modules) -> pathlib.Path:
+def make_selfsigned(root: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path]:
+    """Self-signed localhost cert for the native-TLS listener. Generated
+    per run rather than committed: a fixture certificate in-tree expires
+    and turns into a rolling CI failure
+    (feedback-fixed-date-test-ages-into-failure)."""
+    cert = root / "conf" / "test.crt"
+    key = root / "conf" / "test.key"
+    if shutil.which("openssl") is None:
+        # ci/tools/soak.sh already depends on this binary in the same
+        # jobs, so a miss here means the image changed, not that the
+        # test is optional. Say so instead of surfacing FileNotFoundError.
+        raise RuntimeError(
+            "the openssl CLI is required to generate the native-TLS "
+            "listener's certificate (RFC 9842 secure-context checks); "
+            "install the openssl package"
+        )
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-nodes",
+            "-days",
+            "2",
+            "-subj",
+            "/CN=127.0.0.1",
+            "-addext",
+            "subjectAltName=IP:127.0.0.1",
+            "-keyout",
+            str(key),
+            "-out",
+            str(cert),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return cert, key
+
+
+def write_config(
+    root: pathlib.Path, port: int, tls_port: int, insecure_port: int, modules
+) -> pathlib.Path:
     conf_dir = root / "conf"
     conf_dir.mkdir()
     (root / "logs").mkdir()
+    cert, key = make_selfsigned(root)
     load = "".join(f"load_module {m};\n" for m in modules)
     conf = conf_dir / "nginx.conf"
     conf.write_text(
@@ -144,8 +209,32 @@ http {{
     zstd on;
     zstd_min_length 64;
     zstd_dcz_dict_file {root}/dicts/app-v1.js;
+
+    # Cleartext listener modelling "TLS terminated by a proxy in front":
+    # RFC 9842 section 8 forbids dcz outside a secure context, and this
+    # listener carries the explicit operator acknowledgement that the
+    # client-facing hop was HTTPS. Every pre-existing check in this file
+    # runs here.
     server {{
         listen 127.0.0.1:{port};
+        zstd_dcz_assume_secure_transport on;
+        root html;
+    }}
+
+    # Native TLS: the secure context the RFC actually describes, with no
+    # acknowledgement directive at all. Proves the gate passes on
+    # r->connection->ssl rather than only on the opt-in.
+    server {{
+        listen 127.0.0.1:{tls_port} ssl;
+        ssl_certificate {cert};
+        ssl_certificate_key {key};
+        root html;
+    }}
+
+    # Cleartext with NO acknowledgement: the compiled-in default. Nothing
+    # a client can send may negotiate dcz here.
+    server {{
+        listen 127.0.0.1:{insecure_port};
         root html;
     }}
 }}
@@ -156,13 +245,26 @@ http {{
     return conf
 
 
-def fetch(port: int, headers: dict):
+def fetch(port: int, headers: dict, tls: bool = False):
     """Returns (email.message.Message, body). The Message preserves
     repeated header lines — the module legitimately emits two Vary
     lines (Accept-Encoding via gzip_vary, Available-Dictionary its own),
-    and a dict would silently keep only one of them."""
-    request = urllib.request.Request(f"http://127.0.0.1:{port}/app.js", headers=headers)
-    with urllib.request.urlopen(request, timeout=10) as response:
+    and a dict would silently keep only one of them.
+
+    tls=True talks to the native-TLS listener. The certificate is the
+    per-run self-signed one from make_selfsigned(), so verification is
+    switched off deliberately: this asserts the module's view of
+    r->connection->ssl, not PKI."""
+    scheme = "https" if tls else "http"
+    request = urllib.request.Request(
+        f"{scheme}://127.0.0.1:{port}/app.js", headers=headers
+    )
+    context = None
+    if tls:
+        context = ssl.create_default_context()
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+    with urllib.request.urlopen(request, timeout=10, context=context) as response:
         return response.headers, response.read()
 
 
@@ -240,7 +342,9 @@ def main() -> int:
         os.chmod(tmp, 0o755)
         root = pathlib.Path(tmp)
         dict_bytes, resource = build_fixtures(root, args.fixture_lines)
-        conf = write_config(root, args.port, modules)
+        tls_port = args.tls_port if args.tls_port else args.port + 1
+        insecure_port = args.insecure_port if args.insecure_port else args.port + 2
+        conf = write_config(root, args.port, tls_port, insecure_port, modules)
         dict_hash = hashlib.sha256(dict_bytes).digest()
         dict_b64 = base64.b64encode(dict_hash).decode()
         bad_b64 = base64.b64encode(b"\x01" * 32).decode()
@@ -254,6 +358,70 @@ def main() -> int:
             )
         try:
             wait_for_port(args.port, stderr_file=stderr_file)
+            wait_for_port(tls_port, stderr_file=stderr_file)
+            wait_for_port(insecure_port, stderr_file=stderr_file)
+
+            # -- RFC 9842 section 8: dcz is a secure-context-only coding.
+            dcz_headers = {
+                "Accept-Encoding": "zstd, dcz",
+                "Available-Dictionary": f":{dict_b64}:",
+            }
+
+            tls_headers, tls_body = fetch(tls_port, dict(dcz_headers), tls=True)
+            check(
+                "secure context: native TLS negotiates dcz with no opt-in",
+                content_encoding(tls_headers) == "dcz",
+                f"(got {content_encoding(tls_headers)})",
+            )
+            check(
+                "secure context: native-TLS dcz body carries the RFC magic",
+                tls_body[:8] == DCZ_MAGIC and tls_body[8:40] == dict_hash,
+                f"(got {tls_body[:8].hex()})",
+            )
+
+            insecure_headers, insecure_body = fetch(insecure_port, dict(dcz_headers))
+            check(
+                "secure context: plain HTTP falls back to zstd "
+                "(compiled-in default, no directive)",
+                content_encoding(insecure_headers) == "zstd",
+                f"(got {content_encoding(insecure_headers)})",
+            )
+            insecure_src = root / "insecure-fallback.zst"
+            insecure_src.write_bytes(insecure_body)
+            # check=False on purpose: if the gate regresses, this body is
+            # a dcz frame and the dictionary-less decode EXITS NON-ZERO.
+            # With check=True that regression surfaces as a traceback
+            # that skips every remaining assertion instead of as a
+            # readable FAIL line.
+            insecure_decode = subprocess.run(
+                [args.zstd_bin, "-d", "-q", "-c", str(insecure_src)],
+                check=False,
+                capture_output=True,
+            )
+            check(
+                "secure context: the plain-HTTP fallback is still decodable "
+                "without the dictionary",
+                insecure_decode.returncode == 0 and insecure_decode.stdout == resource,
+                f"(rc={insecure_decode.returncode}, "
+                f"{len(insecure_decode.stdout)} bytes)",
+            )
+
+            # An untrusted client-supplied scheme signal must not
+            # re-enable dcz: X-Forwarded-Proto is settable by anyone who
+            # can reach the listener, so the module never consults it.
+            for spoof in (
+                {"X-Forwarded-Proto": "https"},
+                {"Forwarded": "proto=https"},
+                {"X-Forwarded-Ssl": "on"},
+                {"Front-End-Https": "on"},
+            ):
+                spoof_headers, _ = fetch(insecure_port, {**dcz_headers, **spoof})
+                name = next(iter(spoof))
+                check(
+                    f"secure context: spoofed {name} does not enable dcz",
+                    content_encoding(spoof_headers) == "zstd",
+                    f"(got {content_encoding(spoof_headers)})",
+                )
 
             # -- plain zstd client: baseline and cache-key contract
             headers, plain_body = fetch(args.port, {"Accept-Encoding": "zstd"})

--- a/ci/tools/test_dcz.py
+++ b/ci/tools/test_dcz.py
@@ -104,6 +104,22 @@ def detect_module(explicit, nginx: pathlib.Path, name: str):
     return sib if sib.exists() else None
 
 
+def nginx_has_ssl(nginx: pathlib.Path) -> bool:
+    """Whether this binary can parse `listen ... ssl`.
+
+    Same probe shape the sibling tools use for --with-debug
+    (test_concurrent_cctx_isolation.py:206, test_slow_drain.py:233): ask
+    the binary itself via -V rather than inferring from the environment
+    or the job name. The sanitizer and valgrind nginx builds in this
+    repo's CI are configured WITHOUT --with-http_ssl_module, where an
+    `ssl` listen parameter is a config-time emerg that kills the tool
+    before any assertion runs -- including every plain-HTTP check, which
+    needs no TLS at all.
+    """
+    v = subprocess.run([str(nginx), "-V"], capture_output=True, text=True, check=False)
+    return "--with-http_ssl_module" in v.stderr
+
+
 def wait_for_port(port: int, timeout: float = 10.0, stderr_file=None) -> None:
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -186,13 +202,35 @@ def make_selfsigned(root: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path]:
 
 
 def write_config(
-    root: pathlib.Path, port: int, tls_port: int, insecure_port: int, modules
+    root: pathlib.Path,
+    port: int,
+    tls_port: int,
+    insecure_port: int,
+    modules,
+    with_ssl: bool,
 ) -> pathlib.Path:
     conf_dir = root / "conf"
     conf_dir.mkdir()
     (root / "logs").mkdir()
-    cert, key = make_selfsigned(root)
     load = "".join(f"load_module {m};\n" for m in modules)
+
+    # Only emitted for an SSL-capable binary: `listen ... ssl` against an
+    # nginx without ngx_http_ssl_module is [emerg] at config parse, so an
+    # unconditional block would take every non-TLS assertion down with it.
+    tls_server = ""
+    if with_ssl:
+        cert, key = make_selfsigned(root)
+        tls_server = f"""
+    # Native TLS: the secure context the RFC actually describes, with no
+    # acknowledgement directive at all. Proves the gate passes on
+    # r->connection->ssl rather than only on the opt-in.
+    server {{
+        listen 127.0.0.1:{tls_port} ssl;
+        ssl_certificate {cert};
+        ssl_certificate_key {key};
+        root html;
+    }}
+"""
     conf = conf_dir / "nginx.conf"
     conf.write_text(
         f"""{load}
@@ -221,16 +259,7 @@ http {{
         root html;
     }}
 
-    # Native TLS: the secure context the RFC actually describes, with no
-    # acknowledgement directive at all. Proves the gate passes on
-    # r->connection->ssl rather than only on the opt-in.
-    server {{
-        listen 127.0.0.1:{tls_port} ssl;
-        ssl_certificate {cert};
-        ssl_certificate_key {key};
-        root html;
-    }}
-
+{tls_server}
     # Cleartext with NO acknowledgement: the compiled-in default. Nothing
     # a client can send may negotiate dcz here.
     server {{
@@ -344,7 +373,8 @@ def main() -> int:
         dict_bytes, resource = build_fixtures(root, args.fixture_lines)
         tls_port = args.tls_port if args.tls_port else args.port + 1
         insecure_port = args.insecure_port if args.insecure_port else args.port + 2
-        conf = write_config(root, args.port, tls_port, insecure_port, modules)
+        with_ssl = nginx_has_ssl(nginx_path)
+        conf = write_config(root, args.port, tls_port, insecure_port, modules, with_ssl)
         dict_hash = hashlib.sha256(dict_bytes).digest()
         dict_b64 = base64.b64encode(dict_hash).decode()
         bad_b64 = base64.b64encode(b"\x01" * 32).decode()
@@ -358,8 +388,9 @@ def main() -> int:
             )
         try:
             wait_for_port(args.port, stderr_file=stderr_file)
-            wait_for_port(tls_port, stderr_file=stderr_file)
             wait_for_port(insecure_port, stderr_file=stderr_file)
+            if with_ssl:
+                wait_for_port(tls_port, stderr_file=stderr_file)
 
             # -- RFC 9842 section 8: dcz is a secure-context-only coding.
             dcz_headers = {
@@ -367,17 +398,30 @@ def main() -> int:
                 "Available-Dictionary": f":{dict_b64}:",
             }
 
-            tls_headers, tls_body = fetch(tls_port, dict(dcz_headers), tls=True)
-            check(
-                "secure context: native TLS negotiates dcz with no opt-in",
-                content_encoding(tls_headers) == "dcz",
-                f"(got {content_encoding(tls_headers)})",
-            )
-            check(
-                "secure context: native-TLS dcz body carries the RFC magic",
-                tls_body[:8] == DCZ_MAGIC and tls_body[8:40] == dict_hash,
-                f"(got {tls_body[:8].hex()})",
-            )
+            if with_ssl:
+                tls_headers, tls_body = fetch(tls_port, dict(dcz_headers), tls=True)
+                check(
+                    "secure context: native TLS negotiates dcz with no opt-in",
+                    content_encoding(tls_headers) == "dcz",
+                    f"(got {content_encoding(tls_headers)})",
+                )
+                check(
+                    "secure context: native-TLS dcz body carries the RFC magic",
+                    tls_body[:8] == DCZ_MAGIC and tls_body[8:40] == dict_hash,
+                    f"(got {tls_body[:8].hex()})",
+                )
+            else:
+                # Loud and named, not silent: the sanitizer and valgrind
+                # builds have no ngx_http_ssl_module, so the native-TLS
+                # leg cannot run there. Everything below still gates --
+                # the fail-closed default and the spoof cases are the
+                # security-relevant assertions and need no TLS.
+                print(
+                    "  native-TLS checks skipped (nginx -V has no "
+                    "--with-http_ssl_module: this binary cannot parse "
+                    "`listen ... ssl`); cleartext fail-closed and spoof "
+                    "checks below still run"
+                )
 
             insecure_headers, insecure_body = fetch(insecure_port, dict(dcz_headers))
             check(

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -164,6 +164,17 @@ typedef struct {
     ZSTD_CDict                  *dict;
 
     ngx_array_t                 *dcz_dicts;  /* ngx_http_zstd_dcz_dict_t */
+
+    /*
+     * RFC 9842 secure-context escape hatch. dcz is only offered on a
+     * TLS connection (r->connection->ssl != NULL). Behind a
+     * TLS-terminating proxy nginx sees plaintext and that test fails,
+     * so an operator who terminates TLS in front of this nginx sets
+     * zstd_dcz_assume_secure_transport on to assert the hop the client
+     * actually spoke was secure. Never inferred from a request header:
+     * X-Forwarded-Proto is client-settable on a direct connection.
+     */
+    ngx_flag_t                   dcz_assume_secure;
 } ngx_http_zstd_loc_conf_t;
 
 
@@ -603,6 +614,13 @@ static ngx_command_t  ngx_http_zstd_filter_commands[] = {
       offsetof(ngx_http_zstd_main_conf_t, dict_unsafe),
       NULL },
 
+    { ngx_string("zstd_dcz_assume_secure_transport"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_zstd_loc_conf_t, dcz_assume_secure),
+      NULL },
+
     { ngx_string("zstd_dcz_dict_file"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE12,
       ngx_http_zstd_dcz_dict_file,
@@ -959,6 +977,9 @@ ngx_http_zstd_find_request_header(ngx_http_request_t *r, const char *name,
  * to ordinary content negotiation, never to a broken dcz:
  *
  *   - the location has zstd_dcz_dict_file dictionaries;
+ *   - the connection is a secure context (RFC 9842 section 8): TLS at
+ *     this nginx, or zstd_dcz_assume_secure_transport on for a
+ *     TLS-terminating proxy in front;
  *   - the request carries Available-Dictionary, a structured-field byte
  *     sequence (":base64:") decoding to exactly 32 bytes (the SHA-256 of
  *     the client's cached dictionary), and it matches one of ours;
@@ -1046,6 +1067,7 @@ ngx_http_zstd_dcz_negotiate(ngx_http_request_t *r,
     ngx_http_zstd_loc_conf_t *zlcf)
 {
     u_char                     buf[NGX_HTTP_ZSTD_DCZ_DECODE_BUF_LEN];
+    ngx_uint_t                 secure;
     ngx_uint_t                 i, nheaders;
     ngx_table_elt_t           *h, *ae;
     ngx_http_zstd_dcz_dict_t  *dicts;
@@ -1055,6 +1077,44 @@ ngx_http_zstd_dcz_negotiate(ngx_http_request_t *r,
     }
 
     if (r != r->main) {
+        return NULL;
+    }
+
+    /*
+     * RFC 9842 section 8: compression dictionary transport MUST only be
+     * used in a secure context. Dictionary-compressed responses leak
+     * plaintext length information about content the dictionary already
+     * describes, which is exactly the oracle a network attacker on a
+     * cleartext hop wants. Fail closed: plain HTTP falls back to
+     * ordinary zstd.
+     *
+     * r->connection->ssl is NULL when a proxy in front of nginx
+     * terminated TLS. That deployment is supported only by an explicit
+     * operator acknowledgement (zstd_dcz_assume_secure_transport on),
+     * never by trusting a request header: X-Forwarded-Proto and friends
+     * are client-supplied on a directly reachable listener, so
+     * inferring "https" from one would let any client re-enable dcz
+     * over cleartext by asking for it.
+     *
+     * The guard mirrors ngx_connection_t's own condition for the ssl
+     * member (ngx_connection.h: `#if (NGX_SSL || NGX_COMPAT)`), not
+     * NGX_SSL alone: this module is built --with-compat, where the
+     * field exists (and is always NULL) without an SSL-capable nginx.
+     * Testing a narrower macro would compile the read out of exactly
+     * the build the module ships in.
+     */
+#if (NGX_SSL || NGX_COMPAT)
+    secure = (r->connection->ssl != NULL);
+#else
+    secure = 0;
+#endif
+
+    if (!secure && !zlcf->dcz_assume_secure) {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "zstd dcz: skip, not a secure context (RFC 9842 "
+                       "section 8); set "
+                       "\"zstd_dcz_assume_secure_transport on\" if TLS is "
+                       "terminated upstream");
         return NULL;
     }
 
@@ -2404,6 +2464,7 @@ ngx_http_zstd_create_loc_conf(ngx_conf_t *cf)
     conf->max_cctx_memory = NGX_CONF_UNSET;
     conf->bypass = NGX_CONF_UNSET_PTR;
     conf->dcz_dicts = NGX_CONF_UNSET_PTR;
+    conf->dcz_assume_secure = NGX_CONF_UNSET;
 
     return conf;
 }
@@ -2452,6 +2513,7 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     /* a location that declares its own zstd_dcz_dict_file list replaces the
      * inherited one wholesale (standard nginx array-directive semantics) */
     ngx_conf_merge_ptr_value(conf->dcz_dicts, prev->dcz_dicts, NULL);
+    ngx_conf_merge_value(conf->dcz_assume_secure, prev->dcz_assume_secure, 0);
 
     /*
      * zstd_bypass_vary only makes sense alongside a zstd_bypass predicate: it


### PR DESCRIPTION
> Found during the G5 audit sweep of `ngx_http_zstd_dcz_negotiate()`. Independent of the other dcz work in flight; this touches only the negotiation precondition, not the framing or the dictionary lifecycle.

## TL;DR

When a browser has already downloaded an older copy of a file, this module can send just the *differences* against that old copy instead of the whole thing — much less data over the wire. The catch is that squeezing a page down against something the reader already has makes the resulting size a clue about what the page says. On an encrypted connection nobody can measure that size, so the trick is safe. We were doing it on unencrypted connections too, where anyone on the network path can measure it — and the standard that defines the feature explicitly forbids that.

`ngx_http_zstd_dcz_negotiate()` now requires `r->connection->ssl != NULL` before selecting the `dcz` coding, and falls back to plain zstd otherwise. A new `zstd_dcz_assume_secure_transport` flag re-enables it for deployments that terminate TLS on a proxy in front of nginx.

**Severity:** `Medium` (`protocol violation — RFC 9842 §8 secure-context requirement unenforced; length side-channel on a cleartext hop`)

## What was wrong

The gate checked five things — dictionaries configured, main request, a single well-formed `Available-Dictionary`, a single acceptable `Sec-Fetch-Site`, an explicit `dcz` with `q>0` — and never looked at the connection. `grep -n 'r->connection->ssl' src/*.c` returned nothing: the module had no notion of transport security anywhere. A request meeting the other five conditions over plain HTTP was served `Content-Encoding: dcz`.

[RFC 9842 §8](https://www.rfc-editor.org/rfc/rfc9842#section-8) requires compression dictionary transport to be used only in a secure context. The reason is the usual compression-side-channel shape: the dictionary describes content the attacker may partly control or guess, and the compressed length leaks how well the response matched it. TLS removes the observer; cleartext hands them the oracle.

## The gate

```c
#if (NGX_SSL || NGX_COMPAT)
    secure = (r->connection->ssl != NULL);
#else
    secure = 0;
#endif

    if (!secure && !zlcf->dcz_assume_secure) {
        /* debug log */
        return NULL;
    }
```

Two details worth checking in review:

* **The preprocessor condition mirrors the field's own**, `#if (NGX_SSL || NGX_COMPAT)` in `src/core/ngx_connection.h:159`, rather than `NGX_SSL` alone. This module ships `--with-compat`, where `ssl` exists (and is permanently NULL) without an SSL-capable nginx; testing the narrower macro would compile the read out of exactly the build we ship.
* **HTTP/2 and HTTP/3 are both covered.** h2 shares the connection. For h3, `ngx_event_quic_streams.c:751` does `sc->ssl = c->ssl;`, so a QUIC stream connection inherits a non-NULL pointer. No `>= NGX_HTTP_VERSION_20`-style version test is involved, so there is no h3-shaped hole.

## The opt-in, and why it is not a header sniff

A TLS-terminating proxy leaves `r->connection->ssl` NULL at nginx, so the honest gate breaks that deployment. `zstd_dcz_assume_secure_transport on;` (http/server/location, default off) restores it.

It is an **operator acknowledgement, not a detection**. The module reads no `X-Forwarded-Proto`, no `Forwarded`, no sibling spelling. Those are client-supplied on any listener a client can reach directly, so inferring "secure" from one would reduce the gate to a request for good manners — a client wanting dcz over cleartext would just send the header. Trusting them correctly would mean a configured trust boundary and a proxy-IP parser; the acknowledgement is the cheaper honest contract, and it fails closed when the operator does nothing.

Documented in `README.md` with the deployment caveat that it must only go on a listener genuinely unreachable except through the terminator.

## Testing

Local, against nginx 1.31.4 built `--with-http_ssl_module`:

| Evidence | Result |
|---|---|
| Plain HTTP, all other gates satisfied | `Content-Encoding: zstd`, decodes without a dictionary |
| Native HTTPS, **no directive at all** | `Content-Encoding: dcz`, RFC magic + dictionary SHA-256 in the frame header |
| `zstd_dcz_assume_secure_transport on` over plain HTTP | `Content-Encoding: dcz` |
| `X-Forwarded-Proto: https` (plus `Forwarded`, `X-Forwarded-Ssl`, `Front-End-Https`), opt-in off | `Content-Encoding: zstd` on all four |

`prove ci/t/00-filter.t ci/t/02-conf-warn.t ci/t/03-dcz.t` — 1331 tests, PASS. `test_dcz.py` — 26 checks, OK.

**Negative control, observed:** replacing the guard with `if (0 && (secure || zlcf->dcz_assume_secure))`, rebuilding (`ngx_http_zstd_filter_module.so` 152160 bytes at 05:49:01, down from 152520), and re-running gives:

```
Failed 7/114 subtests
Result: FAIL
```
```
FAIL - secure context: plain HTTP falls back to zstd (compiled-in default, no directive) (got dcz)
FAIL - secure context: the plain-HTTP fallback is still decodable without the dictionary (rc=1, 0 bytes)
FAIL - secure context: spoofed X-Forwarded-Proto does not enable dcz (got dcz)
FAIL - secure context: spoofed Forwarded does not enable dcz (got dcz)
FAIL - secure context: spoofed X-Forwarded-Ssl does not enable dcz (got dcz)
FAIL - secure context: spoofed Front-End-Https does not enable dcz (got dcz)
```

Restoring the guard returns both suites to green. Separately, flipping TEST 29's own `zstd_dcz_assume_secure_transport on;` to `off` fails that one test alone — so the opt-in cases depend on their own directive rather than on the harness default described below.

Full linter roster clean (`review-lint.sh --diff HEAD` plus all 12 `ci/linter/lint-*.sh`).

## The existing tests were asserting the bug — stated plainly

`ci/t/03-dcz.t` had 26 blocks negotiating dcz over plain HTTP, because `Test::Nginx::Socket` has no TLS client. Those tests were pinning the behaviour this PR removes.

They are fixed rather than deleted: the block preprocessor injects `zstd_dcz_assume_secure_transport on;` at http level for every block except those named `secure-context:`. That is not a workaround for the gate — it is precisely the TLS-terminating-proxy deployment, which is a supported configuration, so the 26 blocks keep testing the gates they were written for. The exemption is what lets the new tests see the real compiled-in default.

Six new TAP blocks (TESTs 27–32): the default with no directive anywhere, an explicit `off`, the acknowledgement re-enabling dcz, the four spoofed scheme headers, inheritance into a location, and a location opting back out of an inherited `on`.

The native-TLS half cannot live in the TAP suite, so `ci/tools/test_dcz.py` now runs three listeners: cleartext with the acknowledgement (all pre-existing checks), native TLS with no directive (the gate must pass on `connection->ssl` alone), and cleartext with nothing set (fail-closed plus the spoofs). Its certificate is generated per run rather than committed, so it cannot age into a rolling failure.

## One thing to look at

The three workflow call sites now pass `--tls-port`/`--insecure-port` explicitly rather than relying on the `+1`/`+2` defaults. One of them genuinely needed it: in `tests-asan`, `--port 18089` would have derived 18090 and 18091, both already taken by the two `test_encoding.py` runs in the same job. The other two happened to be free, but pinning all three keeps the allocation readable instead of leaving it to arithmetic that a later port change could quietly invalidate.

Post-change, no port is used twice within any of the three runtime jobs (`tests`, `tests-asan`, `coverage`). `ci/linter/lint-ci-ports.sh` checks band separation between jobs, not collisions among a single job's tool ports, so that part was verified by hand and is worth a second look.

## Deferred

`ci/tools/test_dcz.py::main()` is up to 265 NLOC / CCN 17 and lizard warns on it. Splitting it into per-listener check functions is a mechanical refactor with no behaviour change; filed to the project TODO rather than mixed into a security fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure-transport enforcement for `dcz` dictionary compression.
  * Added the `zstd_dcz_assume_secure_transport` configuration option for deployments with upstream TLS termination.
* **Bug Fixes**
  * Plain HTTP requests now safely fall back to standard `zstd` compression.
  * Client-supplied scheme headers can no longer bypass secure-transport checks.
* **Documentation**
  * Updated configuration guidance and examples for secure `dcz` usage.
* **Tests**
  * Expanded coverage for TLS, fallback behavior, inheritance, and configuration overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->