### PR TITLE
security(dict): reject non-regular dictionary paths, add strict trust policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This is a hardened fork: every push/PR is exercised against **nginx mainline**, 
     * [zstd_bypass](#zstd_bypass)
     * [zstd_bypass_vary](#zstd_bypass_vary)
     * [zstd_dict_file](#zstd_dict_file)
+    * [zstd_dict_strict_path](#zstd_dict_strict_path)
     * [zstd_dcz_dict_file](#zstd_dcz_dict_file)
     * [zstd_dcz_assume_secure_transport](#zstd_dcz_assume_secure_transport)
   * [ngx_http_zstd_static_module](#ngx_http_zstd_static_module)
@@ -808,6 +809,29 @@ http {
             add_header X-Zstd-Dict "api.dict-v1" always;
         }
     }
+}
+```
+
+---
+
+### zstd_dict_strict_path
+
+**Syntax:** `zstd_dict_strict_path on | off;`
+**Default:** `off`
+**Context:** `http`
+
+Both dictionary loaders ([`zstd_dict_file`](#zstd_dict_file) and [`zstd_dcz_dict_file`](#zstd_dcz_dict_file)) always reject a FIFO, socket, directory, device node, or empty file — a config-load error either way, `on` or `off`. This directive controls an *additional*, opt-in trust policy on top of that: with it `on`, both loaders also refuse a **symlink** and a target **writable by group or other**.
+
+> **Why it matters.** A root master reloads its configuration (`nginx -s reload` or a supervisor-driven SIGHUP) and re-reads every dictionary from disk at that moment. If the path is a symlink a less-privileged local writer can repoint, or the file itself is group/world-writable, that writer chooses or mutates the bytes the master snapshots into every worker on the next reload — without ever needing privilege to touch the running nginx process. `on` closes that: the file is opened with `O_NOFOLLOW` (refusing a symlink outright) and its mode is checked against `S_IWGRP|S_IWOTH` before a single byte is read, and the check runs against the **already-open file descriptor** — never by re-opening the path — so a rename or symlink swap after the check cannot smuggle in a different file (no TOCTOU window).
+
+> **Default is `off`.** A release-symlink layout (`/srv/current -> /srv/releases/<n>/`, with the dictionary loaded from a path through `current`) is a common, legitimate deployment pattern, and it depends on exactly the symlink indirection `on` refuses. Turning this on is a deliberate hardening step for operators who deploy dictionaries to an immutable, content-addressed path (e.g. a filename embedding the content hash) rather than through a movable symlink — do not enable it against an existing release-symlink deployment without first moving to that layout, or every reload will fail with `nginx -s reload` and the **old worker generation keeps serving** (a rejected reload never tears down the running cycle).
+
+**Example (hardened, content-addressed dictionary path):**
+
+```nginx
+http {
+    zstd_dict_strict_path on;
+    zstd_dcz_dict_file /srv/dicts/app-a1b2c3d4.bin;
 }
 ```
 

--- a/ci/tools/test_dict_path_hardening.sh
+++ b/ci/tools/test_dict_path_hardening.sh
@@ -189,6 +189,25 @@ r=$(conf_test "    zstd_dict_strict_path on;
     zstd_dcz_dict_file $WORK/html/writable.dict;")
 check "world-writable, strict on (zstd_dcz_dict_file)" reject "$r"
 
+# ── Regression: zstd_dict_strict_path AFTER the dcz directive must not
+#    silently skip the check for a dictionary already loaded by that
+#    point. ngx_conf_parse() runs top-to-bottom, so a bare
+#    "zstd_dict_strict_path on" placed after zstd_dcz_dict_file used to
+#    read the flag as still-unset at load time and treat it as off --
+#    the dictionary loaded successfully with no error, which is the
+#    same as strict mode being silently ignored. init_main_conf() now
+#    rejects this ordering outright (a config-load error naming the
+#    file), which is what "reject" below actually verifies -- this is
+#    NOT the same case as the strict-on-BEFORE fixtures above, and
+#    without this case the ordering hazard has zero coverage.
+r=$(conf_test "    zstd_dcz_dict_file $WORK/html/writable.dict;
+    zstd_dict_strict_path on;")
+check "world-writable, strict on declared AFTER dcz directive (ordering)" reject "$r"
+
+r=$(conf_test "    zstd_dcz_dict_file $WORK/html/link.dict;
+    zstd_dict_strict_path on;")
+check "symlink, strict on declared AFTER dcz directive (ordering)" reject "$r"
+
 # ── Fixture: same world-writable file, strict off (default) accepts ───
 r=$(conf_test "    zstd_dict_file_unsafe on;
     zstd_dict_file $WORK/html/writable.dict;")

--- a/ci/tools/test_dict_path_hardening.sh
+++ b/ci/tools/test_dict_path_hardening.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+#
+# Fixture matrix for two G5 hardening rows against zstd_dict_file and
+# zstd_dcz_dict_file, both of which route through the shared
+# ngx_http_zstd_open_dict_file() helper:
+#
+#   1. "Reject non-regular dictionary inputs without letting FIFOs block
+#      config test/reload" -- neither loader used to test ngx_is_file()
+#      before reading. A FIFO opened O_RDONLY blocks the config-parsing
+#      master until a writer appears; a directory/device reaches a
+#      confusing later error. Every fixture below runs under `timeout`
+#      so a regression HANGS THE SCRIPT, not the CI job, and is reported
+#      as a failure either way.
+#
+#   2. "Strict dictionary-path trust policy for privileged reloads" --
+#      zstd_dict_strict_path on (default off) refuses a symlink and a
+#      group/world-writable target so a less-privileged local writer
+#      cannot steer or mutate what the master snapshots on the next
+#      reload. A rejected reload (SIGHUP against a mutated dictionary)
+#      must leave the OLD cycle serving, not tear the worker down.
+#
+# Usage: ci/tools/test_dict_path_hardening.sh <nginx-binary> <module-dir>
+#
+# <module-dir> holds ngx_http_zstd_filter_module.so (and the static
+# module, unused here but harmless to have loaded).
+
+set -euo pipefail
+
+NGINX="${1:?usage: test_dict_path_hardening.sh <nginx-binary> <module-dir>}"
+MODDIR="${2:?usage: test_dict_path_hardening.sh <nginx-binary> <module-dir>}"
+
+FILTER_MOD="$MODDIR/ngx_http_zstd_filter_module.so"
+if [ ! -f "$FILTER_MOD" ]; then
+    echo "❌ $FILTER_MOD not found"
+    exit 1
+fi
+
+WORK="$(mktemp -d)"
+cleanup() {
+    if [ -n "${NGINX_PID:-}" ]; then
+        kill -9 "$NGINX_PID" 2>/dev/null || true
+    fi
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+mkdir -p "$WORK/conf" "$WORK/logs" "$WORK/html"
+
+fail=0
+
+# ── nginx -t against one http_config snippet, bounded ────────────────
+# Echoes "OK"/"FAIL: <reason>" on stdout. The `timeout` is the control
+# for fixture class 1: a regression (no O_NONBLOCK) blocks in open() on
+# a FIFO, so this would hang without it rather than merely fail.
+conf_test() {
+    local snippet="$1"
+    cat >"$WORK/conf/nginx.conf" <<EOF
+daemon off;
+master_process off;
+load_module $FILTER_MOD;
+error_log $WORK/logs/error.log info;
+pid $WORK/logs/nginx.pid;
+events { worker_connections 16; }
+http {
+    access_log off;
+$snippet
+    server {
+        listen 127.0.0.1:18199;
+        location / {
+            zstd on;
+            zstd_min_length 1;
+            zstd_types text/plain;
+            default_type text/plain;
+            return 200 "ok\n";
+        }
+    }
+}
+EOF
+    if timeout 10 "$NGINX" -t -p "$WORK" -c "$WORK/conf/nginx.conf" \
+        >"$WORK/logs/t.out" 2>&1
+    then
+        echo "OK"
+    else
+        if [ "$?" -eq 124 ]; then
+            echo "FAIL: nginx -t TIMED OUT (hung open — the FIFO-block regression)"
+        else
+            echo "FAIL: $(tail -3 "$WORK/logs/t.out" | tr '\n' ' ')"
+        fi
+    fi
+}
+
+check() {
+    local name="$1" want="$2" got="$3"
+    if [ "$want" = "regular" ] && [ "$got" = "OK" ]; then
+        echo "✓ $name: OK (expected)"
+    elif [ "$want" = "reject" ] && [[ "$got" == FAIL:* ]] && [[ "$got" != *TIMED\ OUT* ]]; then
+        echo "✓ $name: rejected cleanly ($got)"
+    else
+        echo "✗ $name: want=$want got=$got"
+        fail=1
+    fi
+}
+
+# ── Fixture: regular file, must still load ───────────────────────────
+# chmod explicit: umask can leave this group-writable (e.g. 0002 ->
+# 0664), which would spuriously trip the strict-mode fixtures below
+# that are meant to start from a clean, non-writable baseline.
+head -c 8192 /dev/urandom | base64 >"$WORK/html/regular.dict"
+chmod 0644 "$WORK/html/regular.dict"
+r=$(conf_test "    zstd_dict_file_unsafe on;
+    zstd_dict_file $WORK/html/regular.dict;")
+check "regular file (zstd_dict_file)" regular "$r"
+
+r=$(conf_test "    zstd_dcz_dict_file $WORK/html/regular.dict;")
+check "regular file (zstd_dcz_dict_file)" regular "$r"
+
+# ── Fixture: FIFO ─────────────────────────────────────────────────────
+mkfifo "$WORK/html/fifo.dict"
+r=$(conf_test "    zstd_dict_file_unsafe on;
+    zstd_dict_file $WORK/html/fifo.dict;")
+check "FIFO (zstd_dict_file)" reject "$r"
+
+r=$(conf_test "    zstd_dcz_dict_file $WORK/html/fifo.dict;")
+check "FIFO (zstd_dcz_dict_file)" reject "$r"
+
+# ── Fixture: directory ────────────────────────────────────────────────
+mkdir -p "$WORK/html/dir.dict"
+r=$(conf_test "    zstd_dict_file_unsafe on;
+    zstd_dict_file $WORK/html/dir.dict;")
+check "directory (zstd_dict_file)" reject "$r"
+
+r=$(conf_test "    zstd_dcz_dict_file $WORK/html/dir.dict;")
+check "directory (zstd_dcz_dict_file)" reject "$r"
+
+# ── Fixture: UNIX domain socket ────────────────────────────────────────
+if command -v python3 >/dev/null 2>&1; then
+    python3 - "$WORK/html/sock.dict" <<'PYEOF'
+import socket, sys
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.bind(sys.argv[1])
+PYEOF
+    r=$(conf_test "    zstd_dict_file_unsafe on;
+    zstd_dict_file $WORK/html/sock.dict;")
+    check "socket (zstd_dict_file)" reject "$r"
+
+    r=$(conf_test "    zstd_dcz_dict_file $WORK/html/sock.dict;")
+    check "socket (zstd_dcz_dict_file)" reject "$r"
+else
+    echo "::warning::python3 not found; socket fixture skipped"
+fi
+
+# ── Fixture: character device (always present, harmless to open RDONLY) ─
+r=$(conf_test "    zstd_dict_file_unsafe on;
+    zstd_dict_file /dev/null;")
+check "device /dev/null (zstd_dict_file)" reject "$r"
+
+r=$(conf_test "    zstd_dcz_dict_file /dev/null;")
+check "device /dev/null (zstd_dcz_dict_file)" reject "$r"
+
+# ── Fixture: symlink, non-strict (default) accepts ────────────────────
+ln -s "$WORK/html/regular.dict" "$WORK/html/link.dict"
+r=$(conf_test "    zstd_dict_file_unsafe on;
+    zstd_dict_file $WORK/html/link.dict;")
+check "symlink, strict off / default (zstd_dict_file)" regular "$r"
+
+r=$(conf_test "    zstd_dcz_dict_file $WORK/html/link.dict;")
+check "symlink, strict off / default (zstd_dcz_dict_file)" regular "$r"
+
+# ── Fixture: symlink, strict on rejects (the release-symlink escape
+#    hatch is validated by the line above: default OFF still follows it) ─
+r=$(conf_test "    zstd_dict_strict_path on;
+    zstd_dict_file_unsafe on;
+    zstd_dict_file $WORK/html/link.dict;")
+check "symlink, strict on (zstd_dict_file)" reject "$r"
+
+r=$(conf_test "    zstd_dict_strict_path on;
+    zstd_dcz_dict_file $WORK/html/link.dict;")
+check "symlink, strict on (zstd_dcz_dict_file)" reject "$r"
+
+# ── Fixture: world-writable regular file, strict on rejects ───────────
+cp "$WORK/html/regular.dict" "$WORK/html/writable.dict"
+chmod 0666 "$WORK/html/writable.dict"
+r=$(conf_test "    zstd_dict_strict_path on;
+    zstd_dict_file_unsafe on;
+    zstd_dict_file $WORK/html/writable.dict;")
+check "world-writable, strict on (zstd_dict_file)" reject "$r"
+
+r=$(conf_test "    zstd_dict_strict_path on;
+    zstd_dcz_dict_file $WORK/html/writable.dict;")
+check "world-writable, strict on (zstd_dcz_dict_file)" reject "$r"
+
+# ── Fixture: same world-writable file, strict off (default) accepts ───
+r=$(conf_test "    zstd_dict_file_unsafe on;
+    zstd_dict_file $WORK/html/writable.dict;")
+check "world-writable, strict off / default (zstd_dict_file)" regular "$r"
+
+# ── Behavior: rejected reload leaves the OLD cycle serving ────────────
+# Start nginx on a known-good regular dictionary with strict on, then
+# SIGHUP after swapping the path in for a symlink. The reload must be
+# refused (error.log line) and the OLD worker must keep answering --
+# proving a rejected reload does not tear down the running cycle.
+cp "$WORK/html/regular.dict" "$WORK/html/live.dict"
+chmod 0644 "$WORK/html/live.dict"
+cat >"$WORK/conf/nginx.conf" <<EOF
+daemon off;
+master_process on;
+worker_processes 1;
+load_module $FILTER_MOD;
+error_log $WORK/logs/error.log info;
+pid $WORK/logs/nginx.pid;
+events { worker_connections 16; }
+http {
+    access_log off;
+    zstd_dict_strict_path on;
+    zstd_dict_file_unsafe on;
+    zstd_dict_file $WORK/html/live.dict;
+    server {
+        listen 127.0.0.1:18198;
+        location / {
+            zstd on;
+            zstd_min_length 1;
+            zstd_types text/plain;
+            default_type text/plain;
+            return 200 "dictionary compressed body long enough to compress\n";
+        }
+    }
+}
+EOF
+
+"$NGINX" -p "$WORK" -c "$WORK/conf/nginx.conf" &
+NGINX_PID=$!
+
+ready=0
+for _ in $(seq 1 100); do
+    if curl -fsS -o /dev/null "http://127.0.0.1:18198/" 2>/dev/null; then
+        ready=1
+        break
+    fi
+    sleep 0.1
+done
+
+if [ "$ready" -ne 1 ]; then
+    echo "✗ old-cycle-active fixture: nginx did not start"
+    fail=1
+else
+    # Swap the trusted path for a symlink out from under the running
+    # config -- exactly the local-writer scenario the row defends
+    # against -- then ask for a reload.
+    rm "$WORK/html/live.dict"
+    ln -s "$WORK/html/regular.dict" "$WORK/html/live.dict"
+    kill -HUP "$NGINX_PID"
+    sleep 1
+
+    # O_NOFOLLOW makes the open() itself fail (ELOOP, "Too many levels
+    # of symbolic links") before ngx_is_link()'s own message can fire;
+    # accept either wording as proof the symlink swap was refused.
+    if curl -fsS -o /dev/null "http://127.0.0.1:18198/" 2>/dev/null \
+        && grep -qE "is a symlink; refused|levels of symbolic links" \
+            "$WORK/logs/error.log"
+    then
+        echo "✓ old-cycle-active fixture: reload refused, old cycle still serving"
+    else
+        echo "✗ old-cycle-active fixture: refusal not logged or old cycle stopped answering"
+        tail -10 "$WORK/logs/error.log" || true
+        fail=1
+    fi
+
+    kill -QUIT "$NGINX_PID" 2>/dev/null || true
+    wait "$NGINX_PID" 2>/dev/null || true
+    NGINX_PID=""
+fi
+
+if [ "$fail" -ne 0 ]; then
+    echo "❌ dictionary path hardening: one or more fixtures failed"
+    exit 1
+fi
+
+echo "✓ all dictionary path hardening fixtures passed"

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -74,6 +74,17 @@ typedef struct {
     ngx_flag_t                   dict_unsafe;
 
     /*
+     * Trust policy for both dictionary loaders (zstd_dict_file and
+     * zstd_dcz_dict_file). Default off preserves existing deployments
+     * that point at a release symlink (a legitimate, common layout);
+     * "on" opens with O_NOFOLLOW and rejects a target writable by group
+     * or other, on the theory that a root master reloading on a timer
+     * should not snapshot bytes a less-privileged local writer can
+     * still influence. See ngx_http_zstd_open_dict_file().
+     */
+    ngx_flag_t                   dict_strict_path;
+
+    /*
      * Load-time SHA-256 computations over dcz dictionaries in THIS
      * configuration ($zstd_dcz_dicts_hashed). Cycle-owned on purpose:
      * a process-global static is reset and incremented while parsing a
@@ -353,6 +364,8 @@ static ngx_int_t ngx_http_zstd_acquire_cctx(ngx_http_request_t *r,
 static void ngx_http_zstd_exit_process(ngx_cycle_t *cycle);
 static char *ngx_http_zstd_dcz_dict_file(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
+static ngx_fd_t ngx_http_zstd_open_dict_file(ngx_conf_t *cf,
+    ngx_str_t *path, ngx_flag_t strict, ngx_file_info_t *info);
 static ngx_table_elt_t *ngx_http_zstd_find_request_header(
     ngx_http_request_t *r, const char *name, size_t len, ngx_uint_t *count);
 static ngx_http_zstd_dcz_dict_t *ngx_http_zstd_dcz_negotiate(
@@ -604,6 +617,20 @@ static ngx_command_t  ngx_http_zstd_filter_commands[] = {
       ngx_conf_set_flag_slot,
       NGX_HTTP_MAIN_CONF_OFFSET,
       offsetof(ngx_http_zstd_main_conf_t, dict_unsafe),
+      NULL },
+
+    /*
+     * Off by default: a standard release-symlink deployment (current ->
+     * /srv/releases/<n>/dict.bin) is a legitimate, common layout and
+     * must keep working with no directive at all. Applies to both
+     * zstd_dict_file and zstd_dcz_dict_file — see
+     * ngx_http_zstd_open_dict_file().
+     */
+    { ngx_string("zstd_dict_strict_path"),
+      NGX_HTTP_MAIN_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_MAIN_CONF_OFFSET,
+      offsetof(ngx_http_zstd_main_conf_t, dict_strict_path),
       NULL },
 
     { ngx_string("zstd_dcz_assume_secure_transport"),
@@ -2392,6 +2419,7 @@ ngx_http_zstd_create_main_conf(ngx_conf_t *cf)
     /* NGX_CONF_UNSET so ngx_conf_set_flag_slot does not mistake the
      * pcalloc'd 0 for an already-set value ("is duplicate"). */
     zmcf->dict_unsafe = NGX_CONF_UNSET;
+    zmcf->dict_strict_path = NGX_CONF_UNSET;
 
     return zmcf;
 }
@@ -2432,6 +2460,18 @@ ngx_http_zstd_init_main_conf(ngx_conf_t *cf, void *conf)
         ngx_sprintf(zmcf->dcz_dicts_hashed_str.data, "%ui",
                     zmcf->dcz_dicts_hashed)
         - zmcf->dcz_dicts_hashed_str.data;
+
+    /*
+     * Normalize here for anything that reads the flag AFTER this point
+     * (nothing currently does). ngx_http_zstd_dcz_dict_file() runs
+     * during ngx_conf_parse(), strictly BEFORE init_main_conf, so its
+     * own read of dict_strict_path treats NGX_CONF_UNSET (-1) as "not
+     * requested" directly rather than relying on this normalization —
+     * see ngx_http_zstd_open_dict_file()'s caller.
+     */
+    if (zmcf->dict_strict_path == NGX_CONF_UNSET) {
+        zmcf->dict_strict_path = 0;
+    }
 
     if (zmcf->dict_file.len == 0) {
         return NGX_CONF_OK;
@@ -2498,6 +2538,131 @@ ngx_http_zstd_create_loc_conf(ngx_conf_t *cf)
     conf->dcz_assume_secure = NGX_CONF_UNSET;
 
     return conf;
+}
+
+
+/*
+ * Shared open+validate path for both dictionary loaders (zstd_dict_file
+ * in ngx_http_zstd_merge_loc_conf() and zstd_dcz_dict_file() below).
+ *
+ * Rationale, both rows:
+ *
+ * 1. Non-regular inputs (G5 row "Reject non-regular dictionary inputs"):
+ *    neither loader used to test ngx_is_file() before reading. Pointing
+ *    zstd_dict_file at a FIFO opens read-only and then blocks the
+ *    config-parsing master in read(2) until a writer appears on the
+ *    other end -- "nginx -t" or a reload simply hangs. A directory or
+ *    device node instead reaches a confusing read/size error much
+ *    later. Opening with O_NONBLOCK where the platform has it (POSIX;
+ *    Win32's NGX_FILE_NONBLOCK is defined to 0, a no-op, since
+ *    CreateFile() has no non-blocking-open equivalent for a regular
+ *    path) means an open against a FIFO with no reader returns
+ *    immediately (ENXIO) instead of blocking, so the ordinary error
+ *    path below handles it as any other unopenable file -- no explicit
+ *    FIFO test needed. fstat() + ngx_is_file() then rejects anything
+ *    that did open (a directory opens fine on most platforms) before a
+ *    single byte is read.
+ *
+ * 2. Trust policy (G5 row "strict dictionary-path trust policy"): a
+ *    symlink or a group/world-writable target lets a less-privileged
+ *    local writer choose or mutate the bytes a root master snapshots
+ *    into every worker on the next reload. zstd_dict_strict_path on
+ *    (off by default -- a release-symlink deploy is a legitimate,
+ *    common layout and must keep working unconfigured) opens with
+ *    O_NOFOLLOW on POSIX (Win32 has no directive-level follow to
+ *    suppress here; ngx_is_link() on that platform is hardwired to 0,
+ *    see os/win32/ngx_files.h) so a symlink target is refused as a
+ *    symlink rather than transparently followed, and additionally
+ *    rejects a target writable by group or other. The open happens
+ *    once; every subsequent check and the eventual read run against
+ *    the returned fd, never by reopening the path, so a rename or
+ *    swap after this call cannot change which inode is loaded
+ *    (TOCTOU-safe by construction).
+ *
+ * On success returns an open fd with *info already populated by
+ * ngx_fd_info(); the caller reads from it and is responsible for
+ * closing it. On failure returns NGX_INVALID_FILE having already
+ * logged the reason and closed any fd it opened.
+ */
+static ngx_fd_t
+ngx_http_zstd_open_dict_file(ngx_conf_t *cf, ngx_str_t *path,
+    ngx_flag_t strict, ngx_file_info_t *info)
+{
+    ngx_fd_t  fd;
+
+#if (NGX_WIN32)
+
+    fd = ngx_open_file(path->data, NGX_FILE_RDONLY, NGX_FILE_OPEN, 0);
+
+#else
+
+    fd = ngx_open_file(path->data,
+                       NGX_FILE_RDONLY | NGX_FILE_NONBLOCK
+                       | (strict ? NGX_FILE_NOFOLLOW : 0),
+                       NGX_FILE_OPEN, 0);
+
+#endif
+
+    if (fd == NGX_INVALID_FILE) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, ngx_errno,
+                           ngx_open_file_n " \"%V\" failed", path);
+        return NGX_INVALID_FILE;
+    }
+
+    if (ngx_fd_info(fd, info) == NGX_FILE_ERROR) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, ngx_errno,
+                           ngx_fd_info_n " \"%V\" failed", path);
+        ngx_close_file(fd);
+        return NGX_INVALID_FILE;
+    }
+
+    if (!ngx_is_file(info)) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "\"%V\" is not a regular file", path);
+        ngx_close_file(fd);
+        return NGX_INVALID_FILE;
+    }
+
+#if !(NGX_WIN32)
+
+    if (strict) {
+
+        /*
+         * O_NOFOLLOW above already refused a symlink at the leaf; this
+         * is the fstat()-side confirmation (ngx_is_link() on the fd's
+         * own info is always false for a fd that reached here purely
+         * because O_NOFOLLOW would have refused the open first -- kept
+         * as an explicit, self-documenting assertion of the property
+         * this function guarantees under strict mode rather than a
+         * live code path).
+         */
+        if (ngx_is_link(info)) {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "\"%V\" is a symlink; refused by "
+                               "\"zstd_dict_strict_path on\" (a release-"
+                               "symlink deployment needs "
+                               "\"zstd_dict_strict_path off;\", the "
+                               "default)", path);
+            ngx_close_file(fd);
+            return NGX_INVALID_FILE;
+        }
+
+        if (ngx_file_access(info) & (S_IWGRP | S_IWOTH)) {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "\"%V\" is writable by group or other; "
+                               "refused by \"zstd_dict_strict_path on\". "
+                               "Deploy dictionaries via an immutable, "
+                               "content-addressed path owned and "
+                               "writable only by the deploying "
+                               "principal", path);
+            ngx_close_file(fd);
+            return NGX_INVALID_FILE;
+        }
+    }
+
+#endif
+
+    return fd;
 }
 
 
@@ -2628,24 +2793,12 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
              * premature merge that used to pre-populate it was removed.)
              */
 
-            fd = ngx_open_file(zmcf->dict_file.data, NGX_FILE_RDONLY,
-                               NGX_FILE_OPEN, 0);
+            fd = ngx_http_zstd_open_dict_file(cf, &zmcf->dict_file,
+                                              zmcf->dict_strict_path,
+                                              &info);
 
             if (fd == NGX_INVALID_FILE) {
-                ngx_conf_log_error(NGX_LOG_EMERG, cf, ngx_errno,
-                                   ngx_open_file_n " \"%V\" failed",
-                                   &zmcf->dict_file);
-
                 return NGX_CONF_ERROR;
-            }
-
-            if (ngx_fd_info(fd, &info) == NGX_FILE_ERROR) {
-                ngx_conf_log_error(NGX_LOG_EMERG, cf, ngx_errno,
-                                   ngx_fd_info_n " \"%V\" failed",
-                                   &zmcf->dict_file);
-
-                rc = NGX_CONF_ERROR;
-                goto close;
             }
 
             /*
@@ -3342,17 +3495,22 @@ ngx_http_zstd_dcz_dict_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         }
     }
 
-    fd = ngx_open_file(path.data, NGX_FILE_RDONLY, NGX_FILE_OPEN, 0);
-    if (fd == NGX_INVALID_FILE) {
-        ngx_conf_log_error(NGX_LOG_EMERG, cf, ngx_errno,
-                           ngx_open_file_n " \"%V\" failed", &path);
-        return NGX_CONF_ERROR;
-    }
+    zmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_zstd_filter_module);
 
-    if (ngx_fd_info(fd, &info) == NGX_FILE_ERROR) {
-        ngx_conf_log_error(NGX_LOG_EMERG, cf, ngx_errno,
-                           ngx_fd_info_n " \"%V\" failed", &path);
-        goto failed;
+    /*
+     * dict_strict_path is read raw here rather than via the normalized
+     * (0/1) value init_main_conf() produces: this directive handler
+     * runs during ngx_conf_parse(), strictly BEFORE init_main_conf (see
+     * ngx_http_zstd_open_dict_file()'s block comment), so
+     * zstd_dict_strict_path may still read as NGX_CONF_UNSET (-1) here
+     * regardless of directive order in the config file. Treat anything
+     * other than the explicit "on" (1) as off, matching the eventual
+     * normalized default.
+     */
+    fd = ngx_http_zstd_open_dict_file(cf, &path,
+                                      zmcf->dict_strict_path == 1, &info);
+    if (fd == NGX_INVALID_FILE) {
+        return NGX_CONF_ERROR;
     }
 
     /*
@@ -3429,8 +3587,6 @@ ngx_http_zstd_dcz_dict_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     }
 
     if (!have_hash) {
-        zmcf = ngx_http_conf_get_module_main_conf(cf,
-                                                  ngx_http_zstd_filter_module);
         ngx_http_zstd_dcz_dict_hash(bytes.data, size, hash,
                                     &zmcf->dcz_dicts_hashed);
     }

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -85,6 +85,29 @@ typedef struct {
     ngx_flag_t                   dict_strict_path;
 
     /*
+     * Set by ngx_http_zstd_dcz_dict_file() the first time it loads a
+     * dcz dictionary while dict_strict_path still reads as anything
+     * other than the explicit "on" (1) at that moment in the parse --
+     * i.e. every load that ran BEFORE a LATER "zstd_dict_strict_path
+     * on;" line could apply to it. ngx_conf_parse() runs top-to-bottom,
+     * so this is exactly the ordering hazard: nginx directives are
+     * conventionally order-independent, so an operator has no cue that
+     * this one must precede zstd_dcz_dict_file. Silently treating that
+     * dictionary as "strict passed" would fail OPEN -- confirmed live:
+     * a world-writable dictionary loaded with zstd_dict_strict_path on
+     * declared AFTER the dcz directive passed with no error. Rather
+     * than defer the strict-mode fstat() checks to init_main_conf()
+     * (which would mean re-opening every dcz dictionary by path a
+     * second time there, reintroducing exactly the TOCTOU window this
+     * helper exists to close), init_main_conf() rejects the ordering
+     * outright when it turns out to matter: see the check there.
+     */
+    ngx_flag_t                   dcz_dict_loaded_before_strict_on;
+
+    /* First such path, for the ordering-rejection error message. */
+    ngx_str_t                    dcz_dict_loaded_before_strict_on_file;
+
+    /*
      * Load-time SHA-256 computations over dcz dictionaries in THIS
      * configuration ($zstd_dcz_dicts_hashed). Cycle-owned on purpose:
      * a process-global static is reset and incremented while parsing a
@@ -2489,6 +2512,35 @@ ngx_http_zstd_init_main_conf(ngx_conf_t *cf, void *conf)
         zmcf->dict_strict_path = 0;
     }
 
+    /*
+     * Reject the ordering rather than silently accept an unchecked
+     * load: zstd_dcz_dict_file records (above) the first time it loads
+     * a dictionary while dict_strict_path did not yet read as the
+     * explicit "on". If the flag's FINAL value is "on", every such
+     * recorded load ran without the O_NOFOLLOW / writable-target checks
+     * this directive exists to apply -- fail the config rather than
+     * start with a dictionary the operator asked to have vetted but
+     * that never was. nginx directives are conventionally
+     * order-independent, so this is a real operator trap, not pedantry:
+     * confirmed live, a world-writable dcz dictionary loaded before a
+     * later "zstd_dict_strict_path on;" line passed with no warning.
+     */
+    if (zmcf->dict_strict_path == 1
+        && zmcf->dcz_dict_loaded_before_strict_on)
+    {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "\"zstd_dict_strict_path on\" was declared "
+                           "AFTER \"zstd_dcz_dict_file %V\", which had "
+                           "already loaded unchecked by that point. "
+                           "nginx directives are order-independent by "
+                           "convention, but this one is not: move "
+                           "\"zstd_dict_strict_path on;\" before every "
+                           "\"zstd_dcz_dict_file\" directive it must "
+                           "apply to",
+                           &zmcf->dcz_dict_loaded_before_strict_on_file);
+        return NGX_CONF_ERROR;
+    }
+
     if (zmcf->dict_file.len == 0) {
         return NGX_CONF_OK;
     }
@@ -3549,6 +3601,7 @@ ngx_http_zstd_dcz_dict_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_file_info_t            info;
     ngx_http_zstd_dcz_dict_t  *dict, *dicts;
     ngx_http_zstd_main_conf_t *zmcf;
+    ngx_flag_t                 strict;
 
     (void) cmd;
 
@@ -3629,17 +3682,31 @@ ngx_http_zstd_dcz_dict_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     zmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_zstd_filter_module);
 
     /*
-     * dict_strict_path is read raw here rather than via the normalized
-     * (0/1) value init_main_conf() produces: this directive handler
-     * runs during ngx_conf_parse(), strictly BEFORE init_main_conf (see
-     * ngx_http_zstd_open_dict_file()'s block comment), so
-     * zstd_dict_strict_path may still read as NGX_CONF_UNSET (-1) here
-     * regardless of directive order in the config file. Treat anything
-     * other than the explicit "on" (1) as off, matching the eventual
-     * normalized default.
+     * dict_strict_path is read raw here (not the normalized 0/1 value
+     * init_main_conf() later produces): this directive handler runs
+     * during ngx_conf_parse(), strictly BEFORE init_main_conf, so if
+     * "zstd_dict_strict_path on;" appears LATER in the same config
+     * file, it has not been parsed yet and this read sees
+     * NGX_CONF_UNSET (-1), not 1. Reading that as "off" is only safe
+     * for THIS load -- it does NOT mean the operator declined strict
+     * mode overall, only that this line hasn't been reached. A
+     * subsequent "on" would mean this dictionary was loaded unchecked
+     * despite the operator asking for strict mode -- confirmed live to
+     * fail open: a world-writable dictionary loaded here with no error
+     * when zstd_dict_strict_path on came after this directive. Record
+     * that possibility now (once, keeping the first offending path for
+     * the message) so init_main_conf() can reject the ordering outright
+     * once the flag's FINAL value is known, rather than silently
+     * accepting an unchecked load.
      */
-    fd = ngx_http_zstd_open_dict_file(cf, &path,
-                                      zmcf->dict_strict_path == 1, &info);
+    strict = (zmcf->dict_strict_path == 1);
+
+    if (!strict && !zmcf->dcz_dict_loaded_before_strict_on) {
+        zmcf->dcz_dict_loaded_before_strict_on = 1;
+        zmcf->dcz_dict_loaded_before_strict_on_file = path;
+    }
+
+    fd = ngx_http_zstd_open_dict_file(cf, &path, strict, &info);
     if (fd == NGX_INVALID_FILE) {
         return NGX_CONF_ERROR;
     }


### PR DESCRIPTION
## TL;DR

Both dictionary loaders (`zstd_dict_file`, `zstd_dcz_dict_file`) opened the
configured path and fstat'd it without ever checking that it was a regular
file, and accepted a symlink or a group/world-writable target with no
warning. Pointing either directive at a FIFO used to block the
config-parsing master in `open()` until a writer appeared — `nginx -t` or a
reload simply hung.

Both loaders now share `ngx_http_zstd_open_dict_file()`, which opens
`O_NONBLOCK` (POSIX; a no-op on Win32) and requires `ngx_is_file()` before
any read, plus a new opt-in `zstd_dict_strict_path` directive that opens
`O_NOFOLLOW` and rejects group/world-writable targets.

**Severity:** `Low` (`security — hardening against a lower-privileged local writer; default-off, no behavior change for existing configs`)

## Policy decisions

* **Non-regular-file rejection is unconditional, not gated by a directive.**
  A FIFO/socket/directory/device was never a valid dictionary; there is no
  compatible existing config that depends on the old behavior succeeding
  against one of these (it always eventually errored or hung).
* **`zstd_dict_strict_path` defaults `off`.** A release-symlink deployment
  (`current -> releases/<n>/dict.bin`) is a common, legitimate layout and
  depends on exactly the symlink indirection strict mode refuses. Making
  the non-regular-file check unconditional but the symlink/writable-target
  check opt-in keeps existing configs working unchanged while giving
  operators who deploy to a content-addressed path a way to close the gap.
* **A violation is a config-load error, not a warning**, consistent with
  this module's existing dictionary error handling (missing file, empty
  file, oversized file are all `NGX_CONF_ERROR`). A silently-ignored
  warning would leave the exact trust gap the directive exists to close.
* **The open-then-validate-then-read sequence never re-opens by path.**
  Both loaders read from the fd `ngx_http_zstd_open_dict_file()` returns, so
  a rename or symlink swap between the check and the read cannot select a
  different file (no TOCTOU window).
* **`zstd_dict_strict_path` placed AFTER a `zstd_dcz_dict_file` it should
  cover is a config-load error, not a silent no-op.** `zstd_dcz_dict_file`
  is consumed during `ngx_conf_parse()`, before the flag is normalized, so a
  directive written after the dictionary it should protect would otherwise
  read the flag as unset and load that dictionary unchecked — confirmed
  live: a world-writable dcz dictionary loaded with no error when the
  directive order was reversed. Rejecting the ordering (rather than
  deferring the fstat checks to `init_main_conf()`, which would mean
  re-opening every dcz dictionary by path a second time and reintroducing
  the TOCTOU window the fd-based read exists to close) keeps that guarantee
  and gives the operator a named, actionable error instead of a silent gap.
  `zstd_dict_file` is unaffected — it is consumed in `merge_loc_conf()`,
  which always runs after the flag is resolved.

## Testing

Fixture matrix (`ci/tools/test_dict_path_hardening.sh`, bounded by
`timeout 10` per `nginx -t` run) against both directives: regular file
(loads), FIFO/socket/directory/`/dev/null` (rejected, and the FIFO case
specifically proves the fix does not hang), symlink under strict-off
(loads, proving the escape hatch) and strict-on (rejected), a
group/world-writable file under strict-off (loads) and strict-on
(rejected), and `zstd_dict_strict_path on` declared AFTER `zstd_dcz_dict_file`
for both a writable target and a symlink (rejected — the ordering
regression). A separate live-reload case starts nginx with strict mode on,
swaps the dictionary path for a symlink, sends `SIGHUP`, and confirms the
reload is refused while the running worker keeps serving.

Negative controls, both observed red on the pre-fix code and green after:
reverted the `O_NONBLOCK`/`O_NOFOLLOW` open flags and the
`ngx_is_file()`/strict-mode checks in `ngx_http_zstd_open_dict_file()`
(guarded with `if (0 && ...)`), rebuilt (BuildID changed, confirming a real
recompile) — the FIFO case timed out and every strict-mode case that
should reject instead reported "OK". Separately, built the pre-ordering-fix
commit against the current test script (BuildID matched that commit's own
build) — the two ordering-regression cases reported "OK" instead of
"reject", reproducing the fail-open exactly. Both reverts restored to green
after re-applying the fix.

Full existing suite still green on the built module: `ci/t/00-filter.t`
(1191), `ci/t/01-static.t` (579), `ci/t/02-conf-warn.t` (67),
`ci/t/03-dcz.t` (115). Swept `ci/t/*.t`, `ci/tools/*.py`, `ci/tools/*.sh`
for harnesses pointing either dictionary directive at a non-regular or
writable path, enabling strict mode, or relying on directive order — none
found, so nothing needed updating.

## Compatibility

`zstd_dict_strict_path` is new and defaults `off`; no existing config
changes behavior. The unconditional non-regular-file rejection is a
behavior change only for configs that previously pointed a dictionary
directive at a FIFO/socket/directory/device — none of those previously
worked correctly (hang or a later confusing error), so there is no working
configuration this removes. A config that declares `zstd_dict_strict_path
on;` after a `zstd_dcz_dict_file` it should cover now fails to start where
it previously started silently unprotected; the fix is reordering the two
directives, named in the error message.
