### PR TITLE
fix: stop nginx -t dying with SIGFPE on zstd_long + zstd_max_cctx_memory

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1506,6 +1506,15 @@ jobs:
             --nginx-binary "$TEST_NGINX_BINARY" \
             --port 18104 --backend-port 18105
           echo "✓ window-cap + dictionary effect test passed"
+          # Config-load regression: "zstd_long on" + "zstd_max_cctx_memory"
+          # made nginx -t die with SIGFPE, because libzstd's estimator
+          # divides by an LDM sub-parameter that is only derived lazily
+          # during compression setup. ci/t/00-filter.t cannot cover this:
+          # its "--- must_die" cannot distinguish a crash from a
+          # diagnostic. This asserts on the exit status and its sign.
+          python3 ci/tools/test_ldm_budget_config.py \
+            --nginx-binary "$TEST_NGINX_BINARY" --port 18124
+          echo "✓ zstd_long + zstd_max_cctx_memory config validation passed"
 
       - name: Run RFC 9842 dcz end-to-end test
         timeout-minutes: 6
@@ -1947,6 +1956,8 @@ jobs:
           python3 ci/tools/test_terminal_frame.py --nginx-binary "$TEST_NGINX_BINARY" --port 19093
           python3 ci/tools/test_window_cap.py \
             --nginx-binary "$TEST_NGINX_BINARY" --port 19104 --backend-port 19105
+          python3 ci/tools/test_ldm_budget_config.py \
+            --nginx-binary "$TEST_NGINX_BINARY" --port 19122
           python3 ci/tools/test_zstd_long_ldm.py \
             --nginx-binary "$TEST_NGINX_BINARY" --port 19102 --backend-port 19103
           python3 ci/tools/test_dcz.py --nginx-binary "$TEST_NGINX_BINARY" \

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,22 @@
 Changes with http-zstd
 
+    *) Bugfix: "nginx -t" no longer dies with SIGFPE when "zstd_long on"
+       is combined with "zstd_max_cctx_memory". The config-load budget
+       check calls ZSTD_estimateCStreamSize_usingCCtxParams(), which
+       divides by the LDM hash rate. libzstd derives its long-distance
+       matching sub-parameters lazily during compression setup, so a
+       ZSTD_CCtx_params that had only had enableLongDistanceMatching set
+       still carried a zero divisor and the whole process died on a
+       floating-point exception during configuration testing. Setting
+       zstd_window_log did not avoid it. The four LDM sub-parameters are
+       now seeded with the defaults libzstd documents, which both removes
+       the crash and makes the estimate accurate for long mode: it is
+       within 0.05% of a real streaming compressor's measured footprint,
+       so the configured budget keeps its meaning instead of being
+       skipped. Because enabling long mode raises the default window to
+       128 MB, "zstd_long on" now needs a budget of roughly that size, or
+       an explicit zstd_window_log to bring it down.
+
     *) Security: dcz is now offered only in a secure context, as RFC 9842
        section 8 requires. The negotiation gate checked the dictionary
        hash, the main request, the request headers and the coding weight

