### PR TITLE
security: validate skippable .zst frames beyond the four-byte magic

### DIFF
--- a/ci/t/01-static.t
+++ b/ci/t/01-static.t
@@ -953,3 +953,227 @@ Content-Range: bytes 0-3/12
 pack("C*", 0x28, 0xB5, 0x2F, 0xFD)
 --- no_error_log
 [error]
+
+
+
+=== TEST 38: a 4-byte skippable-magic-only file is declined (truncated skip header)
+# sec/g5-static-skippable-frame: ngx_http_zstd_static_probe_frame() must
+# see the 4-byte Frame_Size field before it can trust a skippable frame
+# at all. A file that is only the magic cannot supply it, so this must
+# fail closed exactly like any other truncated header — decline, fall
+# back to serving the uncompressed original.
+--- config
+    location /skip/ {
+        zstd_static on;
+        root html;
+    }
+--- user_files eval
+">>> skip/magiconly.js\nmagic only origin\n>>> skip/magiconly.js.zst\n"
+. pack("C*", 0x50, 0x2A, 0x4D, 0x18)
+--- request
+GET /skip/magiconly.js
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+! Content-Encoding
+--- response_body
+magic only origin
+--- error_code: 200
+--- error_log
+frame header truncated
+
+
+
+=== TEST 39: a 7-byte skippable header (Frame_Size one byte short) is declined
+--- config
+    location /skip/ {
+        zstd_static on;
+        root html;
+    }
+--- user_files eval
+">>> skip/seven.js\nseven byte origin\n>>> skip/seven.js.zst\n"
+. pack("C*", 0x50, 0x2A, 0x4D, 0x18, 0x00, 0x00, 0x00)
+--- request
+GET /skip/seven.js
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+! Content-Encoding
+--- response_body
+seven byte origin
+--- error_code: 200
+--- error_log
+frame header truncated
+
+
+
+=== TEST 40: an exact 8-byte skippable header with nothing after it is declined
+# A zero-length-payload skippable header parses fine (Frame_Size = 0)
+# and passes the bounds check (8 header bytes exactly fill of.size), so
+# the walk advances to offset 8 and probes again — there is nothing
+# left to read there, so the follow-up pread(2) returns 0 and the
+# handler declines exactly as it does for any other pread short-read,
+# rather than reading past EOF looking for a frame that isn't there.
+--- config
+    location /skip/ {
+        zstd_static on;
+        root html;
+    }
+--- user_files eval
+">>> skip/eightonly.js\neight byte origin\n>>> skip/eightonly.js.zst\n"
+. pack("C*", 0x50, 0x2A, 0x4D, 0x18, 0x00, 0x00, 0x00, 0x00)
+--- request
+GET /skip/eightonly.js
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+! Content-Encoding
+--- response_body
+eight byte origin
+--- error_code: 200
+--- error_log
+pread
+
+
+
+=== TEST 41: a skippable Frame_Size that overflows 32-bit arithmetic is declined
+# Frame_Size 0xFFFFFFFF (4294967295) must not be added to the 8-byte
+# header offset with plain 32-bit/size_t arithmetic on a narrow
+# platform — the handler does the bounds check in 64-bit so this fails
+# closed instead of wrapping into a small, in-bounds offset.
+--- config
+    location /skip/ {
+        zstd_static on;
+        root html;
+    }
+--- user_files eval
+">>> skip/overflow.js\noverflow origin\n>>> skip/overflow.js.zst\n"
+. pack("C*", 0x50, 0x2A, 0x4D, 0x18, 0xFF, 0xFF, 0xFF, 0xFF)
+--- request
+GET /skip/overflow.js
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+! Content-Encoding
+--- response_body
+overflow origin
+--- error_code: 200
+--- error_log
+skippable frame declares a 4294967295-byte skip past end of file
+
+
+
+=== TEST 42: a skippable Frame_Size declaring a skip past EOF is declined
+# Frame_Size 1000 in an 8-byte file: 8 + 1000 is nowhere near
+# overflowing, but it is far past of.size. This is the "declared skip
+# length past EOF" case, distinct from TEST 41's overflow case.
+--- config
+    location /skip/ {
+        zstd_static on;
+        root html;
+    }
+--- user_files eval
+">>> skip/pasteof.js\npast eof origin\n>>> skip/pasteof.js.zst\n"
+. pack("C*", 0x50, 0x2A, 0x4D, 0x18, 0xE8, 0x03, 0x00, 0x00)
+--- request
+GET /skip/pasteof.js
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+! Content-Encoding
+--- response_body
+past eof origin
+--- error_code: 200
+--- error_log
+skippable frame declares a 1000-byte skip past end of file
+
+
+
+=== TEST 43: a valid dcz-style skippable prefix followed by a good regular frame IS served
+# The bypass fix must not break the legitimate shape it exists
+# alongside: RFC 9842 dcz frames are exactly a skippable frame ahead of
+# the real payload frame (see README "Standards-based dictionary
+# compression"). One skippable frame (Frame_Size 4, four bytes of
+# opaque payload) followed by a small-window regular frame must still
+# be served normally.
+--- config
+    location /skip/ {
+        zstd_static on;
+        root html;
+    }
+--- user_files eval
+">>> skip/prefix.js\nprefix origin body\n>>> skip/prefix.js.zst\n"
+. pack("C*", 0x50, 0x2A, 0x4D, 0x18, 0x04, 0x00, 0x00, 0x00,
+             0x00, 0x00, 0x00, 0x00,
+             0x28, 0xB5, 0x2F, 0xFD, 0x00, 0x00, 0x19, 0x00, 0x00)
+. "hi\n"
+--- request
+GET /skip/prefix.js
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+Content-Encoding: zstd
+--- error_code: 200
+--- no_error_log
+[error]
+
+
+
+=== TEST 44: a chain of skippable frames longer than the bound is declined
+# NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES caps the walk at 4 leading
+# skippable frames. Five zero-length skippable frames ahead of an
+# otherwise-good regular frame must be declined — the handler gives up
+# rather than searching indefinitely.
+--- config
+    location /skip/ {
+        zstd_static on;
+        root html;
+    }
+--- user_files eval
+">>> skip/toolong.js\ntoo long origin\n>>> skip/toolong.js.zst\n"
+. (pack("C*", 0x50, 0x2A, 0x4D, 0x18, 0x00, 0x00, 0x00, 0x00) x 5)
+. pack("C*", 0x28, 0xB5, 0x2F, 0xFD, 0x00, 0x00, 0x19, 0x00, 0x00)
+. "hi\n"
+--- request
+GET /skip/toolong.js
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+! Content-Encoding
+--- response_body
+too long origin
+--- error_code: 200
+--- error_log
+leading skippable frames
+
+
+
+=== TEST 45: a skippable prefix hiding an oversized-window regular frame is REJECTED
+# THE BYPASS THIS ITEM FIXES: before this change, ANY skippable magic
+# made the probe return OK immediately, so prepending a trivial
+# skippable frame to an oversized-window regular frame skipped the 8 MB
+# window guard entirely — the whole point of the probe. The handler
+# must now resolve the skip and check the frame that actually follows.
+--- config
+    location /skip/ {
+        zstd_static on;
+        root html;
+    }
+--- user_files eval
+">>> skip/bypass.js\nbypass origin body\n>>> skip/bypass.js.zst\n"
+. pack("C*", 0x50, 0x2A, 0x4D, 0x18, 0x04, 0x00, 0x00, 0x00,
+             0x00, 0x00, 0x00, 0x00,
+             0x28, 0xB5, 0x2F, 0xFD, 0x00, 0x88, 0x00, 0x00, 0x00)
+. "payloadbytes"
+--- request
+GET /skip/bypass.js
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+! Content-Encoding
+--- response_body
+bypass origin body
+--- error_code: 200
+--- error_log
+declares a 134217728-byte decompression window
+above the 8 MB limit browsers enforce for Content-Encoding: zstd

