### PR TITLE
security(ci): trust-anchor every download that is unpacked or executed

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -94,9 +94,26 @@ jobs:
       # so a broken workflow fails fast and obviously.
       - name: Lint workflows (actionlint)
         run: |
+          set -euo pipefail
           ACTIONLINT_VERSION=1.7.7
+          # Pinned sha256 for the linux_amd64 release asset, computed once
+          # from an HTTPS fetch and cross-checked against the checksums.txt
+          # rhysd publishes alongside each release -- same "reviewed pin,
+          # verify before use" shape as ci/tools/ci-build.sh's NGINX_SHA256 /
+          # ANGIE_SHA256 tables. A version bump is a reviewed PR that updates
+          # this hash, not a runtime fetch of a fresher one.
+          ACTIONLINT_SHA256=023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757
           curl -fsSL -o /tmp/actionlint.tgz \
             "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          actual="$(sha256sum /tmp/actionlint.tgz | awk '{print $1}')"
+          if [ "$actual" != "$ACTIONLINT_SHA256" ]; then
+            echo "✗ sha256 mismatch for actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" >&2
+            echo "  expected: $ACTIONLINT_SHA256" >&2
+            echo "  actual:   $actual" >&2
+            rm -f /tmp/actionlint.tgz
+            exit 1
+          fi
+          echo "✓ sha256 verified for actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
           tar -xzf /tmp/actionlint.tgz -C /tmp actionlint
           /tmp/actionlint -color "$GITHUB_WORKSPACE"/.github/workflows/*.yml
           echo "✓ actionlint: workflows valid"
@@ -197,14 +214,16 @@ jobs:
           # headers but NOT the build system (no auto/configure), so it can
           # never produce ngx_auto_config.h; the old approach silently failed
           # and scan-build "passed" on incomplete headers (the CI2 complaint).
-          # Download + configure a real nginx source instead.
+          # Download + configure a real nginx source instead. Verified via
+          # ci/tools/fetch-verified-nginx.sh -- same PGP-against-vendored-key
+          # check the build matrix uses, so this download is no less trusted
+          # than the one that actually ships in the test binary.
           set -euo pipefail
           ver=$(curl -fsSL https://nginx.org/en/download.html \
             | grep -oP 'nginx-\K[0-9]+\.[0-9]+\.[0-9]+(?=\.tar\.gz)' \
             | sort -V | tail -1)
           echo "Using nginx $ver to generate lint headers"
-          wget -q "https://nginx.org/download/nginx-${ver}.tar.gz"
-          tar -xzf "nginx-${ver}.tar.gz"
+          "$GITHUB_WORKSPACE/ci/tools/fetch-verified-nginx.sh" "$ver"
           cd "nginx-${ver}"
           CC=gcc ./configure --with-compat \
             --add-dynamic-module="$GITHUB_WORKSPACE" > /dev/null
@@ -547,6 +566,28 @@ jobs:
         run: |
           wget -q -O "zstd-${OLD_ZSTD_VERSION}.tar.gz" \
             "https://github.com/facebook/zstd/releases/download/v${OLD_ZSTD_VERSION}/zstd-${OLD_ZSTD_VERSION}.tar.gz"
+
+      - name: Verify libzstd 1.4.x tarball sha256
+        # Runs on EVERY run, cache hit or fresh download -- a cached tarball
+        # from actions/cache is exactly as untrusted as a freshly-downloaded
+        # one until re-checked (same rule ci-build.sh's header documents for
+        # nginx/angie tarballs, audit sha e289021 F3). facebook/zstd does not
+        # publish a detached signature for release tarballs, so this is
+        # pinned sha256 only, computed once from an HTTPS fetch -- same
+        # approach as ci-build.sh's ANGIE_SHA256 table.
+        env:
+          ZSTD_145_SHA256: 98e91c7c6bf162bf90e4e70fdbc41a8188b9fa8de5ad840c401198014406ce9e
+        run: |
+          set -euo pipefail
+          actual="$(sha256sum "zstd-${OLD_ZSTD_VERSION}.tar.gz" | awk '{print $1}')"
+          if [ "$actual" != "$ZSTD_145_SHA256" ]; then
+            echo "✗ sha256 mismatch for zstd-${OLD_ZSTD_VERSION}.tar.gz" >&2
+            echo "  expected: $ZSTD_145_SHA256" >&2
+            echo "  actual:   $actual" >&2
+            rm -f "zstd-${OLD_ZSTD_VERSION}.tar.gz"
+            exit 1
+          fi
+          echo "✓ sha256 verified for zstd-${OLD_ZSTD_VERSION}.tar.gz"
 
       - name: Build libzstd 1.4.x to a private prefix
         run: |

--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -406,9 +406,12 @@ jobs:
       - name: Build debug nginx + zstd module
         run: |
           set -euo pipefail
-          test -f "nginx-${NGINX_VERSION}.tar.gz" || wget -q -O "nginx-${NGINX_VERSION}.tar.gz" \
-            "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz"
-          tar -xzf "nginx-${NGINX_VERSION}.tar.gz"; cd "nginx-${NGINX_VERSION}"
+          # PGP-verified against the vendored keys every run -- a runner-
+          # persisted tarball from a prior job is exactly as untrusted as a
+          # fresh download until re-checked (same "cache hit is not a trust
+          # boundary" rule as ci-build.sh, audit sha e289021 F3).
+          "$GITHUB_WORKSPACE/ci/tools/fetch-verified-nginx.sh" "$NGINX_VERSION"
+          cd "nginx-${NGINX_VERSION}"
           ./configure \
             --with-compat --with-debug --with-threads --with-file-aio \
             --with-http_ssl_module --with-http_v2_module \
@@ -474,9 +477,12 @@ jobs:
       - name: Build debug nginx + zstd module
         run: |
           set -euo pipefail
-          test -f "nginx-${NGINX_VERSION}.tar.gz" || wget -q -O "nginx-${NGINX_VERSION}.tar.gz" \
-            "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz"
-          tar -xzf "nginx-${NGINX_VERSION}.tar.gz"; cd "nginx-${NGINX_VERSION}"
+          # PGP-verified against the vendored keys every run -- a runner-
+          # persisted tarball from a prior job is exactly as untrusted as a
+          # fresh download until re-checked (same "cache hit is not a trust
+          # boundary" rule as ci-build.sh, audit sha e289021 F3).
+          "$GITHUB_WORKSPACE/ci/tools/fetch-verified-nginx.sh" "$NGINX_VERSION"
+          cd "nginx-${NGINX_VERSION}"
           ./configure \
             --with-compat --with-debug --with-threads --with-file-aio \
             --with-http_ssl_module --with-http_v2_module \
@@ -545,8 +551,12 @@ jobs:
           set -euo pipefail
           ver=$(curl -fsSL https://nginx.org/en/download.html \
             | grep -oP 'nginx-\K[0-9]+\.[0-9]+\.[0-9]+(?=\.tar\.gz)' | sort -V | tail -1)
-          wget -q "https://nginx.org/download/nginx-${ver}.tar.gz"
-          tar -xzf "nginx-${ver}.tar.gz"; cd "nginx-${ver}"
+          # PGP-verified against the vendored keys, same as ci-build.sh and
+          # build-test.yml's scan-build header job -- an unchecked tarball
+          # here means clang-tidy/flawfinder analyze (and this job's later
+          # steps configure/execute) attacker-controlled source.
+          "$GITHUB_WORKSPACE/ci/tools/fetch-verified-nginx.sh" "$ver"
+          cd "nginx-${ver}"
           CC=gcc ./configure --with-compat --add-dynamic-module="$GITHUB_WORKSPACE" >/dev/null
           echo "NGINX_SRC_TREE=$PWD" >> "$GITHUB_ENV"
       - name: flawfinder

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -76,7 +76,7 @@ jobs:
           # that is not really a gate. This module has no lint-sync-stamp.sh
           # or lint-prompt-steps.* (those track the skeleton's own adoption
           # prompt, not this module), so they are not listed.
-          LINT_ONLY: nginx sh python perl yaml spelling ci-runners ci-ports ci-cadence ci-secrets docs-drift
+          LINT_ONLY: nginx sh python perl yaml spelling ci-runners ci-ports ci-cadence ci-secrets ci-provenance docs-drift
         run: ci/linter/run-all.sh
 
       # ast-grep and gitleaks live in .pre-commit-config.yaml rather than in a

--- a/ci/linter/fixtures/policy/provenance-bare-wget-unverified/.github/workflows/ci.yml
+++ b/ci/linter/fixtures/policy/provenance-bare-wget-unverified/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+---
+name: ci
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+      - run: |
+          wget -q "https://example.invalid/tool.tgz"
+      - run: |
+          tar -xzf tool.tgz
+          ./tool/configure

--- a/ci/linter/fixtures/policy/provenance-bare-wget-unverified/README.md
+++ b/ci/linter/fixtures/policy/provenance-bare-wget-unverified/README.md
@@ -1,0 +1,16 @@
+# fixture: provenance-bare-wget-unverified
+
+Same defect as `provenance-unverified-extract`, written with the download
+spelling four of this repo's own jobs actually use: `wget -q "<url>"` with
+**no** `-O`. The first version of the scoping regex required `-O`/`-o`, so a
+job written this way matched no download token at all and was skipped
+WHOLESALE -- not passed, never examined. That is a gate failing open: the
+seven jobs it silently excluded were verified only by luck, and a future
+unverified copy of the idiom would have been invisible.
+
+`curl -O` and PowerShell `Invoke-WebRequest -OutFile` were blind the same
+way; `ci-deep.yml:scanners` is a real site the narrow regex never scanned.
+
+`provenance` must go red here.
+
+Workflow: `.github/workflows/ci.yml`.

--- a/ci/linter/fixtures/policy/provenance-cache-hit-skips-verify/.github/workflows/ci.yml
+++ b/ci/linter/fixtures/policy/provenance-cache-hit-skips-verify/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+---
+name: ci
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+      - name: Cache tool tarball
+        id: tool-tarball
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: tool.tgz
+          key: tool-src
+      - name: Download tool
+        if: steps.tool-tarball.outputs.cache-hit != 'true'
+        run: wget -q -O tool.tgz "https://example.invalid/tool.tgz"
+      - run: |
+          tar -xzf tool.tgz
+          ./tool/configure

--- a/ci/linter/fixtures/policy/provenance-cache-hit-skips-verify/README.md
+++ b/ci/linter/fixtures/policy/provenance-cache-hit-skips-verify/README.md
@@ -1,0 +1,13 @@
+# fixture: provenance-cache-hit-skips-verify
+
+The trap this check exists to close, not just a duplicate of
+`provenance-unverified-extract`: the download step is gated
+`if: steps.tool-tarball.outputs.cache-hit != 'true'`, so on a cache HIT no
+download step runs at all -- and still nothing in the job asserts a
+trust-anchor before `tar -xzf` unpacks whatever `actions/cache` restored. A
+checker that only looked at the download step's presence/absence would read
+this job as having "no download to gate" on a cache hit and pass it; this one
+must still go red because the extract/execute step itself has no anchor
+before it, regardless of which path fed the file.
+
+Workflow: `.github/workflows/ci.yml`.

--- a/ci/linter/fixtures/policy/provenance-curl-O-unverified/.github/workflows/ci.yml
+++ b/ci/linter/fixtures/policy/provenance-curl-O-unverified/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+---
+name: ci
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+      - run: |
+          curl -fsSLO --connect-timeout 30 "https://example.invalid/tool.tgz"
+      - run: |
+          tar -xzf tool.tgz
+          ./tool/configure

--- a/ci/linter/fixtures/policy/provenance-curl-O-unverified/README.md
+++ b/ci/linter/fixtures/policy/provenance-curl-O-unverified/README.md
@@ -1,0 +1,15 @@
+# fixture: provenance-curl-O-unverified
+
+Sibling of `provenance-bare-wget-unverified` for the `curl -O` spelling
+(`windows-build.yml:mingw` uses `curl -fsSLO`). The pre-fix scoping regex
+required a separate `-O <file>` argument pair and did not match the bundled
+`-fsSLO` form, so a job written this way was skipped wholesale rather than
+checked.
+
+Exists because the comment on `DOWNLOAD_RE` claims three spellings are
+covered; without a probe per spelling, a regression in two of them passes
+the selftest.
+
+`provenance` must go red here.
+
+Workflow: `.github/workflows/ci.yml`.

--- a/ci/linter/fixtures/policy/provenance-exec-downloaded-binary/.github/workflows/ci.yml
+++ b/ci/linter/fixtures/policy/provenance-exec-downloaded-binary/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+---
+name: ci
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+      - run: |
+          wget -q -O tool "https://example.invalid/tool"
+      - run: |
+          chmod +x tool
+          ./tool --version

--- a/ci/linter/fixtures/policy/provenance-exec-downloaded-binary/README.md
+++ b/ci/linter/fixtures/policy/provenance-exec-downloaded-binary/README.md
@@ -1,0 +1,11 @@
+# fixture: provenance-exec-downloaded-binary
+
+No archive is involved: a STANDALONE executable is downloaded, marked
+executable, and run directly. The tar/unzip patterns miss this completely,
+so the job passed while running unverified attacker-controllable code on the
+runner -- the same privilege boundary the archive cases exist to guard, one
+step shorter.
+
+`provenance` must go red here.
+
+Workflow: `.github/workflows/ci.yml`.

--- a/ci/linter/fixtures/policy/provenance-iwr-outfile-unverified/.github/workflows/ci.yml
+++ b/ci/linter/fixtures/policy/provenance-iwr-outfile-unverified/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+---
+name: ci
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - run: echo build
+      - shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri "https://example.invalid/tool.tgz" -OutFile tool.tgz
+      - shell: pwsh
+        run: |
+          tar -xzf tool.tgz
+          ./tool/configure

--- a/ci/linter/fixtures/policy/provenance-iwr-outfile-unverified/README.md
+++ b/ci/linter/fixtures/policy/provenance-iwr-outfile-unverified/README.md
@@ -1,0 +1,11 @@
+# fixture: provenance-iwr-outfile-unverified
+
+Sibling of `provenance-bare-wget-unverified` for PowerShell's
+`Invoke-WebRequest -OutFile` (`windows-build.yml:msvc` uses it). A Windows
+runner unpacking an unverified tarball is the same privilege boundary as a
+Linux one; the pre-fix scoping regex knew only `wget`/`curl`, so every
+PowerShell download job was invisible to this check.
+
+`provenance` must go red here.
+
+Workflow: `.github/workflows/ci.yml`.

--- a/ci/linter/fixtures/policy/provenance-noncomparing-sha256/.github/workflows/ci.yml
+++ b/ci/linter/fixtures/policy/provenance-noncomparing-sha256/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+---
+name: ci
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+      - run: |
+          wget -q -O tool.tgz "https://example.invalid/tool.tgz"
+      - run: |
+          sha256sum tool.tgz
+      - run: |
+          tar -xzf tool.tgz
+          ./tool/configure

--- a/ci/linter/fixtures/policy/provenance-noncomparing-sha256/README.md
+++ b/ci/linter/fixtures/policy/provenance-noncomparing-sha256/README.md
@@ -1,0 +1,16 @@
+# fixture: provenance-noncomparing-sha256
+
+The anchor half failing open, mirroring the scoping half. A step runs
+`sha256sum tool.tgz` -- which PRINTS a digest to the log and compares it to
+nothing -- and the extract step follows. The first `TRUST_ANCHOR_RE` matched
+the bare word `sha256sum`, so this job read as anchored while validating no
+bytes at all. A lone `FOO_SHA256:` env declaration nothing tests had the same
+effect.
+
+An anchor must show a COMPARISON: `sha256sum -c`, or a captured digest tested
+against a pinned `*_SHA256`. `provenance-verified-ok` is the green control
+for exactly that shape.
+
+`provenance` must go red here.
+
+Workflow: `.github/workflows/ci.yml`.

--- a/ci/linter/fixtures/policy/provenance-unverified-extract/.github/workflows/ci.yml
+++ b/ci/linter/fixtures/policy/provenance-unverified-extract/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+---
+name: ci
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+      - run: |
+          wget -q -O tool.tgz "https://example.invalid/tool.tgz"
+      - run: |
+          tar -xzf tool.tgz
+          ./tool/configure

--- a/ci/linter/fixtures/policy/provenance-unverified-extract/README.md
+++ b/ci/linter/fixtures/policy/provenance-unverified-extract/README.md
@@ -1,0 +1,9 @@
+# fixture: provenance-unverified-extract
+
+The bypass class this repo hit: a step downloads a tarball with `wget -O`,
+and a later step in the SAME job extracts it with `tar -xzf` and immediately
+runs the unpacked binary's `configure` -- with no `gpg --verify`, no
+`sha256sum` comparison, and no delegation to `ci-build.sh` /
+`fetch-verified-nginx.sh` anywhere in between. `provenance` must go red here.
+
+Workflow: `.github/workflows/ci.yml`.

--- a/ci/linter/fixtures/policy/provenance-verified-ok/.github/workflows/ci.yml
+++ b/ci/linter/fixtures/policy/provenance-verified-ok/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+---
+name: ci
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+      - run: |
+          wget -q -O tool.tgz "https://example.invalid/tool.tgz"
+      - run: |
+          actual="$(sha256sum tool.tgz | awk '{print $1}')"
+          [ "$actual" = "deadbeef" ] || exit 1
+      - run: |
+          tar -xzf tool.tgz
+          ./tool/configure

--- a/ci/linter/fixtures/policy/provenance-verified-ok/README.md
+++ b/ci/linter/fixtures/policy/provenance-verified-ok/README.md
@@ -1,0 +1,9 @@
+# fixture: provenance-verified-ok
+
+The green sibling of `provenance-unverified-extract`: the SAME job, with a
+`sha256sum` comparison step inserted between the download and the
+extract/execute step. Run as a PAIR -- without this fixture, the red on
+`provenance-unverified-extract` would be equally consistent with "any
+download in a job is flagged", not specifically "an unverified one is".
+
+Workflow: `.github/workflows/ci.yml`.

--- a/ci/linter/lint-ci-provenance.sh
+++ b/ci/linter/lint-ci-provenance.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 Thijs Eilander
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# ci/linter/lint-ci-provenance.sh -- every step that extracts an archive or
+# executes a downloaded artifact must be preceded, in the same job, by a
+# gpg/sha256 trust-anchor assertion. A cache-hit path is not exempt: a cached
+# tarball is exactly as untrusted as a fresh download until re-checked.
+#
+# The rule and the detector live in ci/linter/workflow_policy.py (subcommand
+# `provenance`); this wrapper exists so run-all.sh picks the check up by glob
+# and LINT_ONLY=ci-provenance selects it.
+#
+# The failure it prevents: a release/origin/cache compromise becomes code
+# execution on the self-hosted runner the moment CI unpacks or runs what it
+# just fetched with no verification -- audit sha e289021 F3.
+#
+# Usage: ci/linter/lint-ci-provenance.sh [files...]   Env: LINT_MODE=staged|all
+# Extend: a new trust-anchor shape (a detached signature against a different
+# tool, a different pinned-hash naming convention) goes in TRUST_ANCHOR_RE in
+# workflow_policy.py, not here.
+
+# shellcheck source=ci/linter/lib.sh
+. "$(git rev-parse --show-toplevel)/ci/linter/lib.sh"
+
+mapfile -t FILES < <(lint_files '^\.github/workflows/.*\.ya?ml$' "$@")
+[ "${#FILES[@]}" -gt 0 ] || { echo "lint-ci-provenance: no workflow files to check"; exit 0; }
+
+need python3 "apt-get install python3"
+# Whole-tree by nature: a download in one step and its extract/exec several
+# steps later are the same JOB, so the file list only decides relevance.
+exec python3 "$(git rev-parse --show-toplevel)/ci/linter/workflow_policy.py" provenance

--- a/ci/linter/selftest.sh
+++ b/ci/linter/selftest.sh
@@ -117,6 +117,7 @@ policy_msg_() {
 policy_ 0 clean runners
 policy_ 0 clean ports
 policy_ 0 clean docs
+policy_ 0 clean provenance
 # Deliberately NO `policy_ 0 clean cadence`: the clean fixture has no
 # workflow_call member, so that line would assert green over an empty set --
 # vacuous, and indistinguishable from the check being broken. The green control
@@ -206,6 +207,22 @@ policy_ 1 secrets-undeclared secrets
 # first written: member requires it, caller wires nothing.
 policy_ 1 secrets-required-not-wired secrets
 policy_ 0 secrets-typed-ok secrets
+
+# A step downloads a tarball; a later step in the same job extracts it and
+# runs the unpacked configure with no gpg/sha256 trust-anchor assertion
+# anywhere in between -- the class this repo hit in build-test.yml/ci-deep.yml
+# after the ci-build.sh fix (a direct download/extract/execute path added
+# outside that already-verified helper). These run as a PAIR: the -ok fixture
+# is the same job with a sha256 comparison step inserted, so the red above is
+# not equally consistent with "any download in a job is flagged".
+policy_ 1 provenance-unverified-extract provenance
+policy_ 0 provenance-verified-ok provenance
+# The trap this check exists to close: the download step is gated
+# `cache-hit != 'true'`, so a cache HIT skips it entirely and a checker that
+# only looks for a download step present would read the job as having
+# nothing to verify. This must still go red -- a cached tarball is exactly as
+# untrusted as a fresh one until re-checked.
+policy_ 1 provenance-cache-hit-skips-verify provenance
 
 # A mistyped pool label in a schedule-only workflow. The trust half of the
 # runners check does not apply to a workflow no fork can reach, and skipping it

--- a/ci/linter/selftest.sh
+++ b/ci/linter/selftest.sh
@@ -223,6 +223,12 @@ policy_ 0 provenance-verified-ok provenance
 # nothing to verify. This must still go red -- a cached tarball is exactly as
 # untrusted as a fresh one until re-checked.
 policy_ 1 provenance-cache-hit-skips-verify provenance
+# The scoping regex must know every spelling that writes a file from the
+# network, not just `-O`/`-o`. A bare `wget "<url>"` is the idiom four of this
+# repo's own jobs use; while the regex required -O those jobs matched no
+# download token and were skipped wholesale rather than checked -- a gate
+# failing open. Same class for `curl -O` and `Invoke-WebRequest -OutFile`.
+policy_ 1 provenance-bare-wget-unverified provenance
 
 # A mistyped pool label in a schedule-only workflow. The trust half of the
 # runners check does not apply to a workflow no fork can reach, and skipping it

--- a/ci/linter/selftest.sh
+++ b/ci/linter/selftest.sh
@@ -229,6 +229,19 @@ policy_ 1 provenance-cache-hit-skips-verify provenance
 # download token and were skipped wholesale rather than checked -- a gate
 # failing open. Same class for `curl -O` and `Invoke-WebRequest -OutFile`.
 policy_ 1 provenance-bare-wget-unverified provenance
+# One probe per spelling the DOWNLOAD_RE comment claims to cover. Without
+# these two, a regression in the curl -O or Invoke-WebRequest branch passes
+# the selftest while the comment still advertises them as handled.
+policy_ 1 provenance-curl-O-unverified provenance
+policy_ 1 provenance-iwr-outfile-unverified provenance
+# The ANCHOR half failing open, not the scoping half: a bare `sha256sum f`
+# prints a digest and compares nothing, yet used to satisfy TRUST_ANCHOR_RE.
+# provenance-verified-ok is the green control for a real comparison.
+policy_ 1 provenance-noncomparing-sha256 provenance
+# No archive at all: download a standalone binary, chmod +x, run it. The
+# tar/unzip patterns miss this entirely, yet it is the same privilege
+# boundary one step shorter.
+policy_ 1 provenance-exec-downloaded-binary provenance
 
 # A mistyped pool label in a schedule-only workflow. The trust half of the
 # runners check does not apply to a workflow no fork can reach, and skipping it

--- a/ci/linter/workflow_policy.py
+++ b/ci/linter/workflow_policy.py
@@ -642,14 +642,26 @@ TRUST_ANCHOR_RE = re.compile(
     r"fetch-verified-nginx\.sh"
 )
 
-# A step that only DOWNLOADS (wget/curl -o) and does not itself extract or
-# execute is not a finding on its own -- the extract/exec step downstream is
-# what this check anchors on. Restricting the scan to run: text that mentions
-# a download-shaped command keeps the check from firing on, say, a `tar -xzf`
+# A step that only DOWNLOADS and does not itself extract or execute is not a
+# finding on its own -- the extract/exec step downstream is what this check
+# anchors on. Restricting the scan to run: text that mentions a
+# download-shaped command keeps the check from firing on, say, a `tar -xzf`
 # of a repo-local artifact this job built itself (build-test.yml's ccache /
 # coverage tarballs never leave the runner and have no external origin to
 # forge).
-DOWNLOAD_RE = re.compile(r"\b(?:wget|curl)\b.*(?:-O\b|-o\b)|actions/cache@")
+#
+# Every spelling that WRITES A FILE from the network must appear here, not
+# just the `-O`/`-o` ones: `wget <url>` with no -O (the idiom four of this
+# repo's own jobs use), `curl -O`/`-OJ`, and PowerShell's
+# `Invoke-WebRequest -OutFile` (windows-build.yml) all fetch to disk. An
+# omitted spelling does not make the check lenient -- it makes the whole JOB
+# unscanned, so a future unverified copy of that idiom is invisible rather
+# than flagged. That is a gate failing open, so the scoping regex is
+# deliberately broader than the extract/exec one.
+DOWNLOAD_RE = re.compile(
+    r"\bwget\b|\bcurl\b(?:\s+\S+)*\s+-\S*[oO]\b|\bcurl\b[^\n]*\s-\S*O|"
+    r"Invoke-WebRequest\b|actions/cache@"
+)
 
 
 def check_provenance() -> int:

--- a/ci/linter/workflow_policy.py
+++ b/ci/linter/workflow_policy.py
@@ -8,6 +8,7 @@
     ci/linter/workflow_policy.py docs        README <-> workflows drift
     ci/linter/workflow_policy.py cadence     one PR entry point per member
     ci/linter/workflow_policy.py secrets     typed per-member secrets, no inherit
+    ci/linter/workflow_policy.py provenance  extract/exec steps trust-anchored
 
 Each subcommand is wrapped by a ci/linter/lint-*.sh so run-all.sh picks it up by
 glob and a human can select it with LINT_ONLY. Exit: 0 clean, 1 findings,
@@ -608,6 +609,95 @@ def check_cadence() -> int:
 
 
 # --------------------------------------------------------------------------
+# provenance
+#
+# A step that extracts an archive or executes a downloaded artifact with no
+# nearby trust-anchor assertion is code execution on the self-hosted runner
+# the moment the origin, a release, or a poisoned actions/cache entry is
+# compromised -- audit sha e289021 F3, re-opened by direct-download steps
+# added after the ci-build.sh fix. A cache HIT is not exempt: a cached
+# tarball is exactly as untrusted as a fresh download until re-checked, so
+# this check does not care whether the step is gated by a
+# `cache-hit != 'true'` condition -- it looks at whether the JOB proves
+# trust somewhere before the extract/execute point, which a cache-skipped
+# download step cannot do on its own.
+
+# What counts as "this step unpacks or runs something fetched from outside
+# the repo". Deliberately textual (same _body()/_steps() shape as the ports
+# check): a `tar -xzf` or a direct `./configure`/binary invocation is the
+# actual privilege boundary, not the download line above it.
+EXTRACT_OR_EXEC_RE = re.compile(
+    r"(?<![\w-])tar\s+-?x|(?<![\w-])unzip\b|(?<![\w-])/tmp/actionlint\b"
+)
+
+# What counts as a trust-anchor assertion having been made ON THIS PATH
+# before the extract/exec point. Any one of:
+#   - a detached-signature check (gpg --verify)
+#   - a checksum comparison (sha256sum, and the pinned-hash variable naming
+#     convention this repo uses: *_SHA256)
+#   - delegating to a helper this repo already verified for the SAME
+#     property (ci-build.sh, fetch-verified-nginx.sh)
+TRUST_ANCHOR_RE = re.compile(
+    r"gpg\b(?:\s+\S+)*\s+--\S*verify|sha256sum|_SHA256\b|ci-build\.sh|"
+    r"fetch-verified-nginx\.sh"
+)
+
+# A step that only DOWNLOADS (wget/curl -o) and does not itself extract or
+# execute is not a finding on its own -- the extract/exec step downstream is
+# what this check anchors on. Restricting the scan to run: text that mentions
+# a download-shaped command keeps the check from firing on, say, a `tar -xzf`
+# of a repo-local artifact this job built itself (build-test.yml's ccache /
+# coverage tarballs never leave the runner and have no external origin to
+# forge).
+DOWNLOAD_RE = re.compile(r"\b(?:wget|curl)\b.*(?:-O\b|-o\b)|actions/cache@")
+
+
+def check_provenance() -> int:
+    """An extract/execute step with no trust-anchor assertion anywhere earlier
+    in the same job is unverified code execution on the self-hosted runner.
+
+    Scoped to jobs that show a download-shaped command (wget/curl writing a
+    file, or an actions/cache restore feeding one) SOMEWHERE in the job --
+    a job with no external fetch at all has nothing for this check to gate.
+    Within such a job, every extract/exec step must be preceded (same step or
+    an earlier one, in source order) by a trust-anchor assertion: this check
+    does not attempt to prove the anchor covers the SAME artifact byte for
+    byte, only that the job asserts one at all before it unpacks or runs
+    something -- the gap this exists to close is "no check ran", not "the
+    check that ran was subtly wrong".
+    """
+    errors: list[str] = []
+    for path in workflows():
+        doc = load(path)
+        for job, node in jobs(doc):
+            runs = _steps(node)
+            if not any(DOWNLOAD_RE.search(r) for r in runs):
+                continue
+            anchored = False
+            for i, run in enumerate(runs):
+                if TRUST_ANCHOR_RE.search(run):
+                    anchored = True
+                extract = EXTRACT_OR_EXEC_RE.search(run)
+                if extract is not None:
+                    # Same-step trust anchor still counts: a script/step
+                    # written as one shell block can verify then extract in
+                    # sequence, same as the ordering check's same-step case.
+                    if anchored or TRUST_ANCHOR_RE.search(run[: extract.start()]):
+                        continue
+                    errors.append(
+                        f"{path.name}:{job} step {i + 1} extracts or executes "
+                        "a downloaded artifact with no gpg/sha256 trust-anchor "
+                        "assertion earlier in the job -- verify before "
+                        "extraction/execution, cache-hit path included"
+                    )
+    return report(
+        "lint-ci-provenance",
+        errors,
+        "every download-then-extract/execute step is trust-anchored first",
+    )
+
+
+# --------------------------------------------------------------------------
 # secrets
 
 
@@ -764,6 +854,7 @@ COMMANDS = {
     "docs": check_docs,
     "cadence": check_cadence,
     "secrets": check_secrets,
+    "provenance": check_provenance,
 }
 
 

--- a/ci/linter/workflow_policy.py
+++ b/ci/linter/workflow_policy.py
@@ -628,18 +628,46 @@ def check_cadence() -> int:
 # actual privilege boundary, not the download line above it.
 EXTRACT_OR_EXEC_RE = re.compile(
     r"(?<![\w-])tar\s+-?x|(?<![\w-])unzip\b|(?<![\w-])/tmp/actionlint\b"
+    # Direct execution of a fetched artifact, without any unpacking step in
+    # between: `chmod +x tool && ./tool`, or a bare `./tool` / `./tool/x`
+    # invocation. A standalone downloaded executable is the same privilege
+    # boundary as an unpacked tarball, and the tar/unzip patterns above miss
+    # it entirely. Deliberately textual and therefore approximate: this
+    # matches a relative-path invocation whether or not the file came from
+    # the network, which is safe here because the whole check is already
+    # scoped to jobs that DO fetch something (see DOWNLOAD_RE).
+    r"|(?<![\w./-])\./[\w.-]+"
 )
 
 # What counts as a trust-anchor assertion having been made ON THIS PATH
 # before the extract/exec point. Any one of:
 #   - a detached-signature check (gpg --verify)
-#   - a checksum comparison (sha256sum, and the pinned-hash variable naming
-#     convention this repo uses: *_SHA256)
+#   - a checksum COMPARISON -- `sha256sum -c`, or a digest captured into a
+#     variable that is then tested against a pinned `*_SHA256`
 #   - delegating to a helper this repo already verified for the SAME
 #     property (ci-build.sh, fetch-verified-nginx.sh)
+#
+# A bare `sha256sum tool.tgz` PRINTS a digest and compares nothing, and a
+# lone `FOO_SHA256:` env declaration is a pinned value nothing tests. Both
+# used to satisfy this regex, so a job could look anchored while validating
+# no bytes at all -- the anchor half failing open the same way the scoping
+# half did. Matching a comparison means an `if`/`test`/`[`/`||`/`&&` or a
+# `-c` check must appear with the digest, not merely the digest command.
 TRUST_ANCHOR_RE = re.compile(
-    r"gpg\b(?:\s+\S+)*\s+--\S*verify|sha256sum|_SHA256\b|ci-build\.sh|"
-    r"fetch-verified-nginx\.sh"
+    # detached signature
+    r"gpg\b(?:\s+\S+)*\s+--\S*verify"
+    # sha256sum -c / --check against a manifest
+    r"|sha256sum\b[^\n]*\s-(?:c\b|-check\b)"
+    # digest captured, then compared -- either order, same step or later
+    r"|sha256sum\b[^\n]*\n?[^\n]*(?:\bif\b|\btest\b|\[|!=|==|\|\||&&)"
+    # PowerShell: Get-FileHash captured, then compared (windows-build.yml:msvc
+    # does `$actual = (Get-FileHash ...).Hash` then `if ($actual -ne $s.sha)`).
+    # -ne/-eq are the comparison operators, not != / ==.
+    r"|Get-FileHash\b[\s\S]*?(?:-ne\b|-eq\b|\bif\b)"
+    r"|(?:\bif\b|\btest\b|\[|!=|==)[^\n]*_SHA256\b"
+    r"|_SHA256\b[^\n]*(?:!=|==|\|\||&&)"
+    # helpers whose own verification this repo already reviewed
+    r"|ci-build\.sh|fetch-verified-nginx\.sh"
 )
 
 # A step that only DOWNLOADS and does not itself extract or execute is not a
@@ -677,6 +705,14 @@ def check_provenance() -> int:
     byte, only that the job asserts one at all before it unpacks or runs
     something -- the gap this exists to close is "no check ran", not "the
     check that ran was subtly wrong".
+
+    Both halves have been tightened once already after review found them
+    failing open: the scoping regex missed bare `wget <url>` / `curl -O` /
+    `Invoke-WebRequest`, which skipped whole JOBS rather than passing them,
+    and the anchor regex accepted a non-comparing `sha256sum` or an untested
+    `*_SHA256` declaration. Each spelling has its own red fixture; add one
+    with any future widening, or the claim in these comments outruns what
+    the selftest actually proves.
     """
     errors: list[str] = []
     for path in workflows():

--- a/ci/tools/fetch-verified-nginx.sh
+++ b/ci/tools/fetch-verified-nginx.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Download an nginx release tarball and verify its detached PGP signature
+# against the signer keys VENDORED in ci/tools/keys/ (never fetched from
+# nginx.org at CI time -- see ci-build.sh's file header for why bootstrapping
+# the keys from the same origin that serves the tarball+signature would let
+# an origin compromise substitute all three, audit sha e289021 F3).
+#
+# This is the same verification ci-build.sh performs before a full test-suite
+# build, factored out for the CI jobs that only need a source tree to
+# configure headers from (scan-build, clang-tidy) or to build a debug binary
+# for a Valgrind soak (memcheck, helgrind) -- neither wants ci-build.sh's
+# .build/ cache tree, coverage mode or dynamic-module test-suite flags.
+#
+#   ci/tools/fetch-verified-nginx.sh <version>
+#
+# On success, leaves "nginx-<version>.tar.gz" (verified) in the CURRENT
+# directory and extracts it there. A verification failure removes the
+# tarball and exits 1 -- callers must not catch and continue past this.
+set -euo pipefail
+
+VERSION="${1:?usage: fetch-verified-nginx.sh <version>}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KEYRING_DIR="$SCRIPT_DIR/keys"
+
+DIR="nginx-${VERSION}"
+TARBALL="${DIR}.tar.gz"
+URL="https://nginx.org/download/${TARBALL}"
+
+if [ ! -f "$TARBALL" ]; then
+    wget -q -O "$TARBALL" "$URL"
+fi
+wget -q -O "${TARBALL}.asc" "${URL}.asc"
+
+gnupghome="$(mktemp -d)"
+export GNUPGHOME="$gnupghome"
+chmod 700 "$gnupghome"
+for keyfile in "$KEYRING_DIR"/*.key; do
+    gpg --quiet --import "$keyfile" 2>/dev/null
+done
+
+if gpg --quiet --verify "${TARBALL}.asc" "$TARBALL"; then
+    echo "✓ PGP signature verified for ${TARBALL}"
+else
+    echo "✗ PGP signature verification FAILED for ${TARBALL}" >&2
+    rm -rf "$gnupghome" "$TARBALL" "${TARBALL}.asc"
+    exit 1
+fi
+rm -rf "$gnupghome"
+unset GNUPGHOME
+
+tar -xzf "$TARBALL"


### PR DESCRIPTION
## TL;DR

Several CI steps downloaded an artifact and then unpacked or executed it with
no signature or checksum check: actionlint, the nginx source used to
configure scan-build/clang-tidy headers, libzstd 1.4.x, and the nginx builds
in the Memcheck and Helgrind soaks. `ci/tools/ci-build.sh`'s build matrix was
already fixed by an earlier audit; these direct-download paths regressed the
same class outside it.

Every extract/execute site now verifies before unpacking: actionlint and
libzstd 1.4.x get a pinned sha256 (neither publishes a detached signature);
the four nginx-source sites route through a new `ci/tools/fetch-verified-nginx.sh`,
factored out of `ci-build.sh`'s PGP-against-vendored-keys check for callers
that only need a source tree rather than a full test build.

**Severity:** `High` (`security — unverified code execution on a self-hosted runner`)

## Mechanism

`fetch-verified-nginx.sh` downloads `nginx-<version>.tar.gz` + `.asc`,
imports `ci/tools/keys/*.key` into a scratch `GNUPGHOME`, runs
`gpg --verify`, and only then extracts — removing the tarball and exiting 1
on failure. It replaces the raw `wget`+`tar -xzf` in:

- `build-test.yml`'s scan-build header job
- `ci-deep.yml`'s Memcheck job, Helgrind job, and clang-tidy/flawfinder job

The Memcheck/Helgrind case matters beyond a fresh download: both jobs used
`test -f nginx-$V.tar.gz || wget ...` against a self-hosted runner's
persisted disk, so a tarball surviving from a prior (possibly compromised)
run was previously trusted with no re-check. The helper verifies
unconditionally regardless of whether it downloaded or found the file
already present.

actionlint and libzstd get pinned sha256 instead, since neither publishes a
detached signature for release assets; libzstd's check runs unconditionally
after the `actions/cache` restore step, so a cache hit is re-verified exactly
like a fresh download.

Added `ci/linter/workflow_policy.py provenance` (wired as `ci-provenance`
into `run-all.sh`/`lint.yml`): flags any step that extracts an archive or
executes a downloaded artifact with no `gpg --verify`/`sha256sum`/
`_SHA256`-pin/known-helper call earlier in the same job — including on the
`actions/cache` cache-hit path, which the check treats as no more trusted
than a fresh download.

## Testing

- `bash ci/linter/selftest.sh` — all controls held, including the new
  `provenance-unverified-extract` (red), `provenance-verified-ok` (green),
  and `provenance-cache-hit-skips-verify` (red) fixture trio.
- Negative control 1 (corrupted artifact, fresh): appended garbage bytes to a
  real, freshly-downloaded `nginx-1.30.4.tar.gz` and re-ran
  `fetch-verified-nginx.sh 1.30.4` — exit 1, `✗ PGP signature verification
  FAILED for nginx-1.30.4.tar.gz`, tarball removed, no extraction.
- Negative control 1b (corrupted artifact, cache-hit-equivalent): placed a
  garbage-content `nginx-1.30.4.tar.gz` on disk before running the script
  (simulating a poisoned `actions/cache` restore) — same failure, same exit
  1, no extraction, confirming the always-verify shape holds regardless of
  which path produced the file.
- Negative control 2 (delete a verification line): replaced the Memcheck
  job's `fetch-verified-nginx.sh` call with a raw unverified
  `wget`+`tar -xzf`, then ran `python3 ci/linter/workflow_policy.py
  provenance` — exit 1, `ci-deep.yml:memcheck step 4 extracts or executes a
  downloaded artifact with no gpg/sha256 trust-anchor assertion earlier in
  the job`. Reverted and reran clean (exit 0).
- `ci/tools/test_ci_build_provenance.sh` (existing regression suite for
  `ci-build.sh`'s own F2/F3 fixes, untouched by this PR) still passes.
- `.claude/skills/_shared/review-lint.sh --diff HEAD`: shellcheck/actionlint/
  zizmor/mypy clean on every real workflow and script touched; the only
  zizmor/checkov findings are `permissions:`-less test fixture files, which
  match every pre-existing fixture in `ci/linter/fixtures/policy/`.

## Left undone

- The `build` matrix job in `build-test.yml` currently only ever resolves
  `flavor: nginx` (the `resolve` job's matrix has no angie entry), so its
  `if: matrix.flavor == 'nginx'`-gated PGP check covers the only flavor
  reachable there today. If an angie leg is ever added to that matrix
  directly (rather than through `ci-build.sh`, which already has
  `ANGIE_SHA256`), it will need its own sha256 pin — flagged here rather than
  speculatively added since no such leg exists yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened CI artifact handling by requiring checksum or signature verification before archives are extracted or executed.
  * Ensured cached downloads receive the same verification checks as newly downloaded files.
  * Improved verification of nginx and other build-tool sources, with failed validation preventing continued processing.

* **New Features**
  * Added CI provenance checks covering common download methods, cache paths, and workflow extraction scenarios.

* **Tests**
  * Added positive and negative coverage for verified and unverified artifact workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->