--- a/README.md
+++ b/README.md
@@ -619,6 +619,17 @@ server {
 }
 ```
 
+> **Interaction with `zstd_long`.** Enabling long-distance matching
+> raises libzstd's default window to 128 MB (`windowLog` 27) unless
+> `zstd_window_log` sets one explicitly, and adds the LDM hash table on
+> top. That is a large jump: level 3 costs ~3.6 MB per request without
+> `zstd_long` and ~144 MB with it. The budget check accounts for this —
+> it derives the same LDM sub-parameters libzstd would and estimates
+> against them, so `zstd_long on` with a budget below ~128 MB is
+> refused at config load rather than accepted and blown at runtime.
+> Pair `zstd_long on` with an explicit `zstd_window_log` to bring it
+> back down (level 3 with `zstd_window_log 20` costs ~2.7 MB).
+
 **Why a config-load assert and not a runtime cap.** The directive does
 **not** silently tune anything. A too-tight budget is a hard error so
 operators see the misconfiguration up front, instead of discovering it

--- a/ci/tools/config_bench.py
+++ b/ci/tools/config_bench.py
@@ -152,6 +152,23 @@ PROFILE_TUPLES: list[tuple[int, str, int]] = [
     (1, "off", 0),
 ]
 
+# The multi-profile workload's per-request memory budget.
+#
+# Two of the tuples above enable long-distance matching at a large window
+# (level 9 / windowLog 27 and level 12 / windowLog 30). zstd_max_cctx_memory
+# is validated at config load against libzstd's own estimator, and those two
+# profiles genuinely need ~156 MB and ~1.14 GB of per-request compressor
+# memory respectively -- so the 32m this workload used to emit is a budget
+# they cannot satisfy, and nginx correctly refuses the configuration.
+#
+# This workload measures config-LOAD COST as a function of the number of
+# distinct profiles; the budget is fixture shape, not the thing under
+# measurement. So it is raised to a value every tuple fits in rather than
+# dropping the LDM tuples, which would change what the benchmark measures.
+# Keep this above the largest estimate any PROFILE_TUPLES entry produces.
+# (nginx size values accept only k/m suffixes, so this is spelled in MB.)
+MULTI_PROFILE_BUDGET = "2048m"
+
 # The self-check's floor. Between the smallest and largest scale point, the
 # measured config-load cost must rise by at least this factor, or the harness
 # has not demonstrated that it can see config scale at all.
@@ -284,7 +301,7 @@ def generate_config(
                 f"        zstd_comp_level {level};\n"
                 f"        zstd_long {long_mode};\n"
                 f"{win}"
-                f"        zstd_max_cctx_memory 32m;\n"
+                f"        zstd_max_cctx_memory {MULTI_PROFILE_BUDGET};\n"
                 f"    }}\n"
             )
 

--- a/ci/tools/test_ldm_budget_config.py
+++ b/ci/tools/test_ldm_budget_config.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Config-load regression: ``zstd_long`` + ``zstd_max_cctx_memory``.
+
+``ZSTD_estimateCStreamSize_usingCCtxParams()`` divides by
+``params.ldmParams.hashRateLog``. libzstd derives the LDM sub-parameters
+lazily during compression setup, so a ``ZSTD_CCtx_params`` that has only
+had ``ZSTD_c_enableLongDistanceMatching`` set still carries
+``hashRateLog == 0``. The config-load budget check called the estimator
+on exactly such a params object, so ``nginx -t`` died with **SIGFPE**
+(exit 136) for any configuration combining ``zstd_long on`` with
+``zstd_max_cctx_memory``. Setting ``zstd_window_log`` did not avoid it --
+the divisor is unrelated to the window.
+
+Why this test is not folded into ``ci/t/00-filter.t``: that harness's
+``--- must_die`` cannot tell a crash from a diagnostic. A SIGFPE and a
+clean ``[emerg]`` both "die", so a ``must_die`` block would have passed
+against the crashing build and proved nothing. This test asserts on the
+**exit status and its sign** -- a negative ``returncode`` (or 128+N) is a
+signal and always a failure, whatever the message says.
+
+Arms
+----
+1. ``zstd_long on`` + ``zstd_max_cctx_memory 256m``  -> must PASS.
+   The regression arm. Pre-fix: SIGFPE.
+2. ``zstd_long on`` + ``zstd_max_cctx_memory 64m``   -> must be REFUSED
+   with a diagnostic naming the budget. This is the arm that keeps the
+   fix honest: it proves the estimate is still *enforced* under LDM
+   rather than skipped, so the operator does not silently lose the bound
+   they asked for. It also pins the magnitude -- the seeded estimate must
+   land in the >=128 MB range that LDM's 128 MB default window implies,
+   which is what distinguishes a correctly seeded estimate from one
+   computed against the level's much smaller default window.
+3. ``zstd_long on`` + ``zstd_window_log 20`` + ``64m`` -> must PASS.
+   A capped window brings the same profile back under the same budget,
+   proving arm 2's refusal is a real measurement and not a blanket
+   "LDM always fails".
+4. ``zstd_max_cctx_memory 256m`` alone (no LDM)      -> must PASS.
+5. ``zstd_long on`` alone (no budget)                -> must PASS.
+
+Arms 4 and 5 are the controls: both passed on the crashing build too, so
+they are what stops this test from going vacuous if the estimator block
+is ever short-circuited or compiled out entirely.
+"""
+
+import argparse
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+# LDM raises libzstd's default windowLog to 27 (128 MB). A correctly
+# seeded estimate for level 3 + LDM with no zstd_window_log is therefore
+# ~144 MB (measured 144328225 against libzstd 1.5.7; a real streaming
+# ZSTD_CCtx over 256 MB of input reported ZSTD_sizeof_CCtx() 144262689).
+# An estimate computed against the level's default window instead would
+# be ~3.6 MB, two orders of magnitude low, and would wrongly fit in the
+# 64 MB budget of arm 2.
+MIN_EXPECTED_LDM_ESTIMATE = 128 * 1024 * 1024
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--nginx-binary", required=True)
+    p.add_argument("--filter-module")
+    p.add_argument("--port", type=int, default=18099)
+    return p.parse_args()
+
+
+def detect_module(explicit, nginx: pathlib.Path):
+    if explicit:
+        return pathlib.Path(explicit)
+    sib = nginx.parent / "ngx_http_zstd_filter_module.so"
+    return sib if sib.exists() else None
+
+
+def config_test(nginx: pathlib.Path, module, port: int, directives: str):
+    """Run ``nginx -t`` on a minimal config; return (returncode, output)."""
+    with tempfile.TemporaryDirectory() as td:
+        root = pathlib.Path(td)
+        (root / "conf").mkdir()
+        (root / "logs").mkdir()
+
+        load = f"load_module {module};\n" if module else ""
+        (root / "conf" / "nginx.conf").write_text(
+            f"{load}"
+            "events {}\n"
+            "http {\n"
+            f"    server {{\n"
+            f"        listen 127.0.0.1:{port};\n"
+            "        zstd on;\n"
+            f"        {directives}\n"
+            "    }\n"
+            "}\n"
+        )
+
+        proc = subprocess.run(
+            [str(nginx), "-p", str(root), "-c", "conf/nginx.conf", "-t"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        return proc.returncode, proc.stdout + proc.stderr
+
+
+def check_not_a_signal(name: str, rc: int, out: str) -> list:
+    """The core assertion: nginx -t must never terminate on a signal."""
+    if rc < 0:
+        return [
+            (
+                f"{name}: nginx -t died on signal {-rc} "
+                f"(SIGFPE is 8); output: {out.strip()!r}"
+            )
+        ]
+    if rc > 128:
+        return [
+            (
+                f"{name}: nginx -t exited {rc} (128+{rc - 128}), which is "
+                f"a signal death, not a diagnostic; output: "
+                f"{out.strip()!r}"
+            )
+        ]
+    return []
+
+
+def main() -> int:
+    args = parse_args()
+    nginx = pathlib.Path(args.nginx_binary).resolve()
+    if not nginx.exists():
+        print(f"FAIL: nginx binary not found: {nginx}", file=sys.stderr)
+        return 1
+
+    module = detect_module(args.filter_module, nginx)
+    if module is not None:
+        module = module.resolve()
+        if not module.exists():
+            print(f"FAIL: filter module not found: {module}", file=sys.stderr)
+            return 1
+
+    failures = []
+
+    # --- Arm 1: the regression. Pre-fix this was SIGFPE / exit 136. -----
+    rc, out = config_test(
+        nginx, module, args.port, "zstd_long on; zstd_max_cctx_memory 256m;"
+    )
+    failures += check_not_a_signal("arm1 ldm+256m", rc, out)
+    if rc != 0:
+        failures.append(
+            f"arm1 ldm+256m: expected nginx -t to succeed (level 3 + LDM "
+            f"needs ~144 MB, which fits in 256m) but it exited {rc}; "
+            f"output: {out.strip()!r}"
+        )
+    print(f"  arm1 zstd_long + 256m           -> exit {rc} (want 0)")
+
+    # --- Arm 2: the budget is still ENFORCED under LDM. ----------------
+    rc, out = config_test(
+        nginx, module, args.port, "zstd_long on; zstd_max_cctx_memory 64m;"
+    )
+    failures += check_not_a_signal("arm2 ldm+64m", rc, out)
+    if rc == 0:
+        failures.append(
+            "arm2 ldm+64m: nginx -t SUCCEEDED, but level 3 + LDM needs "
+            "~144 MB, which exceeds the 64m budget. The operator asked "
+            "for a bound and silently did not get one -- the estimator "
+            "is either skipping LDM profiles or sizing against the "
+            "wrong window."
+        )
+    else:
+        if "zstd_max_cctx_memory" not in out:
+            failures.append(
+                f"arm2 ldm+64m: refused, but the diagnostic does not name "
+                f'"zstd_max_cctx_memory", so the operator cannot tell why: '
+                f"{out.strip()!r}"
+            )
+        m = re.search(r"need ~(\d+) bytes", out)
+        if not m:
+            failures.append(
+                f"arm2 ldm+64m: diagnostic does not report the estimated "
+                f"byte count: {out.strip()!r}"
+            )
+        elif int(m.group(1)) < MIN_EXPECTED_LDM_ESTIMATE:
+            failures.append(
+                f"arm2 ldm+64m: estimate {m.group(1)} bytes is below "
+                f"{MIN_EXPECTED_LDM_ESTIMATE}. LDM raises the default "
+                f"windowLog to 27 (128 MB), so a correctly seeded estimate "
+                f"cannot be this small -- the LDM sub-parameters were not "
+                f"seeded and the estimate was computed against the level's "
+                f"default window."
+            )
+        else:
+            print(f"  arm2 estimate reported          -> {m.group(1)} bytes")
+    print(f"  arm2 zstd_long + 64m            -> exit {rc} (want non-zero)")
+
+    # --- Arm 3: a capped window fits the same budget. ------------------
+    rc, out = config_test(
+        nginx,
+        module,
+        args.port,
+        "zstd_long on; zstd_window_log 20; zstd_max_cctx_memory 64m;",
+    )
+    failures += check_not_a_signal("arm3 ldm+wl20+64m", rc, out)
+    if rc != 0:
+        failures.append(
+            f"arm3 ldm+wl20+64m: expected success (a 2^20 window under LDM "
+            f"needs ~2.7 MB, well inside 64m) but nginx -t exited {rc}. "
+            f"Arm 2's refusal is therefore a blanket rejection of LDM, not "
+            f"a measurement; output: {out.strip()!r}"
+        )
+    print(f"  arm3 zstd_long + wl20 + 64m     -> exit {rc} (want 0)")
+
+    # --- Arm 4 (control): budget alone, no LDM. -----------------------
+    rc, out = config_test(nginx, module, args.port, "zstd_max_cctx_memory 256m;")
+    failures += check_not_a_signal("arm4 256m only", rc, out)
+    if rc != 0:
+        failures.append(
+            f"arm4 256m only (control): exited {rc}; output: {out.strip()!r}"
+        )
+    print(f"  arm4 256m alone (control)       -> exit {rc} (want 0)")
+
+    # --- Arm 5 (control): LDM alone, no budget. -----------------------
+    rc, out = config_test(nginx, module, args.port, "zstd_long on;")
+    failures += check_not_a_signal("arm5 ldm only", rc, out)
+    if rc != 0:
+        failures.append(
+            f"arm5 ldm only (control): exited {rc}; output: {out.strip()!r}"
+        )
+    print(f"  arm5 zstd_long alone (control)  -> exit {rc} (want 0)")
+
+    if failures:
+        print("\nFAIL: zstd_long + zstd_max_cctx_memory config test", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+
+    print("\nOK: zstd_long + zstd_max_cctx_memory config validation (5/5 arms)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -259,6 +259,22 @@ typedef struct {
 #define NGX_HTTP_ZSTD_LEVEL_UNSET  (-NGX_MAX_INT_T_VALUE - 1)
 
 
+/*
+ * libzstd's documented defaults for the long-distance-matching
+ * sub-parameters (see the ZSTD_c_ldm* comments in zstd.h). They are
+ * derived lazily inside compression setup, so a ZSTD_CCtx_params that
+ * has only had ZSTD_c_enableLongDistanceMatching set still carries
+ * zeroes -- which makes ZSTD_estimateCStreamSize_usingCCtxParams()
+ * divide by zero. The config-load budget check seeds them explicitly.
+ *
+ * NGX_HTTP_ZSTD_LDM_WINDOWLOG is the window (128 MB) libzstd itself
+ * switches to when LDM is enabled without an explicit ZSTD_c_windowLog.
+ */
+#define NGX_HTTP_ZSTD_LDM_WINDOWLOG      27
+#define NGX_HTTP_ZSTD_LDM_MINMATCH       64
+#define NGX_HTTP_ZSTD_LDM_BUCKETSIZELOG  3
+
+
 static ngx_http_output_header_filter_pt  ngx_http_next_header_filter;
 static ngx_http_output_body_filter_pt  ngx_http_next_body_filter;
 
@@ -2878,6 +2894,8 @@ close:
         }
 
         if (conf->long_mode) {
+            ngx_int_t  ldm_wlog, ldm_hlog, ldm_rlog;
+
             srv = ZSTD_CCtxParams_setParameter(
                       cp, ZSTD_c_enableLongDistanceMatching, 1);
             if (ZSTD_isError(srv)) {
@@ -2886,6 +2904,119 @@ close:
                                    "ZSTD_CCtxParams_setParameter("
                                    "enableLongDistanceMatching) failed: %s",
                                    ZSTD_getErrorName(srv));
+                return NGX_CONF_ERROR;
+            }
+
+            /*
+             * BLOCKER fix: ZSTD_estimateCStreamSize_usingCCtxParams()
+             * divides by params->ldmParams.hashRateLog. libzstd derives
+             * the LDM sub-parameters lazily, inside compression setup --
+             * a ZSTD_CCtx_params that has only had
+             * ZSTD_c_enableLongDistanceMatching set still carries
+             * hashRateLog == 0, so the estimator divides by zero and the
+             * whole process dies with SIGFPE during "nginx -t". Setting
+             * ZSTD_c_windowLog does not help: the divisor is unrelated to
+             * the window.
+             *
+             * There is no public "adjust these params the way you would
+             * internally" entry point, so we derive the same four values
+             * libzstd documents in zstd.h and push them explicitly. From
+             * the ZSTD_c_ldm* documentation:
+             *
+             *   - enabling LDM raises the default windowLog to 27
+             *     (128 MB) unless windowLog was expressly set;
+             *   - ldmHashLog     default = windowLog - 7, clamped to
+             *                    [ZSTD_LDM_HASHLOG_MIN,
+             *                     ZSTD_LDM_HASHLOG_MAX];
+             *   - ldmMinMatch    default = 64;
+             *   - ldmBucketSizeLog default = 3;
+             *   - ldmHashRateLog default = MAX(0, windowLog - ldmHashLog).
+             *
+             * Seeding these makes the estimate accurate rather than
+             * merely non-crashing. Measured against a real streaming
+             * ZSTD_CCtx compressing 256 MB with unknown content size
+             * (libzstd 1.5.7, level 3): seeded estimate 144328225 bytes
+             * vs. ZSTD_sizeof_CCtx() 144262689 -- 0.05% conservative.
+             * With "zstd_window_log 20": 2705953 vs. 2705441, 0.02%
+             * conservative. So the operator's budget still means what it
+             * says under LDM; we neither crash nor silently drop the
+             * bound, and we do not manufacture spurious rejections.
+             *
+             * Note that windowLog is pushed explicitly here even when the
+             * operator did not configure one: the estimator must see the
+             * same 27 that libzstd would default to under LDM, otherwise
+             * it would size for the level's much smaller default window
+             * and under-report by two orders of magnitude.
+             */
+
+            ldm_wlog = conf->window_log > 0 ? conf->window_log
+                                            : NGX_HTTP_ZSTD_LDM_WINDOWLOG;
+
+            ldm_hlog = ldm_wlog - 7;
+            if (ldm_hlog < ZSTD_LDM_HASHLOG_MIN) {
+                ldm_hlog = ZSTD_LDM_HASHLOG_MIN;
+            }
+            if (ldm_hlog > ZSTD_LDM_HASHLOG_MAX) {
+                ldm_hlog = ZSTD_LDM_HASHLOG_MAX;
+            }
+
+            ldm_rlog = ldm_wlog - ldm_hlog;
+            if (ldm_rlog < 0) {
+                ldm_rlog = 0;
+            }
+
+            srv = ZSTD_CCtxParams_setParameter(cp, ZSTD_c_windowLog,
+                                               (int) ldm_wlog);
+            if (!ZSTD_isError(srv)) {
+                srv = ZSTD_CCtxParams_setParameter(cp, ZSTD_c_ldmHashLog,
+                                                   (int) ldm_hlog);
+            }
+            if (!ZSTD_isError(srv)) {
+                srv = ZSTD_CCtxParams_setParameter(
+                          cp, ZSTD_c_ldmMinMatch,
+                          NGX_HTTP_ZSTD_LDM_MINMATCH);
+            }
+            if (!ZSTD_isError(srv)) {
+                srv = ZSTD_CCtxParams_setParameter(
+                          cp, ZSTD_c_ldmBucketSizeLog,
+                          NGX_HTTP_ZSTD_LDM_BUCKETSIZELOG);
+            }
+            if (!ZSTD_isError(srv)) {
+                srv = ZSTD_CCtxParams_setParameter(cp, ZSTD_c_ldmHashRateLog,
+                                                   (int) ldm_rlog);
+            }
+
+            if (ZSTD_isError(srv)) {
+                ZSTD_freeCCtxParams(cp);
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                   "ZSTD_CCtxParams_setParameter() failed "
+                                   "while deriving the \"zstd_long\" "
+                                   "parameters for the "
+                                   "\"zstd_max_cctx_memory\" estimate: %s",
+                                   ZSTD_getErrorName(srv));
+                return NGX_CONF_ERROR;
+            }
+
+            /*
+             * Defence in depth. The derivation above is the documented
+             * one, but it is libzstd's documentation rather than a
+             * contract enforced by a public API, and a future release
+             * could add a fifth divisor-bearing sub-parameter. Rather
+             * than risk another SIGFPE taking out "nginx -t", refuse the
+             * configuration if the estimate would still be computed from
+             * a zero divisor we know about.
+             */
+            if (ldm_rlog <= 0) {
+                ZSTD_freeCCtxParams(cp);
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                   "\"zstd_max_cctx_memory\" cannot be "
+                                   "verified for this \"zstd_long\" "
+                                   "profile: the derived LDM hash rate is "
+                                   "zero (window_log %i). Raise "
+                                   "\"zstd_window_log\", disable "
+                                   "\"zstd_long\", or remove "
+                                   "\"zstd_max_cctx_memory\"",
+                                   (ngx_int_t) ldm_wlog);
                 return NGX_CONF_ERROR;
             }
         }


### PR DESCRIPTION
> Found while working the crash reported against `master` at `947a8b4`. Independent of the `Vary` work in #163; this touches only the config-load memory-budget check.

## TL;DR

If you asked nginx to use zstd's "long mode" and also gave it a memory limit for compression, the config check didn't just complain — it killed the process outright, with no message at all. Either setting on its own was fine; only the pair was fatal. That means an operator who set both would find their server refusing to start, or a reload failing, with nothing in the log explaining why.

`ngx_http_zstd_merge_loc_conf()` now seeds the four long-distance-matching sub-parameters before calling `ZSTD_estimateCStreamSize_usingCCtxParams()`, which previously divided by a zero `ldmHashRateLog` and raised `SIGFPE`.

**Severity:** `High` (`availability — nginx -t and reload die on a signal for a documented, valid configuration`)

## The crash

`zstd_max_cctx_memory` is validated at config load against libzstd's own estimator. That estimator divides by `params->ldmParams.hashRateLog`.

libzstd derives the LDM sub-parameters *lazily*, inside compression setup. A `ZSTD_CCtx_params` that has only had `ZSTD_c_enableLongDistanceMatching` set still carries `hashRateLog == 0`, so the estimator divides by zero and takes the process with it.

Reproduced on a clean `947a8b4` build, nginx 1.31.4, libzstd 1.5.7:

```nginx
zstd on;
zstd_long on;
zstd_max_cctx_memory 256m;
```

```
$ objs/nginx -p <dir> -c conf/nginx.conf -t
Floating point exception     # exit 136
```

Both single-directive arms exit 0 on the same binary, so this is exactly the conjunction: the budget is what makes the estimator run, and long mode is what makes it divide by zero. Setting `zstd_window_log` does not help — the divisor is unrelated to the window, which is the part that cost the most time to establish.

## The fix, and why seeding rather than skipping

libzstd exposes no public "adjust these params the way you would internally" call, so the four defaults documented in the `ZSTD_c_ldm*` comments in `zstd.h` are derived and pushed explicitly:

| sub-parameter | seeded value |
|---|---|
| `windowLog` | operator's `zstd_window_log`, else `27` — enabling LDM raises libzstd's own default to 128 MB |
| `ldmHashLog` | `windowLog - 7`, clamped to `[ZSTD_LDM_HASHLOG_MIN, ZSTD_LDM_HASHLOG_MAX]` |
| `ldmMinMatch` | `64` |
| `ldmBucketSizeLog` | `3` |
| `ldmHashRateLog` | `MAX(0, windowLog - ldmHashLog)` |

The obvious cheaper option was to detect the profile and skip enforcement with a warning. I rejected it because seeding turns out to produce an estimate that is *accurate*, not merely non-crashing — so there is no reason to hand the operator a warning instead of the bound they asked for.

Measured against a real streaming `ZSTD_CCtx` compressing 256 MB with unknown content size, libzstd 1.5.7, level 3:

| profile | seeded estimate | measured `ZSTD_sizeof_CCtx()` | error |
|---|---|---|---|
| `zstd_long on`, no window cap | 144328225 | 144262689 | +0.05% |
| `zstd_long on`, `zstd_window_log 20` | 2705953 | 2705441 | +0.02% |

Pushing `windowLog` explicitly is load-bearing rather than tidiness: without it the estimator sizes against the level's default window and under-reports by two orders of magnitude (~3.6 MB instead of ~144 MB), which would quietly accept configurations that blow the budget at runtime.

A defensive refusal covers a derived hash rate of zero. It is unreachable with current libzstd — the clamp floor keeps it positive even at `zstd_window_log 10` — but if a future release adds another lazily-derived divisor, the estimator degrades to a diagnostic instead of back to a crash.

## Operator-visible consequence

Enabling long mode implies a 128 MB window, so `zstd_long on` now needs a budget of roughly that size unless `zstd_window_log` brings it down:

```
nginx: [emerg] the configured zstd parameters need ~144328225 bytes of
per-request compressor memory, which exceeds "zstd_max_cctx_memory"
67108864; lower "zstd_comp_level" (currently 3), lower "zstd_window_log",
disable "zstd_long", or raise the budget
```

That refusal is correct and is the point of the directive — the memory really is needed. Nobody loses a bound silently. `README.md` gains a note giving both figures so the 128 MB jump is not a surprise, and `CHANGES` records the behaviour change.

`ci/tools/config_bench.py`'s multi-profile workload emitted two LDM profiles under a `32m` budget, which are now correctly refused (they genuinely need ~156 MB and ~1.14 GB). Its fixture budget is raised to `2048m`. That workload measures config-load *cost*, not the budget, so raising it preserves what the benchmark measures rather than dropping the LDM tuples. Those configurations were already broken — pre-fix they crashed rather than loading.

## Testing

New: `ci/tools/test_ldm_budget_config.py`, wired into the `tests` and `coverage` jobs.

It lives outside `ci/t/00-filter.t` deliberately. That harness's `--- must_die` cannot tell a crash from a diagnostic — a `SIGFPE` and a clean `[emerg]` both "die" — so a `must_die` block would have passed against the crashing build and proved nothing. This test asserts on the exit status *and its sign*.

Five arms, all observed:

| arm | expected |
|---|---|
| `zstd_long on` + `256m` | pass — the regression |
| `zstd_long on` + `64m` | refused, diagnostic names the budget, estimate ≥ 128 MB |
| `zstd_long on` + `zstd_window_log 20` + `64m` | pass |
| `256m` alone | pass — control |
| `zstd_long on` alone | pass — control |

Arm 2 pins the magnitude, so an estimator that silently stopped seeding would fail it rather than pass with a plausible-looking small number. Arms 4 and 5 passed on the crashing build too, which is what stops the whole test going vacuous if the estimator block is ever short-circuited.

**Negative control, run rather than reasoned about.** Reverting the source and rebuilding (`ngx_http_zstd_filter_module.so` 151656 bytes, versus 153464 with the fix) turns arms 1–3 red with `nginx -t died on signal 8`, while arms 4 and 5 stay green. Restoring and rebuilding returns 5/5.

Also run locally against the rebuilt release binary:

* `ci/t/00-filter.t` — 1191 assertions, 0 failures
* `ci/t/02-conf-warn.t` — 67, `ci/t/03-dcz.t` — 115, 0 failures
* `ci/tools/test_cctx_reuse.py`, `ci/tools/test_zstd_long_ldm.py` — pass
* `zstd_window_log` sweep 10→31 with `zstd_long on`: no signal at any value; `31` correctly reports 2285389345 bytes over a `2048m` budget
* `review-lint.sh --branch master` — clean on the diff's own lines, no `coverage gap` block (every lens had its tool)

## Not in this PR

`config_bench.py`'s self-check floor (`SCALE_MIN_HI_SECONDS = 0.05`) is unreachable on fast hardware — 4000 locations load in 27–33 ms, so both location workloads abort before reporting a curve. Pre-existing and environmental: the untouched same-profile workload fails identically, and the harness is not wired into any workflow. Ledgered rather than fixed here.