--- a/ci/tests/unit/test_static_probe.c
+++ b/ci/tests/unit/test_static_probe.c
@@ -66,6 +66,7 @@ typedef unsigned char  u_char;
 #define NGX_HTTP_ZSTD_STATIC_FRAME_NOT_ZSTD    1
 #define NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED   2
 #define NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG  3
+#define NGX_HTTP_ZSTD_STATIC_FRAME_SKIP        4
 
 /*
  * Included by RELATIVE path, not via -I, for the same reason
@@ -231,32 +232,74 @@ case_valid_zst_frame(void)
 
 
 /*
- * A skippable leading frame is a legal start to a zstd stream and is
- * exempt from the window check -- the real header sits after a
- * variable-length skip. All 16 skippable magics must be accepted, and none
- * of them may fall through into the regular-frame window parse (which
- * would read a Window_Descriptor out of what is actually a length field).
+ * A skippable leading frame is a legal start to a zstd stream, but the
+ * probe itself never certifies one OK: it returns SKIP with the declared
+ * skip length, and it is the CALLER's job (the handler's bounded walk,
+ * covered in ci/t/01-static.t, not here) to resolve the skip and probe
+ * whatever frame follows before deciding. All 16 skippable magics must
+ * take this path, and none of them may fall through into the
+ * regular-frame window parse (which would read a Window_Descriptor out of
+ * what is actually a length field) or -- the bug this replaces -- be
+ * certified OK on the magic alone.
  */
 static void
-case_skippable_frame_accepted_and_window_exempt(void)
+case_skippable_frame_reports_skip_not_ok(void)
 {
     uint64_t  w;
     int       i, ok = 1;
 
     for (i = 0; i < 16; i++) {
-        /* ZSTD_MAGIC_SKIPPABLE_START | i, little-endian, then a frame
-         * length field whose bytes would decode as a 128 MB window if the
-         * regular-frame path were wrongly taken. */
+        /* ZSTD_MAGIC_SKIPPABLE_START | i, little-endian, then a
+         * declared skip length of 0xFFFFFFFF -- the caller must reject
+         * this against of.size, not the probe. */
         u_char  f[] = { 0x50 + (u_char) i, 0x2A, 0x4D, 0x18,
                         0xFF, 0xFF, 0xFF, 0xFF };
 
-        if (probe(f, sizeof(f), &w) != NGX_HTTP_ZSTD_STATIC_FRAME_OK) {
+        w = 0;
+
+        if (probe(f, sizeof(f), &w) != NGX_HTTP_ZSTD_STATIC_FRAME_SKIP
+            || w != 0xFFFFFFFFU)
+        {
             ok = 0;
         }
     }
 
-    check(ok, "all 16 skippable-frame magics are OK and exempt from the "
-              "window check");
+    check(ok, "all 16 skippable-frame magics report SKIP with the declared "
+              "skip length, never OK on the magic alone");
+}
+
+
+/*
+ * A skippable frame's 8-byte header (magic + Frame_Size) is the outermost
+ * bound the probe can check without file-level knowledge: fewer than 8
+ * bytes and it cannot even read the length field. These fixtures mirror
+ * the "widest header, one byte short" boundary test above, but for the
+ * skip-header layout.
+ */
+static void
+case_skippable_frame_header_truncation(void)
+{
+    uint64_t  w;
+
+    static const u_char  magic_only[] = { 0x50, 0x2A, 0x4D, 0x18 };
+    check(probe(magic_only, sizeof(magic_only), &w)
+              == NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED,
+          "a 4-byte skippable magic with no Frame_Size field is TRUNCATED");
+
+    static const u_char  seven[] = { 0x50, 0x2A, 0x4D, 0x18,
+                                     0x00, 0x00, 0x00 };
+    check(probe(seven, sizeof(seven), &w)
+              == NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED,
+          "a 7-byte skippable header (Frame_Size one byte short) is "
+          "TRUNCATED");
+
+    static const u_char  eight[] = { 0x50, 0x2A, 0x4D, 0x18,
+                                     0x00, 0x00, 0x00, 0x00 };
+    w = 123;
+    check(probe(eight, sizeof(eight), &w) == NGX_HTTP_ZSTD_STATIC_FRAME_SKIP
+              && w == 0,
+          "an exact 8-byte skippable header with a zero-length payload "
+          "is SKIP with skip length 0");
 }
 
 
@@ -551,7 +594,8 @@ main(void)
     case_smallest_complete_streaming_header();
     case_exactly_probe_buffer_size();
     case_valid_zst_frame();
-    case_skippable_frame_accepted_and_window_exempt();
+    case_skippable_frame_reports_skip_not_ok();
+    case_skippable_frame_header_truncation();
     case_magic_mismatch();
     case_zero_length_file_never_reaches_the_probe();
     case_single_segment_content_size_widths();

--- a/src/ngx_http_zstd_static_module.c
+++ b/src/ngx_http_zstd_static_module.c
@@ -141,6 +141,20 @@ ngx_module_t  ngx_http_zstd_static_module = {
 #define NGX_HTTP_ZSTD_STATIC_FRAME_NOT_ZSTD    1
 #define NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED   2
 #define NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG  3
+#define NGX_HTTP_ZSTD_STATIC_FRAME_SKIP        4
+
+/*
+ * How many leading skippable frames the caller's walk (in the handler,
+ * below) will follow before giving up and declining. A dcz-style prefix
+ * (see README "Standards-based dictionary compression") is exactly ONE
+ * skippable frame — the 40-byte SHA-256 header — ahead of the real
+ * payload frame, so 4 is generous headroom for that shape plus the odd
+ * extra marker frame, while still bounding the walk to a handful of
+ * pread(2) calls: an attacker cannot turn this into an unbounded scan
+ * by chaining skippable frames, because each one past the bound is a
+ * hard decline, not a longer search.
+ */
+#define NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES   4
 
 
 /*
@@ -156,7 +170,11 @@ ngx_module_t  ngx_http_zstd_static_module = {
  * carry different log lines.
  *
  * On NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG the declared window is
- * stored through `window` for the caller's error message. `window` is
+ * stored through `window` for the caller's error message. On
+ * NGX_HTTP_ZSTD_STATIC_FRAME_SKIP the skippable frame's declared
+ * 4-byte little-endian skip length (RFC 8878 §3.2) is stored through
+ * `window` instead — same out-param, different unit, always read
+ * against the matching verdict so there is no ambiguity. `window` is
  * untouched on every other verdict.
  *
  * No I/O, no logging, no allocation, no request state: this is the
@@ -185,6 +203,34 @@ ngx_http_zstd_static_probe_frame(const u_char *hdr, size_t n, uint64_t *window)
     }
 
     /*
+     * Skippable frame (RFC 8878 §3.2): magic(4) + Frame_Size(4, little-
+     * endian) + Frame_Size bytes of opaque payload to skip. The
+     * declared window guarantee this probe exists for does not apply
+     * to a skippable frame directly — there is no window here, only a
+     * length to jump — so the caller does not get to serve on this
+     * verdict alone. It must resolve the skip, bounded, and probe
+     * whatever frame follows: an attacker-controlled skippable prefix
+     * must not be a way to dodge the window check on the frame that
+     * actually gets decoded (that was the bug: unconditionally OK-ing
+     * every skippable magic let a one-byte-longer file bypass the 8 MB
+     * guard entirely). TRUNCATED here, same as a regular frame, means
+     * "not enough bytes to decide" — the caller's fail-closed path is
+     * identical either way.
+     */
+    if (mw != ZSTD_MAGICNUMBER) {
+        if (n < 8) {
+            return NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED;
+        }
+
+        *window = ((uint64_t) hdr[4])
+                | ((uint64_t) hdr[5] << 8)
+                | ((uint64_t) hdr[6] << 16)
+                | ((uint64_t) hdr[7] << 24);
+
+        return NGX_HTTP_ZSTD_STATIC_FRAME_SKIP;
+    }
+
+    /*
      * Declared-window check (RFC 8878 §3.1.1.1) on regular frames —
      * see NGX_HTTP_ZSTD_STATIC_MAX_WINDOW for why: a frame declaring
      * more than 8 MB is rejected by every browser before decoding, so
@@ -193,19 +239,16 @@ ngx_http_zstd_static_probe_frame(const u_char *hdr, size_t n, uint64_t *window)
      * (the zstd filter, gzip_static or identity takes over) and puts
      * the actionable cause in the error log.
      *
-     * The check covers the LEADING frame only. A skippable leading
-     * frame is exempt (the real header sits after a variable-length
-     * skip), and in a concatenation of regular frames only the first
-     * is inspected: a regular frame's header does not declare its
+     * The check covers the LEADING regular frame reached after
+     * resolving any leading skippable frames (bounded, see the
+     * caller). In a concatenation of regular frames only the first is
+     * inspected: a regular frame's header does not declare its
      * compressed length, so walking the sequence would mean decoding
      * every block header in every frame — unbounded I/O for a
-     * serve-time guard. Multi-frame .zst web assets are pathological
-     * (no common tooling emits them); the README documents the
-     * leading-frame scope.
+     * serve-time guard. Multi-regular-frame .zst web assets are
+     * pathological (no common tooling emits them); the README
+     * documents that scope.
      */
-    if (mw != ZSTD_MAGICNUMBER) {
-        return NGX_HTTP_ZSTD_STATIC_FRAME_OK;
-    }
 
     if (n < 5) {
         return NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED;
@@ -455,11 +498,13 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
          * files return fewer bytes; each parse path checks it got what
          * that frame layout requires.
          */
-        u_char     hdrbuf[18];
-        u_char    *hdr;
-        size_t     want;
-        ssize_t    n;
-        uint64_t   window;
+        u_char       hdrbuf[18];
+        u_char      *hdr;
+        size_t       want;
+        ssize_t      n;
+        uint64_t     window, skip;
+        ngx_uint_t   frames;
+        off_t        pos;
 
         if (of.size < 4) {
             ngx_log_error(NGX_LOG_ERR, log, 0,
@@ -484,61 +529,126 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
             want = sizeof(hdrbuf);
         }
 
-        n = pread(of.fd, hdr, want, 0);
-        if (n < 4) {
-            if (of.is_directio) {
-                ngx_log_error(NGX_LOG_ERR, log, ngx_errno,
-                              "zstd static: %uz-byte aligned probe on "
-                              "directio file \"%s\" returned %z — "
-                              "declining; check directio_alignment "
-                              "against the device geometry",
-                              want, path.data, n);
+        pos = 0;
+
+        /*
+         * Walk a bounded chain of leading skippable frames to reach the
+         * first regular frame, so the window guard below cannot be
+         * dodged by prepending one (see NGX_HTTP_ZSTD_STATIC_FRAME_SKIP
+         * and NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES). Each iteration
+         * pread()s at the current offset, exactly like the original
+         * single-shot probe did at offset 0; only the offset and the
+         * loop are new.
+         */
+        for (frames = 0; ; frames++) {
+
+            if (frames >= NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES) {
+                ngx_log_error(NGX_LOG_ERR, log, 0,
+                              "zstd static: \"%s\" has more than %ui "
+                              "leading skippable frames — declining "
+                              "rather than searching further for the "
+                              "first regular frame",
+                              path.data,
+                              (ngx_uint_t)
+                                  NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES);
                 return NGX_DECLINED;
             }
 
-            ngx_log_error(NGX_LOG_CRIT, log, ngx_errno,
-                          "zstd static: pread(\"%s\", frame header) "
-                          "returned %z", path.data, n);
-            return NGX_DECLINED;
-        }
+            n = pread(of.fd, hdr, want, pos);
+            if (n < 4) {
+                if (of.is_directio) {
+                    ngx_log_error(NGX_LOG_ERR, log, ngx_errno,
+                                  "zstd static: %uz-byte aligned probe on "
+                                  "directio file \"%s\" returned %z — "
+                                  "declining; check directio_alignment "
+                                  "against the device geometry",
+                                  want, path.data, n);
+                    return NGX_DECLINED;
+                }
 
-        if (of.is_directio) {
-            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
-                           "zstd static: %uz-byte aligned probe on "
-                           "directio file \"%s\"", want, path.data);
-        }
+                ngx_log_error(NGX_LOG_CRIT, log, ngx_errno,
+                              "zstd static: pread(\"%s\", frame header) "
+                              "returned %z", path.data, n);
+                return NGX_DECLINED;
+            }
 
-        switch (ngx_http_zstd_static_probe_frame(hdr, (size_t) n, &window)) {
+            if (of.is_directio) {
+                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
+                               "zstd static: %uz-byte aligned probe on "
+                               "directio file \"%s\"", want, path.data);
+            }
 
-        case NGX_HTTP_ZSTD_STATIC_FRAME_NOT_ZSTD:
-            ngx_log_error(NGX_LOG_ERR, log, 0,
-                          "zstd static: \"%s\" is not a zstd frame "
-                          "(leading bytes 0x%02xd%02xd%02xd%02xd)",
-                          path.data,
-                          (ngx_uint_t) hdr[0], (ngx_uint_t) hdr[1],
-                          (ngx_uint_t) hdr[2], (ngx_uint_t) hdr[3]);
-            return NGX_DECLINED;
+            switch (ngx_http_zstd_static_probe_frame(hdr, (size_t) n,
+                                                      &window))
+            {
 
-        case NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED:
-            ngx_log_error(NGX_LOG_ERR, log, 0,
-                          "zstd static: \"%s\" frame header truncated",
-                          path.data);
-            return NGX_DECLINED;
+            case NGX_HTTP_ZSTD_STATIC_FRAME_NOT_ZSTD:
+                ngx_log_error(NGX_LOG_ERR, log, 0,
+                              "zstd static: \"%s\" is not a zstd frame "
+                              "(leading bytes 0x%02xd%02xd%02xd%02xd)",
+                              path.data,
+                              (ngx_uint_t) hdr[0], (ngx_uint_t) hdr[1],
+                              (ngx_uint_t) hdr[2], (ngx_uint_t) hdr[3]);
+                return NGX_DECLINED;
 
-        case NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG:
-            ngx_log_error(NGX_LOG_ERR, log, 0,
-                          "zstd static: \"%s\" declares a %uL-byte "
-                          "decompression window, above the 8 MB limit "
-                          "browsers enforce for Content-Encoding: zstd "
-                          "(RFC 8878) — declining so a fallback "
-                          "encoding is used; recompress with a window "
-                          "log <= 23 (streaming encoders default to "
-                          "the compression level's window when not "
-                          "told the input size)",
-                          path.data, window);
-            return NGX_DECLINED;
+            case NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED:
+                ngx_log_error(NGX_LOG_ERR, log, 0,
+                              "zstd static: \"%s\" frame header truncated",
+                              path.data);
+                return NGX_DECLINED;
 
-        default:
+            case NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG:
+                ngx_log_error(NGX_LOG_ERR, log, 0,
+                              "zstd static: \"%s\" declares a %uL-byte "
+                              "decompression window, above the 8 MB limit "
+                              "browsers enforce for Content-Encoding: zstd "
+                              "(RFC 8878) — declining so a fallback "
+                              "encoding is used; recompress with a window "
+                              "log <= 23 (streaming encoders default to "
+                              "the compression level's window when not "
+                              "told the input size)",
+                              path.data, window);
+                return NGX_DECLINED;
+
+            case NGX_HTTP_ZSTD_STATIC_FRAME_SKIP:
+
+                /*
+                 * `window` carries the declared skip length here (see
+                 * the probe's doc comment). Prove the 8-byte skippable
+                 * header AND the full declared skip both fit within
+                 * of.size before trusting the jump — checked
+                 * arithmetic throughout, since `skip` is attacker-
+                 * controlled and 32-bit-wide enough to overflow a
+                 * 32-bit off_t/size_t add on its own.
+                 */
+                skip = window;
+
+                if ((uint64_t) pos > (uint64_t) of.size
+                    || (uint64_t) of.size - (uint64_t) pos < 8)
+                {
+                    ngx_log_error(NGX_LOG_ERR, log, 0,
+                                  "zstd static: \"%s\" skippable frame "
+                                  "header runs past end of file",
+                                  path.data);
+                    return NGX_DECLINED;
+                }
+
+                if (skip > (uint64_t) of.size - (uint64_t) pos - 8) {
+                    ngx_log_error(NGX_LOG_ERR, log, 0,
+                                  "zstd static: \"%s\" skippable frame "
+                                  "declares a %uL-byte skip past end of "
+                                  "file", path.data, skip);
+                    return NGX_DECLINED;
+                }
+
+                pos += (off_t) 8 + (off_t) skip;
+
+                continue;
+
+            default:
+                break;
+            }
+
             break;
         }
     }


### PR DESCRIPTION
> Backlog security row against `ngx_http_zstd_static_module.c`'s serve-time frame probe. Independent of #158 (RFC 9842 dcz secure-context gate), which touches the filter module; this PR only touches the static module.

## TL;DR

The static module refuses to serve a `.zst` file whose declared decompression window is too large for browsers to accept — that check exists so a bad build never ships an undecodable response. But the probe had a side door: a zstd file format also allows small "skippable" marker blocks before the real payload, and the code treated the mere presence of one as enough to wave the whole file through, without ever checking what came after it. Prepending one such marker to an otherwise-oversized file made the guard vanish.

In code terms: `ngx_http_zstd_static_probe_frame()` (`src/ngx_http_zstd_static_module.c`) returned `NGX_HTTP_ZSTD_STATIC_FRAME_OK` immediately on any `ZSTD_MAGIC_SKIPPABLE_*` magic, without validating the frame's 4-byte length field or resolving to the frame that follows.

**Severity:** `Medium` (`serve-time validation bypass — the browser decompression-window guard can be dodged by prepending a trivial skippable frame`)

## What is going on

* `ngx_http_zstd_static_probe_frame()` — `src/ngx_http_zstd_static_module.c`: pure frame-header arithmetic over the first bytes read from a `.zst` file. On a regular zstd frame it computes the declared decompression window and returns `NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG` above `NGX_HTTP_ZSTD_STATIC_MAX_WINDOW` (8 MB, the RFC 8878 limit browsers enforce). On a skippable frame (`ZSTD_MAGIC_SKIPPABLE_START..+0xF`, RFC 8878 §3.2) it previously returned `OK` unconditionally.
* `ngx_http_zstd_static_handler()` — same file: pread(2)s the leading header once at offset 0 and switches on the probe's verdict to decide whether to serve `Content-Encoding: zstd`.

RFC 9842 dcz dictionary compression (this module's own feature, README "Standards-based dictionary compression") legitimately produces exactly this shape: a 40-byte skippable frame (the dictionary SHA-256) ahead of the real payload frame. The probe's old behaviour treated *any* skippable magic the same way, without distinguishing "this is the dcz shape, the real frame still needs checking" from "this magic alone is sufficient".

## Why that is a problem

1. A `.zst` sidecar is served whenever `zstd_static on|always` is configured and the probe does not decline.
2. An attacker who can place or influence a `.zst` file (a compromised build pipeline, a mistakenly-shipped intermediate artifact, or an operator error) prepends an 8-byte skippable header (magic + a valid small Frame_Size) to a regular frame that declares a decompression window above 8 MB.
3. The probe read the skippable magic, matched the mask, and returned `OK` without inspecting the Frame_Size field or looking at the bytes after it.
4. The handler served the file with `Content-Encoding: zstd`.
5. Firefox and Chromium refuse to decode a frame declaring more than 8 MB before reading a single byte (`NS_ERROR_INVALID_CONTENT_ENCODING` / `ERR_CONTENT_DECODING_FAILED`), so the client gets a decode failure — exactly the outage class the window guard exists to prevent, now reachable by anyone who can prepend 8 bytes to a file.

This is a validation-bypass bug, not a memory-safety one: the probe still only inspects header bytes it has bounds-checked, and the worst case with the AND without the fix is a broken response, never a crash. It is deterministic (no timing/concurrency dependence), reachable through nothing but the file's own bytes (no request input feeds it), and gated entirely on `zstd_static` being configured with an on-disk `.zst` — the same trust boundary the whole probe already assumes (whoever controls the `.zst` file controls what gets probed).

## Proposed fix

* The probe (`ngx_http_zstd_static_probe_frame()`) now returns a new verdict, `NGX_HTTP_ZSTD_STATIC_FRAME_SKIP`, for a skippable magic, carrying the frame's declared 4-byte little-endian skip length via the existing `window` out-parameter (documented as dual-purpose in the function's header comment — same slot, verdict-qualified meaning, no signature churn against the ~42 existing unit-test call sites). Fewer than 8 bytes available for the header → `NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED`, same as any other under-length header.
* The handler resolves a **bounded** chain of leading skippable frames before running the window check: `NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES` (4) — generous headroom over the RFC 9842 dcz shape (exactly one skippable frame), while keeping the walk to a handful of `pread(2)` calls rather than an unbounded scan. Exceeding the bound declines with a dedicated log line.
* Each hop is bounds-checked in 64-bit arithmetic against `of.size` before trusting it: the header itself must fit (`pos + 8 <= of.size`), and the declared skip must fit after it (`skip <= of.size - pos - 8`), so a `0xFFFFFFFF`-byte declared skip cannot overflow a narrower `off_t`/`size_t` add into a small, in-bounds offset.
* The window check itself is unchanged — it now simply runs against whichever frame the bounded walk actually reaches, closing the bypass without touching the check's own arithmetic.
* Multi-*regular*-frame concatenation remains explicitly out of scope, as documented before this change (a regular frame's header does not declare its own compressed length, so walking that sequence would mean decoding every block header — unbounded I/O for a serve-time guard). This PR only changes how *skippable* frames — whose length **is** declared — are resolved.

## Testing

* Unit (`ci/tests/unit/test_static_probe.c`, built against the shipped function body via `ci/fuzz/extract_static_probe.sh`, not a hand copy): replaced the one case that asserted the old "every skippable magic is OK" contract with two cases — all 16 skippable magics report `SKIP` with the declared length, never `OK`; and the skippable header's own truncation boundaries (4-byte magic-only, 7-byte, exact 8-byte). 45/45 checks pass (`bash ci/tests/unit/run.sh`).
* TAP (`ci/t/01-static.t`, run against a locally built nginx 1.31.4 + both `.so`s via `ci/tools/ci-build.sh`): 8 new cases —
  * TEST 38/39: 4-byte and 7-byte skippable headers decline (`frame header truncated`)
  * TEST 40: exact 8-byte header with nothing after it declines (follow-up pread at EOF returns 0, same as any other short read)
  * TEST 41: Frame_Size `0xFFFFFFFF` (32-bit-arithmetic overflow case) declines with the past-EOF message, not a wrapped in-bounds offset
  * TEST 42: Frame_Size 1000 in an 8-byte file (declared skip past EOF, no overflow involved) declines
  * TEST 43: a valid dcz-style prefix (skippable frame, Frame_Size 4) followed by a small-window regular frame **is still served** — the positive control proving the fix doesn't regress the legitimate shape
  * TEST 44: 5 chained zero-length skippable frames (one past the bound of 4) declines
  * TEST 45: **the bypass itself** — a skippable prefix followed by a regular frame declaring a 128 MB window is REJECTED (`declares a 134217728-byte decompression window ... above the 8 MB limit`)
  All 555 assertions in the file pass.
* Negative control (mandatory, observed): stashed the source fix only, rebuilt (`ngx_http_zstd_static_module.so` BuildID changed from `e5e941f7...`/87016 bytes to `faafdaed...`/85416 bytes, confirming a real rebuild against the reverted code), reran the TAP suite — 66 of 555 assertions went red, including every TEST 45 assertion (`Content-Encoding: zstd` present when it must not be; the window-check log line absent; the bypass payload served verbatim). Restored the fix, rebuilt again (87016 bytes, matching the pre-revert build), reran: 555/555 green, 45/45 unit checks green.
* Lint pre-pass (`review-lint.sh`) clean on the touched files; two pre-existing findings outside this diff's line ranges (an `ast-grep` `nginx-unchecked-palloc` note on three unrelated `ngx_pcalloc` sites, and a `codespell` false positive on the `r->exten` nginx core field name at line 676) were ledgered in `memory/labs/http-zstd/TODO.md` rather than fixed here, along with the handler function's complexity increase (227/49 NLOC/CCN → 265/55) from the added bounded walk.

## Security considerations

* Trust boundary: unchanged. Whoever controls the `.zst` file already controls everything the probe inspects; this fix does not add a new trust boundary, it closes a gap in enforcing the existing one (the window guard) against a shape (skippable prefix) the format itself allows.
* Fail-closed: every new failure path (truncated skippable header, declared-skip arithmetic overflow, declared-skip past EOF, bound exceeded) declines exactly the way the pre-existing probe already declined a malformed regular frame — same `NGX_DECLINED` / fallback-to-uncompressed-or-404 behaviour, no new failure mode introduced.
* Residual/out of scope: multi-regular-frame concatenation is still not walked past the first regular frame (unchanged, pre-existing, documented scope); this PR only changes the skippable-frame resolution ahead of that first regular frame.
