### PR TITLE
feat: warn when an enabled zstd profile commits large per-request memory

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1515,6 +1515,18 @@ jobs:
           python3 ci/tools/test_ldm_budget_config.py \
             --nginx-binary "$TEST_NGINX_BINARY" --port 18124
           echo "✓ zstd_long + zstd_max_cctx_memory config validation passed"
+          # Implicit per-request CCtx memory advisory. zstd_max_cctx_memory
+          # is optional, so the estimator used to be skipped entirely for
+          # the common no-budget config and an expensive profile
+          # (zstd_comp_level 22, zstd_long on) committed hundreds of MB per
+          # concurrent response silently. The matrix asserts the advisory
+          # fires on the large profiles, stays silent on the ordinary ones
+          # and on an explicit budget/acknowledgement, and -- the part
+          # Test::Nginx cannot express -- that it never turns a working
+          # nginx -t into a failing one.
+          python3 ci/tools/test_cctx_advisory_policy.py \
+            --nginx-binary "$TEST_NGINX_BINARY" --port 18130
+          echo "✓ CCtx memory advisory policy matrix passed"
 
       - name: Run RFC 9842 dcz end-to-end test
         timeout-minutes: 6
@@ -1958,6 +1970,8 @@ jobs:
             --nginx-binary "$TEST_NGINX_BINARY" --port 19104 --backend-port 19105
           python3 ci/tools/test_ldm_budget_config.py \
             --nginx-binary "$TEST_NGINX_BINARY" --port 19122
+          python3 ci/tools/test_cctx_advisory_policy.py \
+            --nginx-binary "$TEST_NGINX_BINARY" --port 19130
           python3 ci/tools/test_zstd_long_ldm.py \
             --nginx-binary "$TEST_NGINX_BINARY" --port 19102 --backend-port 19103
           python3 ci/tools/test_dcz.py --nginx-binary "$TEST_NGINX_BINARY" \

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,26 @@
 Changes with http-zstd
 
+    *) Feature: compression enabled without an explicit
+       "zstd_max_cctx_memory" now estimates the per-request compressor
+       working set at config load and warns when it exceeds 32 MB.
+       zstd_max_cctx_memory is optional and rarely set, so the estimator
+       was previously skipped for the common case: a later
+       "zstd_comp_level 22" or "zstd_long on" committed hundreds of MB
+       per concurrent response (level 22 estimates ~769 MB, zstd_long at
+       the default level ~138 MB) even though the module already knew
+       the figure at config load. The warning names the estimate, the
+       level, and the retained worker bound -- each worker keeps up to
+       four contexts, so worker RSS can reach four times the per-request
+       figure, and that again per worker process. It is advisory only
+       and never fails the configuration: a config that loads today
+       keeps loading. Set "zstd_max_cctx_memory <size>" to have a bound
+       enforced at config load instead, or "zstd_max_cctx_memory 0" to
+       acknowledge the profile and silence the warning. An explicit
+       non-zero budget keeps its existing hard-failure behaviour
+       unchanged. Requires the same -DZSTD_STATIC_LINKING_ONLY build as
+       the directive; a build without the estimator API does not warn
+       rather than implying a guarantee it cannot compute.
+
     *) Bugfix: "nginx -t" no longer dies with SIGFPE when "zstd_long on"
        is combined with "zstd_max_cctx_memory". The config-load budget
        check calls ZSTD_estimateCStreamSize_usingCCtxParams(), which

--- a/README.md
+++ b/README.md
@@ -657,7 +657,7 @@ The 32 MB threshold sits in the natural gap between `zstd_comp_level`
 11 (~28.7 MB) and 12 (~52.7 MB), so the ordinary web-serving range is
 silent and only genuinely large profiles are named:
 
-| profile (level 3 unless stated) | per request | retained per worker (×4) | advisory |
+| profile (level 3 unless stated) | per request | per worker (×4) | advisory |
 | --- | ---: | ---: | :---: |
 | `zstd_comp_level 1` | 1.3 MB | 5.2 MB | no |
 | default (`zstd_comp_level 3`) | 3.5 MB | 14.0 MB | no |

--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ location /api/bulk-export {
 ### zstd_max_cctx_memory
 
 **Syntax:** `zstd_max_cctx_memory size;`
-**Default:** `—` (disabled, no budget enforced)
+**Default:** `—` (no budget enforced; see [the advisory](#implicit-advisory-when-no-budget-is-set) below)
 **Context:** `http, server, location`
 **Requires:** module built with `-DZSTD_STATIC_LINKING_ONLY` against libzstd ≥ 1.4.0 (the project's production and CI builds do; see [Compatibility](#compatibility)).
 
@@ -630,6 +630,61 @@ server {
 > refused at config load rather than accepted and blown at runtime.
 > Pair `zstd_long on` with an explicit `zstd_window_log` to bring it
 > back down (level 3 with `zstd_window_log 20` costs ~2.7 MB).
+
+#### Implicit advisory when no budget is set
+
+Setting `zstd_max_cctx_memory` is optional, and most configurations
+never do. Compression enabled with **no** `zstd_max_cctx_memory`
+anywhere in the inheritance chain therefore still runs the same
+estimate at config load, and emits a **warning** — not an error — when
+the profile needs more than **32 MB** of per-request compressor memory:
+
+```
+nginx: [warn] the configured zstd parameters need ~144328225 bytes of
+per-request compressor memory (zstd_comp_level 3); each worker retains
+up to 4 such contexts, so worker RSS can reach ~577312900 bytes, and
+that again per worker process. Set "zstd_max_cctx_memory" to a budget
+to have this enforced at config load, or "zstd_max_cctx_memory 0" to
+acknowledge the profile and silence this warning
+```
+
+This exists because the expensive levers are one line away from a
+working config: a later `zstd_comp_level 22` or `zstd_long on` commits
+hundreds of MB per concurrent response, and without the advisory the
+module knew that number at config load and said nothing.
+
+The 32 MB threshold sits in the natural gap between `zstd_comp_level`
+11 (~28.7 MB) and 12 (~52.7 MB), so the ordinary web-serving range is
+silent and only genuinely large profiles are named:
+
+| profile (level 3 unless stated) | per request | retained per worker (×4) | advisory |
+| --- | ---: | ---: | :---: |
+| `zstd_comp_level 1` | 1.3 MB | 5.2 MB | no |
+| default (`zstd_comp_level 3`) | 3.5 MB | 14.0 MB | no |
+| `zstd_comp_level 9` | 16.7 MB | 67.0 MB | no |
+| `zstd_comp_level 11` | 28.7 MB | 115.0 MB | no |
+| `zstd_comp_level 12` | 52.7 MB | 211.0 MB | **yes** |
+| `zstd_comp_level 19` | 89.5 MB | 358.0 MB | **yes** |
+| `zstd_comp_level 22` | 769.5 MB | 3078.0 MB | **yes** |
+| `zstd_long on` | 137.6 MB | 550.6 MB | **yes** |
+| `zstd_window_log 27` | 129.5 MB | 518.0 MB | **yes** |
+| `zstd_long on` + `zstd_window_log 20` | 2.6 MB | 10.3 MB | no |
+
+*(`ZSTD_estimateCStreamSize_usingCCtxParams()`, libzstd 1.5.7,
+streaming with unknown content size — the module's own path.)*
+
+Two ways to silence it, and they mean different things:
+
+* **`zstd_max_cctx_memory <size>;`** — you want the bound *enforced*.
+  Exceeding it is a hard config-load error, as documented above.
+* **`zstd_max_cctx_memory 0;`** — you have read the number and accept
+  it. Nothing is enforced and nothing is warned about.
+
+It never fails the configuration on its own: a config that loads today
+keeps loading after an upgrade. Note that the advisory requires the
+same `-DZSTD_STATIC_LINKING_ONLY` build as the directive; a build
+without the estimator API simply does not warn, rather than implying a
+guarantee it cannot compute.
 
 **Why a config-load assert and not a runtime cap.** The directive does
 **not** silently tune anything. A too-tight budget is a hard error so

--- a/ci/tools/test_cctx_advisory_policy.py
+++ b/ci/tools/test_cctx_advisory_policy.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Config-load policy: the implicit per-request CCtx memory advisory.
+
+``zstd_max_cctx_memory`` merges to ``0`` when the operator never sets it,
+and the config-load estimator used to be skipped entirely in that case.
+A later ``zstd_comp_level 22`` or ``zstd_long on`` could therefore commit
+hundreds of MB of compressor working set per concurrent response --
+multiplied by the ``NGX_HTTP_ZSTD_CCTX_SLOTS`` (4) contexts each worker
+retains, and again by ``worker_processes`` -- even though the module
+already knew the number at config load.
+
+The policy under test
+---------------------
+Compression enabled and **no** explicit ``zstd_max_cctx_memory``
+anywhere in the inheritance chain:
+
+  * run libzstd's estimator on the merged profile;
+  * if the estimate exceeds ``NGX_HTTP_ZSTD_CCTX_ADVISORY_BYTES``
+    (32 MB), emit an ``[warn]`` naming the estimate and the retained
+    worker bound;
+  * **warn, never fail** -- turning ``nginx -t`` from pass to fail on a
+    configuration that works today would break deployments on upgrade.
+
+An explicit ``zstd_max_cctx_memory 0`` is the operator's
+acknowledgement and silences the advisory. (``ngx_conf_set_size_slot()``
+parses sizes only, so ``0`` -- not the keyword ``off`` -- is the
+spelling; the directive is capped at ``INT_MAX``, hence ``1024m`` rather
+than ``1g`` in arm 5.) An explicit non-zero value
+keeps the pre-existing hard-failure semantics untouched.
+
+Why this test and not ``ci/t/00-filter.t``: Test::Nginx's ``--- must_die``
+and error-log greps cannot express "must PASS *and* must have emitted
+exactly this warning", which is the whole contract here -- a policy that
+failed the config would satisfy any must_die-shaped assertion while being
+precisely the breaking change this design rejected.
+
+Arms
+----
+1. default profile (``zstd on`` only)            -> PASS, NO advisory.
+2. ``zstd_comp_level 22``                        -> PASS, advisory.
+3. ``zstd_long on``                              -> PASS, advisory.
+4. ``zstd_window_log 27``                        -> PASS, advisory.
+5. ``zstd_comp_level 22`` + explicit 1024m budget -> PASS, NO advisory
+   (the explicit-budget path owns this config; the advisory must not
+   double-report).
+6. ``zstd_comp_level 22`` + ``zstd_max_cctx_memory 0``
+                                                 -> PASS, NO advisory
+   (the acknowledgement is honoured).
+7. ``zstd_comp_level 22`` + explicit 64m budget  -> REFUSED (the hard
+   check is unchanged; the advisory did not soften it).
+8. dictionary + default level                    -> PASS, NO advisory
+   (a dictionary does not move the working set into advisory range).
+
+Arms 1, 5, 6 and 8 are the controls that stop this test going vacuous:
+each asserts the advisory is **absent**, so a build that warned
+unconditionally -- the obvious wrong implementation -- fails them.
+"""
+
+import argparse
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+# NGX_HTTP_ZSTD_CCTX_ADVISORY_BYTES in
+# src/ngx_http_zstd_filter_module.c. Kept in sync by arms 1 and 2:
+# level 3 estimates ~3.5 MB (below) and level 22 ~769 MB (above), so a
+# threshold moved outside the (28.7 MB, 52.7 MB) gap between levels 11
+# and 12 does not silently pass this test.
+ADVISORY_BYTES = 32 * 1024 * 1024
+
+# NGX_HTTP_ZSTD_CCTX_SLOTS.
+CCTX_SLOTS = 4
+
+# The advisory is identified by this phrase; matching on it rather than
+# on "[warn]" keeps the unrelated zstd_bypass_vary warning from
+# satisfying an arm.
+ADVISORY_RE = re.compile(r"need ~(\d+) bytes of per-request compressor memory")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--nginx-binary", required=True)
+    p.add_argument("--filter-module")
+    p.add_argument("--port", type=int, default=18130)
+    return p.parse_args()
+
+
+def detect_module(explicit, nginx: pathlib.Path):
+    if explicit:
+        return pathlib.Path(explicit)
+    sib = nginx.parent / "ngx_http_zstd_filter_module.so"
+    return sib if sib.exists() else None
+
+
+def config_test(nginx, module, port, directives, want_dict=False):
+    """Run ``nginx -t``; return (returncode, combined output)."""
+    with tempfile.TemporaryDirectory() as td:
+        root = pathlib.Path(td)
+        (root / "conf").mkdir()
+        (root / "logs").mkdir()
+
+        extra = ""
+        if want_dict:
+            # A small raw dictionary is enough: the point of the arm is
+            # that loading one does not push the estimate over the
+            # advisory threshold, not the dictionary's content.
+            dic = root / "dict.bin"
+            dic.write_bytes(b"the quick brown fox jumps over the lazy dog" * 64)
+            # zstd_dict_file additionally requires the operator to
+            # acknowledge the non-negotiated Content-Encoding; that gate
+            # is unrelated to this test but must be satisfied to reach
+            # the memory policy at all.
+            extra = f"zstd_dict_file {dic};\n    zstd_dict_file_unsafe on;\n    "
+
+        load = f"load_module {module};\n" if module else ""
+        (root / "conf" / "nginx.conf").write_text(
+            f"{load}"
+            "events {}\n"
+            "http {\n"
+            f"    {extra}"
+            f"    server {{\n"
+            f"        listen 127.0.0.1:{port};\n"
+            "        zstd on;\n"
+            f"        {directives}\n"
+            "    }\n"
+            "}\n"
+        )
+
+        proc = subprocess.run(
+            [str(nginx), "-p", str(root), "-c", "conf/nginx.conf", "-t"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        return proc.returncode, proc.stdout + proc.stderr
+
+
+def check_not_a_signal(name, rc, out):
+    if rc < 0:
+        return [f"{name}: nginx -t died on signal {-rc}; output: {out.strip()!r}"]
+    if rc > 128:
+        return [
+            (
+                f"{name}: nginx -t exited {rc} (128+{rc - 128}), a signal "
+                f"death, not a diagnostic; output: {out.strip()!r}"
+            )
+        ]
+    return []
+
+
+def run_arm(
+    nginx,
+    module,
+    port,
+    name,
+    directives,
+    want_pass,
+    want_advisory,
+    want_dict=False,
+    min_estimate=None,
+):
+    """One matrix cell. Returns (failures, printable summary)."""
+    rc, out = config_test(nginx, module, port, directives, want_dict=want_dict)
+    failures = check_not_a_signal(name, rc, out)
+
+    if want_pass and rc != 0:
+        failures.append(
+            f"{name}: expected nginx -t to PASS but it exited {rc}. The "
+            f"advisory policy must never turn a working config into a "
+            f"config-load failure; output: {out.strip()!r}"
+        )
+    if not want_pass and rc == 0:
+        failures.append(
+            f"{name}: expected nginx -t to be REFUSED but it exited 0; "
+            f"output: {out.strip()!r}"
+        )
+
+    m = ADVISORY_RE.search(out)
+    saw_warn = m is not None and "[warn]" in out
+
+    if want_advisory and not saw_warn:
+        failures.append(
+            f"{name}: expected the [warn] advisory naming the estimate, "
+            f"but it was not emitted. The operator gets no signal that "
+            f"this profile commits a large per-request working set; "
+            f"output: {out.strip()!r}"
+        )
+    if not want_advisory and saw_warn:
+        failures.append(
+            f"{name}: the advisory was emitted but must NOT be. Either "
+            f"the threshold is wrong or an explicit budget / "
+            f"acknowledgement is not being honoured; output: "
+            f"{out.strip()!r}"
+        )
+
+    est = None
+    if saw_warn:
+        est = int(m.group(1))
+        if min_estimate is not None and est < min_estimate:
+            failures.append(
+                f"{name}: advisory reports {est} bytes, below the expected "
+                f"{min_estimate}. The estimate was computed against the "
+                f"wrong parameters."
+            )
+        if est <= ADVISORY_BYTES:
+            failures.append(
+                f"{name}: advisory fired at {est} bytes, which is <= the "
+                f"{ADVISORY_BYTES}-byte threshold. The condition is not "
+                f"the documented one."
+            )
+        # The message must give the operator the retained worker bound,
+        # not just the per-context figure -- the per-worker number is
+        # what actually shows up in RSS.
+        if str(est * CCTX_SLOTS) not in out:
+            failures.append(
+                f"{name}: advisory does not state the retained worker "
+                f"bound ({est} x {CCTX_SLOTS} = {est * CCTX_SLOTS} "
+                f"bytes); output: {out.strip()!r}"
+            )
+        if "zstd_max_cctx_memory 0" not in out:
+            failures.append(
+                f"{name}: advisory does not tell the operator how to "
+                f'acknowledge it ("zstd_max_cctx_memory 0"); output: '
+                f"{out.strip()!r}"
+            )
+
+    summary = (
+        f"  {name:<38} exit {rc} (want {'0' if want_pass else 'non-zero'}), "
+        f"advisory {'yes' if saw_warn else 'no':<3} "
+        f"(want {'yes' if want_advisory else 'no'})"
+        + (f", estimate {est} bytes" if est is not None else "")
+    )
+    return failures, summary
+
+
+def main() -> int:
+    args = parse_args()
+    nginx = pathlib.Path(args.nginx_binary).resolve()
+    if not nginx.exists():
+        print(f"FAIL: nginx binary not found: {nginx}", file=sys.stderr)
+        return 1
+
+    module = detect_module(args.filter_module, nginx)
+    if module is not None:
+        module = module.resolve()
+        if not module.exists():
+            print(f"FAIL: filter module not found: {module}", file=sys.stderr)
+            return 1
+
+    # (name, directives, want_pass, want_advisory, want_dict, min_estimate)
+    #
+    # min_estimate pins the magnitude where the profile implies one, so a
+    # correctly-firing advisory computed against the wrong parameters is
+    # still caught. LDM and window_log 27 both imply a 128 MB window.
+    matrix = [
+        ("1 default profile", "", True, False, False, None),
+        (
+            "2 zstd_comp_level 22",
+            "zstd_comp_level 22;",
+            True,
+            True,
+            False,
+            512 * 1024 * 1024,
+        ),
+        ("3 zstd_long on", "zstd_long on;", True, True, False, 128 * 1024 * 1024),
+        (
+            "4 zstd_window_log 27",
+            "zstd_window_log 27;",
+            True,
+            True,
+            False,
+            128 * 1024 * 1024,
+        ),
+        (
+            "5 level 22 + budget 1024m",
+            "zstd_comp_level 22; zstd_max_cctx_memory 1024m;",
+            True,
+            False,
+            False,
+            None,
+        ),
+        (
+            "6 level 22 + budget 0 (ack)",
+            "zstd_comp_level 22; zstd_max_cctx_memory 0;",
+            True,
+            False,
+            False,
+            None,
+        ),
+        (
+            "7 level 22 + budget 64m",
+            "zstd_comp_level 22; zstd_max_cctx_memory 64m;",
+            False,
+            False,
+            False,
+            None,
+        ),
+        ("8 dictionary, default level", "", True, False, True, None),
+    ]
+
+    failures = []
+    print("zstd CCtx memory advisory policy matrix:")
+    for i, (name, directives, wp, wa, wd, mn) in enumerate(matrix):
+        f, summary = run_arm(
+            nginx,
+            module,
+            args.port + i,
+            name,
+            directives,
+            wp,
+            wa,
+            want_dict=wd,
+            min_estimate=mn,
+        )
+        failures += f
+        print(summary)
+
+    if failures:
+        print("\nFAIL: CCtx memory advisory policy", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+
+    print(f"\nOK: CCtx memory advisory policy ({len(matrix)}/{len(matrix)} arms)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -2734,6 +2734,268 @@ ngx_http_zstd_open_dict_file(ngx_conf_t *cf, ngx_str_t *path,
 }
 
 
+#if defined(ZSTD_STATIC_LINKING_ONLY) && ZSTD_VERSION_NUMBER >= 10400
+
+/*
+ * Advisory threshold for the implicit (no zstd_max_cctx_memory) budget
+ * policy, in bytes of per-request compressor working set.
+ *
+ * The module retains up to NGX_HTTP_ZSTD_CCTX_SLOTS (4) contexts per
+ * worker, and ZSTD_sizeof_CCtx() does not shrink on reset, so the
+ * retained worker high-water mark is threshold x slots -- 128 MB at the
+ * value below. Multiply again by worker_processes for the box.
+ *
+ * Chosen from ZSTD_estimateCStreamSize_usingCCtxParams() measured on
+ * libzstd 1.5.7, streaming with unknown content size (the module's
+ * path), no zstd_window_log, no LDM:
+ *
+ *     zstd_comp_level   estimate      per worker (x4)
+ *      1                  1.3 MB           5.2 MB
+ *      3 (default)        3.5 MB          14.0 MB
+ *      6                  5.7 MB          23.0 MB
+ *      9                 16.7 MB          67.0 MB
+ *     11                 28.7 MB         115.0 MB
+ *     ---- 32 MB advisory threshold ----
+ *     12                 52.7 MB         211.0 MB
+ *     15                 68.7 MB         275.0 MB
+ *     19                 89.5 MB         358.0 MB
+ *     22                769.5 MB        3078.0 MB
+ *
+ * and with the specialist window/LDM levers at the DEFAULT level 3:
+ *
+ *     zstd_long on                     137.6 MB         550.6 MB
+ *     zstd_window_log 27               129.5 MB         518.0 MB
+ *     zstd_long on + window_log 20       2.6 MB          10.3 MB
+ *
+ * 32 MB therefore falls in the natural gap between level 11 (28.7 MB)
+ * and level 12 (52.7 MB): every level in the ordinary web-serving range
+ * stays silent, while every profile that reaches hundreds of MB per
+ * worker -- high levels, LDM, and a wide explicit window -- is named.
+ * It is not a directive: an operator who wants a real bound sets
+ * zstd_max_cctx_memory (hard failure), and one who has accepted the
+ * larger profile sets "zstd_max_cctx_memory 0" to acknowledge it.
+ */
+#ifndef NGX_HTTP_ZSTD_CCTX_ADVISORY_BYTES
+#define NGX_HTTP_ZSTD_CCTX_ADVISORY_BYTES  (32 * 1024 * 1024)
+#endif
+
+
+/*
+ * Compute libzstd's own estimate of the per-request streaming compressor
+ * working set for this location's configured profile.
+ *
+ * Single source of truth for both consumers -- the hard check against an
+ * explicit zstd_max_cctx_memory and the implicit advisory -- so the two
+ * cannot drift into disagreeing about what a profile costs. Every exit
+ * path frees the ZSTD_CCtx_params; a leak here would be per-location at
+ * config load.
+ *
+ * On success writes the estimate to *est and returns NGX_CONF_OK. On
+ * failure it has already logged an actionable diagnostic at
+ * NGX_LOG_EMERG and returns NGX_CONF_ERROR: a profile whose cost cannot
+ * be computed is a configuration we refuse to start on, not one we
+ * quietly stop measuring.
+ */
+static char *
+ngx_http_zstd_estimate_cctx_memory(ngx_conf_t *cf,
+    ngx_http_zstd_loc_conf_t *conf, size_t *est)
+{
+    ZSTD_CCtx_params  *cp;
+    size_t             srv;
+    size_t             e;
+
+    cp = ZSTD_createCCtxParams();
+    if (cp == NULL) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "ZSTD_createCCtxParams() failed");
+        return NGX_CONF_ERROR;
+    }
+
+    srv = ZSTD_CCtxParams_init(cp, (int) conf->level);
+    if (ZSTD_isError(srv)) {
+        ZSTD_freeCCtxParams(cp);
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "ZSTD_CCtxParams_init(level=%i) failed: %s",
+                           conf->level, ZSTD_getErrorName(srv));
+        return NGX_CONF_ERROR;
+    }
+
+    if (conf->window_log > 0) {
+        srv = ZSTD_CCtxParams_setParameter(cp, ZSTD_c_windowLog,
+                                           (int) conf->window_log);
+        if (ZSTD_isError(srv)) {
+            ZSTD_freeCCtxParams(cp);
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "ZSTD_CCtxParams_setParameter("
+                               "windowLog=%i) failed: %s",
+                               conf->window_log,
+                               ZSTD_getErrorName(srv));
+            return NGX_CONF_ERROR;
+        }
+    }
+
+    if (conf->long_mode) {
+        ngx_int_t  ldm_wlog, ldm_hlog, ldm_rlog;
+
+        srv = ZSTD_CCtxParams_setParameter(
+                  cp, ZSTD_c_enableLongDistanceMatching, 1);
+        if (ZSTD_isError(srv)) {
+            ZSTD_freeCCtxParams(cp);
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "ZSTD_CCtxParams_setParameter("
+                               "enableLongDistanceMatching) failed: %s",
+                               ZSTD_getErrorName(srv));
+            return NGX_CONF_ERROR;
+        }
+
+        /*
+         * BLOCKER fix: ZSTD_estimateCStreamSize_usingCCtxParams()
+         * divides by params->ldmParams.hashRateLog. libzstd derives
+         * the LDM sub-parameters lazily, inside compression setup --
+         * a ZSTD_CCtx_params that has only had
+         * ZSTD_c_enableLongDistanceMatching set still carries
+         * hashRateLog == 0, so the estimator divides by zero and the
+         * whole process dies with SIGFPE during "nginx -t". Setting
+         * ZSTD_c_windowLog does not help: the divisor is unrelated to
+         * the window.
+         *
+         * There is no public "adjust these params the way you would
+         * internally" entry point, so we derive the same four values
+         * libzstd documents in zstd.h and push them explicitly. From
+         * the ZSTD_c_ldm* documentation:
+         *
+         *   - enabling LDM raises the default windowLog to 27
+         *     (128 MB) unless windowLog was expressly set;
+         *   - ldmHashLog     default = windowLog - 7, clamped to
+         *                    [ZSTD_LDM_HASHLOG_MIN,
+         *                     ZSTD_LDM_HASHLOG_MAX];
+         *   - ldmMinMatch    default = 64;
+         *   - ldmBucketSizeLog default = 3;
+         *   - ldmHashRateLog default = MAX(0, windowLog - ldmHashLog).
+         *
+         * Seeding these makes the estimate accurate rather than
+         * merely non-crashing. Measured against a real streaming
+         * ZSTD_CCtx compressing 256 MB with unknown content size
+         * (libzstd 1.5.7, level 3): seeded estimate 144328225 bytes
+         * vs. ZSTD_sizeof_CCtx() 144262689 -- 0.05% conservative.
+         * With "zstd_window_log 20": 2705953 vs. 2705441, 0.02%
+         * conservative. So the operator's budget still means what it
+         * says under LDM; we neither crash nor silently drop the
+         * bound, and we do not manufacture spurious rejections.
+         *
+         * Note that windowLog is pushed explicitly here even when the
+         * operator did not configure one: the estimator must see the
+         * same 27 that libzstd would default to under LDM, otherwise
+         * it would size for the level's much smaller default window
+         * and under-report by two orders of magnitude.
+         */
+
+        ldm_wlog = conf->window_log > 0 ? conf->window_log
+                                        : NGX_HTTP_ZSTD_LDM_WINDOWLOG;
+
+        ldm_hlog = ldm_wlog - 7;
+        if (ldm_hlog < ZSTD_LDM_HASHLOG_MIN) {
+            ldm_hlog = ZSTD_LDM_HASHLOG_MIN;
+        }
+        if (ldm_hlog > ZSTD_LDM_HASHLOG_MAX) {
+            ldm_hlog = ZSTD_LDM_HASHLOG_MAX;
+        }
+
+        ldm_rlog = ldm_wlog - ldm_hlog;
+        if (ldm_rlog < 0) {
+            ldm_rlog = 0;
+        }
+
+        srv = ZSTD_CCtxParams_setParameter(cp, ZSTD_c_windowLog,
+                                           (int) ldm_wlog);
+        if (!ZSTD_isError(srv)) {
+            srv = ZSTD_CCtxParams_setParameter(cp, ZSTD_c_ldmHashLog,
+                                               (int) ldm_hlog);
+        }
+        if (!ZSTD_isError(srv)) {
+            srv = ZSTD_CCtxParams_setParameter(
+                      cp, ZSTD_c_ldmMinMatch,
+                      NGX_HTTP_ZSTD_LDM_MINMATCH);
+        }
+        if (!ZSTD_isError(srv)) {
+            srv = ZSTD_CCtxParams_setParameter(
+                      cp, ZSTD_c_ldmBucketSizeLog,
+                      NGX_HTTP_ZSTD_LDM_BUCKETSIZELOG);
+        }
+        if (!ZSTD_isError(srv)) {
+            srv = ZSTD_CCtxParams_setParameter(cp, ZSTD_c_ldmHashRateLog,
+                                               (int) ldm_rlog);
+        }
+
+        if (ZSTD_isError(srv)) {
+            ZSTD_freeCCtxParams(cp);
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "ZSTD_CCtxParams_setParameter() failed "
+                               "while deriving the \"zstd_long\" "
+                               "parameters for the per-request "
+                               "compressor memory estimate: %s",
+                               ZSTD_getErrorName(srv));
+            return NGX_CONF_ERROR;
+        }
+
+        /*
+         * Defence in depth. The derivation above is the documented
+         * one, but it is libzstd's documentation rather than a
+         * contract enforced by a public API, and a future release
+         * could add a fifth divisor-bearing sub-parameter. Rather
+         * than risk another SIGFPE taking out "nginx -t", refuse the
+         * configuration if the estimate would still be computed from
+         * a zero divisor we know about.
+         */
+        if (ldm_rlog <= 0) {
+            ZSTD_freeCCtxParams(cp);
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "the per-request compressor memory "
+                               "estimate cannot be computed for this "
+                               "\"zstd_long\" profile: the derived LDM "
+                               "hash rate is zero (window_log %i). Raise "
+                               "\"zstd_window_log\" or disable "
+                               "\"zstd_long\"",
+                               (ngx_int_t) ldm_wlog);
+            return NGX_CONF_ERROR;
+        }
+    }
+
+#if ZSTD_VERSION_NUMBER >= 10506
+    if (conf->target_cblock_size > 0) {
+        srv = ZSTD_CCtxParams_setParameter(
+                  cp, ZSTD_c_targetCBlockSize,
+                  (int) conf->target_cblock_size);
+        if (ZSTD_isError(srv)) {
+            ZSTD_freeCCtxParams(cp);
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "ZSTD_CCtxParams_setParameter("
+                               "targetCBlockSize=%z) failed: %s",
+                               conf->target_cblock_size,
+                               ZSTD_getErrorName(srv));
+            return NGX_CONF_ERROR;
+        }
+    }
+#endif
+
+    e = ZSTD_estimateCStreamSize_usingCCtxParams(cp);
+    ZSTD_freeCCtxParams(cp);
+
+    if (ZSTD_isError(e)) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "ZSTD_estimateCStreamSize_usingCCtxParams() "
+                           "failed: %s", ZSTD_getErrorName(e));
+        return NGX_CONF_ERROR;
+    }
+
+    *est = e;
+
+    return NGX_CONF_OK;
+}
+
+#endif
+
+
 static char *
 ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 {
@@ -2770,7 +3032,19 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_value(conf->target_cblock_size, prev->target_cblock_size, 0);
     ngx_conf_merge_value(conf->window_log, prev->window_log, 0);
     ngx_conf_merge_value(conf->long_mode, prev->long_mode, 0);
-    ngx_conf_merge_value(conf->max_cctx_memory, prev->max_cctx_memory, 0);
+    /*
+     * Merged to NGX_CONF_UNSET, not to 0, deliberately: the implicit
+     * advisory below has to tell "the operator never mentioned this
+     * directive" apart from "the operator wrote zstd_max_cctx_memory
+     * off", and ngx_conf_set_size_slot() stores the latter as 0. Folding
+     * UNSET to 0 here would collapse the two into one value and make the
+     * acknowledgement indistinguishable from silence -- the advisory
+     * would then either never fire or ignore "off". The only other
+     * reader is the explicit-budget check, which already tests
+     * "!= NGX_CONF_UNSET && > 0" and is unaffected.
+     */
+    ngx_conf_merge_value(conf->max_cctx_memory, prev->max_cctx_memory,
+                         NGX_CONF_UNSET);
     ngx_conf_merge_ptr_value(conf->bypass, prev->bypass, NULL);
     ngx_conf_merge_str_value(conf->bypass_vary, prev->bypass_vary, "");
 
@@ -3038,218 +3312,60 @@ close:
     }
 
     /*
-     * Per-request CCtx memory budget (config-load assertion).
+     * Per-request CCtx memory policy (config load).
      *
      * zstd's streaming compressor working set is dominated by the
      * compression-level *strategy* tables (chain/hash/search), not by
-     * the window alone — see the README. Lowering windowLog therefore
+     * the window alone -- see the README. Lowering windowLog therefore
      * does NOT meaningfully bound memory for high levels (level 22 at
-     * windowLog 20 still allocates ~640 MB). The honest, precise lever
-     * is to validate the configured parameters against the operator's
-     * budget at config load using libzstd's own estimator, and refuse
-     * to start if they exceed it. The directive does not silently tune
-     * anything — a too-tight budget is a hard error so operators see
-     * the misconfiguration up front instead of discovering it as a
-     * worker-RSS surprise under concurrency.
+     * windowLog 20 still estimates ~642 MB per context). The honest,
+     * precise lever is libzstd's own estimator, run at config load
+     * against the parameters this location actually merged.
+     *
+     * Two consumers, one estimate (ngx_http_zstd_estimate_cctx_memory()
+     * above computes it for both, so they cannot drift):
+     *
+     *   1. An explicit non-zero "zstd_max_cctx_memory" is a budget the
+     *      operator asked to be held to. Exceeding it is a hard error at
+     *      config load, unchanged: a too-tight budget is a
+     *      misconfiguration the operator should see up front rather than
+     *      discover as a worker-RSS surprise under concurrency.
+     *
+     *   2. No "zstd_max_cctx_memory" at all is the far more common case,
+     *      and it used to mean the estimator never ran -- so a later
+     *      "zstd_comp_level 22" or "zstd_long on" could quietly commit
+     *      hundreds of MB per concurrent response even though the module
+     *      already knew the number at config load. Compression enabled
+     *      with no explicit budget therefore now runs the same estimate
+     *      and WARNS when it exceeds NGX_HTTP_ZSTD_CCTX_ADVISORY_BYTES.
+     *
+     * Why the implicit path warns rather than fails: turning "nginx -t"
+     * from pass to fail on a configuration that works today would break
+     * running deployments on upgrade. The advisory names the number and
+     * the retained worker bound, and tells the operator the two ways to
+     * silence it -- an explicit budget (which restores the hard check)
+     * or an explicit "zstd_max_cctx_memory 0", which is the
+     * acknowledgement that the larger profile is intentional.
      *
      * The estimator API lives in libzstd's experimental section
-     * (ZSTDLIB_STATIC_API), so the check is compiled in only when the
+     * (ZSTDLIB_STATIC_API), so both paths are compiled in only when the
      * module is built with -DZSTD_STATIC_LINKING_ONLY against
      * libzstd >= 1.4.0 (the project's production and CI builds enable
-     * this). Without it, the directive is unsupported and rejected with
-     * an actionable error rather than silently no-op'd.
+     * this). Without it an explicit directive is rejected with an
+     * actionable error rather than silently no-op'd, and the implicit
+     * advisory simply does not run -- a non-static build must not
+     * pretend to be enforcing a bound it cannot compute.
      */
     if (rc == NGX_CONF_OK && conf->enable
         && conf->max_cctx_memory != NGX_CONF_UNSET
         && conf->max_cctx_memory > 0)
     {
 #if defined(ZSTD_STATIC_LINKING_ONLY) && ZSTD_VERSION_NUMBER >= 10400
-        ZSTD_CCtx_params  *cp;
-        size_t             est;
-        size_t             srv;
+        size_t  est;
 
-        cp = ZSTD_createCCtxParams();
-        if (cp == NULL) {
-            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                               "ZSTD_createCCtxParams() failed");
-            return NGX_CONF_ERROR;
-        }
-
-        srv = ZSTD_CCtxParams_init(cp, (int) conf->level);
-        if (ZSTD_isError(srv)) {
-            ZSTD_freeCCtxParams(cp);
-            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                               "ZSTD_CCtxParams_init(level=%i) failed: %s",
-                               conf->level, ZSTD_getErrorName(srv));
-            return NGX_CONF_ERROR;
-        }
-
-        if (conf->window_log > 0) {
-            srv = ZSTD_CCtxParams_setParameter(cp, ZSTD_c_windowLog,
-                                               (int) conf->window_log);
-            if (ZSTD_isError(srv)) {
-                ZSTD_freeCCtxParams(cp);
-                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                                   "ZSTD_CCtxParams_setParameter("
-                                   "windowLog=%i) failed: %s",
-                                   conf->window_log,
-                                   ZSTD_getErrorName(srv));
-                return NGX_CONF_ERROR;
-            }
-        }
-
-        if (conf->long_mode) {
-            ngx_int_t  ldm_wlog, ldm_hlog, ldm_rlog;
-
-            srv = ZSTD_CCtxParams_setParameter(
-                      cp, ZSTD_c_enableLongDistanceMatching, 1);
-            if (ZSTD_isError(srv)) {
-                ZSTD_freeCCtxParams(cp);
-                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                                   "ZSTD_CCtxParams_setParameter("
-                                   "enableLongDistanceMatching) failed: %s",
-                                   ZSTD_getErrorName(srv));
-                return NGX_CONF_ERROR;
-            }
-
-            /*
-             * BLOCKER fix: ZSTD_estimateCStreamSize_usingCCtxParams()
-             * divides by params->ldmParams.hashRateLog. libzstd derives
-             * the LDM sub-parameters lazily, inside compression setup --
-             * a ZSTD_CCtx_params that has only had
-             * ZSTD_c_enableLongDistanceMatching set still carries
-             * hashRateLog == 0, so the estimator divides by zero and the
-             * whole process dies with SIGFPE during "nginx -t". Setting
-             * ZSTD_c_windowLog does not help: the divisor is unrelated to
-             * the window.
-             *
-             * There is no public "adjust these params the way you would
-             * internally" entry point, so we derive the same four values
-             * libzstd documents in zstd.h and push them explicitly. From
-             * the ZSTD_c_ldm* documentation:
-             *
-             *   - enabling LDM raises the default windowLog to 27
-             *     (128 MB) unless windowLog was expressly set;
-             *   - ldmHashLog     default = windowLog - 7, clamped to
-             *                    [ZSTD_LDM_HASHLOG_MIN,
-             *                     ZSTD_LDM_HASHLOG_MAX];
-             *   - ldmMinMatch    default = 64;
-             *   - ldmBucketSizeLog default = 3;
-             *   - ldmHashRateLog default = MAX(0, windowLog - ldmHashLog).
-             *
-             * Seeding these makes the estimate accurate rather than
-             * merely non-crashing. Measured against a real streaming
-             * ZSTD_CCtx compressing 256 MB with unknown content size
-             * (libzstd 1.5.7, level 3): seeded estimate 144328225 bytes
-             * vs. ZSTD_sizeof_CCtx() 144262689 -- 0.05% conservative.
-             * With "zstd_window_log 20": 2705953 vs. 2705441, 0.02%
-             * conservative. So the operator's budget still means what it
-             * says under LDM; we neither crash nor silently drop the
-             * bound, and we do not manufacture spurious rejections.
-             *
-             * Note that windowLog is pushed explicitly here even when the
-             * operator did not configure one: the estimator must see the
-             * same 27 that libzstd would default to under LDM, otherwise
-             * it would size for the level's much smaller default window
-             * and under-report by two orders of magnitude.
-             */
-
-            ldm_wlog = conf->window_log > 0 ? conf->window_log
-                                            : NGX_HTTP_ZSTD_LDM_WINDOWLOG;
-
-            ldm_hlog = ldm_wlog - 7;
-            if (ldm_hlog < ZSTD_LDM_HASHLOG_MIN) {
-                ldm_hlog = ZSTD_LDM_HASHLOG_MIN;
-            }
-            if (ldm_hlog > ZSTD_LDM_HASHLOG_MAX) {
-                ldm_hlog = ZSTD_LDM_HASHLOG_MAX;
-            }
-
-            ldm_rlog = ldm_wlog - ldm_hlog;
-            if (ldm_rlog < 0) {
-                ldm_rlog = 0;
-            }
-
-            srv = ZSTD_CCtxParams_setParameter(cp, ZSTD_c_windowLog,
-                                               (int) ldm_wlog);
-            if (!ZSTD_isError(srv)) {
-                srv = ZSTD_CCtxParams_setParameter(cp, ZSTD_c_ldmHashLog,
-                                                   (int) ldm_hlog);
-            }
-            if (!ZSTD_isError(srv)) {
-                srv = ZSTD_CCtxParams_setParameter(
-                          cp, ZSTD_c_ldmMinMatch,
-                          NGX_HTTP_ZSTD_LDM_MINMATCH);
-            }
-            if (!ZSTD_isError(srv)) {
-                srv = ZSTD_CCtxParams_setParameter(
-                          cp, ZSTD_c_ldmBucketSizeLog,
-                          NGX_HTTP_ZSTD_LDM_BUCKETSIZELOG);
-            }
-            if (!ZSTD_isError(srv)) {
-                srv = ZSTD_CCtxParams_setParameter(cp, ZSTD_c_ldmHashRateLog,
-                                                   (int) ldm_rlog);
-            }
-
-            if (ZSTD_isError(srv)) {
-                ZSTD_freeCCtxParams(cp);
-                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                                   "ZSTD_CCtxParams_setParameter() failed "
-                                   "while deriving the \"zstd_long\" "
-                                   "parameters for the "
-                                   "\"zstd_max_cctx_memory\" estimate: %s",
-                                   ZSTD_getErrorName(srv));
-                return NGX_CONF_ERROR;
-            }
-
-            /*
-             * Defence in depth. The derivation above is the documented
-             * one, but it is libzstd's documentation rather than a
-             * contract enforced by a public API, and a future release
-             * could add a fifth divisor-bearing sub-parameter. Rather
-             * than risk another SIGFPE taking out "nginx -t", refuse the
-             * configuration if the estimate would still be computed from
-             * a zero divisor we know about.
-             */
-            if (ldm_rlog <= 0) {
-                ZSTD_freeCCtxParams(cp);
-                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                                   "\"zstd_max_cctx_memory\" cannot be "
-                                   "verified for this \"zstd_long\" "
-                                   "profile: the derived LDM hash rate is "
-                                   "zero (window_log %i). Raise "
-                                   "\"zstd_window_log\", disable "
-                                   "\"zstd_long\", or remove "
-                                   "\"zstd_max_cctx_memory\"",
-                                   (ngx_int_t) ldm_wlog);
-                return NGX_CONF_ERROR;
-            }
-        }
-
-#if ZSTD_VERSION_NUMBER >= 10506
-        if (conf->target_cblock_size > 0) {
-            srv = ZSTD_CCtxParams_setParameter(
-                      cp, ZSTD_c_targetCBlockSize,
-                      (int) conf->target_cblock_size);
-            if (ZSTD_isError(srv)) {
-                ZSTD_freeCCtxParams(cp);
-                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                                   "ZSTD_CCtxParams_setParameter("
-                                   "targetCBlockSize=%z) failed: %s",
-                                   conf->target_cblock_size,
-                                   ZSTD_getErrorName(srv));
-                return NGX_CONF_ERROR;
-            }
-        }
-#endif
-
-        est = ZSTD_estimateCStreamSize_usingCCtxParams(cp);
-        ZSTD_freeCCtxParams(cp);
-
-        if (ZSTD_isError(est)) {
-            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                               "ZSTD_estimateCStreamSize_usingCCtxParams() "
-                               "failed: %s", ZSTD_getErrorName(est));
+        if (ngx_http_zstd_estimate_cctx_memory(cf, conf, &est)
+            != NGX_CONF_OK)
+        {
             return NGX_CONF_ERROR;
         }
 
@@ -3273,6 +3389,50 @@ close:
                            "\"zstd_window_log\" for a coarse window-based "
                            "bound");
         return NGX_CONF_ERROR;
+#endif
+    }
+
+    /*
+     * Implicit advisory: compression enabled, no explicit budget.
+     *
+     * "max_cctx_memory == 0" is reached two ways and they mean different
+     * things. NGX_CONF_UNSET means the operator never mentioned the
+     * directive anywhere in the inheritance chain -- that is the case
+     * this advisory exists for. A merged 0 that is NOT UNSET came from
+     * an explicit "zstd_max_cctx_memory 0", which is the operator
+     * acknowledging the profile. The two are only distinguishable
+     * because the merge above preserves NGX_CONF_UNSET instead of
+     * folding it to 0; see the note there.
+     */
+    if (rc == NGX_CONF_OK && conf->enable
+        && conf->max_cctx_memory == NGX_CONF_UNSET)
+    {
+#if defined(ZSTD_STATIC_LINKING_ONLY) && ZSTD_VERSION_NUMBER >= 10400
+        size_t  est;
+
+        if (ngx_http_zstd_estimate_cctx_memory(cf, conf, &est)
+            != NGX_CONF_OK)
+        {
+            return NGX_CONF_ERROR;
+        }
+
+        if (est > NGX_HTTP_ZSTD_CCTX_ADVISORY_BYTES) {
+            ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                               "the configured zstd parameters need ~%uz "
+                               "bytes of per-request compressor memory "
+                               "(zstd_comp_level %i); each worker retains "
+                               "up to %d such contexts, so worker RSS can "
+                               "reach ~%uz bytes, and that again per "
+                               "worker process. Set "
+                               "\"zstd_max_cctx_memory\" to a budget to "
+                               "have this enforced at config load, or "
+                               "\"zstd_max_cctx_memory 0\" to "
+                               "acknowledge the profile and silence this "
+                               "warning",
+                               est, conf->level,
+                               (int) NGX_HTTP_ZSTD_CCTX_SLOTS,
+                               est * NGX_HTTP_ZSTD_CCTX_SLOTS);
+        }
 #endif
     }
 


### PR DESCRIPTION
> From the G5 backlog row on `zstd_max_cctx_memory` defaulting to `0`. Builds on #164, which fixed the SIGFPE that made the estimator unsafe to run on LDM profiles — that fix is what makes running it unconditionally possible at all.

## TL;DR

The module can already work out, at config load, how much memory each compression profile will need per request. It only ever did that when an operator explicitly asked for a budget, which almost nobody does. So the expensive settings were one line away from a working config with nothing to warn you: turn on `zstd_comp_level 22` and every concurrent response quietly commits about 769 MB of compressor scratch space. Now that estimate always runs, and says something when the number is large.

Compression enabled with no explicit `zstd_max_cctx_memory` now runs `ngx_http_zstd_estimate_cctx_memory()` at merge time and emits an `NGX_LOG_WARN` naming the estimate when it exceeds `NGX_HTTP_ZSTD_CCTX_ADVISORY_BYTES` (32 MB).

**Severity:** `Low` (`resource exhaustion — a known-at-config-load memory commitment went unreported`)

## Why it warns instead of failing

Failing would be the stronger guarantee and it is the wrong call here. `nginx -t` currently passes on `zstd_comp_level 22`; making it fail turns a working deployment into a broken one on package upgrade, for a config the operator may have chosen deliberately. So the advisory is informational, and the two explicit spellings keep their meaning:

| config | behaviour |
| --- | --- |
| no `zstd_max_cctx_memory` | estimate runs, warns above 32 MB — **new** |
| `zstd_max_cctx_memory <size>` | hard config-load failure if exceeded — unchanged |
| `zstd_max_cctx_memory 0` | operator acknowledgement, silent |

`0` rather than `off` because the directive uses `ngx_conf_set_size_slot()`, which parses sizes only. Swapping in a custom setter to gain a synonym was out of scope.

## Mechanism

Telling "never set" from "explicitly 0" needed a merge change. `ngx_conf_merge_value()` folded `NGX_CONF_UNSET` to `0`, so both cases arrived at the advisory as the same value — the first version of this patch tested for `NGX_CONF_UNSET` after that merge and the branch was simply dead. The merge now preserves `NGX_CONF_UNSET`; the only other reader already tests `!= NGX_CONF_UNSET && > 0` and is unaffected.

The estimator body moved into one static helper shared by both consumers, so the LDM sub-parameter seeding from #164, the `ldm_rlog <= 0` guard and the `targetCBlockSize` block cannot drift between the hard check and the advisory. Every error path still frees the `ZSTD_CCtx_params`: 7 frees against 8 post-allocation returns, the eighth being the pre-allocation `cp == NULL` return.

Side effect worth noting — `ngx_http_zstd_merge_loc_conf()` dropped from **CCN 50 / 284 NLOC to CCN 37 / 197 NLOC** (`lizard`) despite gaining a feature.

## Choosing 32 MB

Measured with `ZSTD_estimateCStreamSize_usingCCtxParams()` on libzstd 1.5.7, streaming with unknown content size — the module's actual path, not a pledged-size measurement:

| profile (level 3 unless stated) | per request | per worker (×4) | advisory |
| --- | ---: | ---: | :---: |
| `zstd_comp_level 3` (default) | 3.5 MB | 14.0 MB | no |
| `zstd_comp_level 9` | 16.7 MB | 67.0 MB | no |
| `zstd_comp_level 11` | 28.7 MB | 115.0 MB | no |
| `zstd_comp_level 12` | 52.7 MB | 211.0 MB | **yes** |
| `zstd_comp_level 19` | 89.5 MB | 358.0 MB | **yes** |
| `zstd_comp_level 22` | 769.5 MB | 3078.0 MB | **yes** |
| `zstd_long on` | 137.6 MB | 550.6 MB | **yes** |
| `zstd_window_log 27` | 129.5 MB | 518.0 MB | **yes** |
| `zstd_long on` + `zstd_window_log 20` | 2.6 MB | 10.3 MB | no |

32 MB lands in the natural gap between level 11 and level 12, so the ordinary web-serving range stays silent. The `×4` column is `NGX_HTTP_ZSTD_CCTX_SLOTS`: `ZSTD_sizeof_CCtx()` does not shrink on reset, so a worker's high-water mark is the estimate times the ring size — and that again per worker process. The warning states that figure rather than only the per-request one, because the per-worker number is what shows up in RSS.

## Config-load cost

The estimator now runs on every enabled location, so I measured it rather than reasoning from shape (`ci/tools/config_bench.py`, 5 rounds, median):

| workload | 2000 loc | 8000 loc | 16000 loc |
| --- | ---: | ---: | ---: |
| `locations-same-profile` | +0.3% | +0.9% | -3.0% |
| `locations-multi-profile` | +13.6% | +4.5% | +4.1% |

Same-profile is noise — the sign flips across scales. Multi-profile costs a real but small **+4.3 ms at 16 000 distinct-profile locations** (105.4 ms → 109.7 ms), about 0.27 µs each, with peak RSS flat to within 0.1%. `ZSTD_estimateCStreamSize_usingCCtxParams()` is arithmetic over the params struct and allocates no workspace, which is why it is this cheap. Not worth memoizing; a gate would add a cache to save 4 ms of one-time work.

## Testing

New: `ci/tools/test_cctx_advisory_policy.py`, wired into both the `tests` and coverage jobs in `build-test.yml`. Eight `nginx -t` arms covering the matrix the row asked for — default, level 22, `zstd_long`, explicit `zstd_window_log`, dictionary, explicit budget, explicit acknowledgement, and a too-tight budget. Each asserts both the exit status *and* whether the advisory appeared, which is the part `ci/t/00-filter.t` cannot express: `--- must_die` cannot say "must pass **and** must have warned", and a policy that failed the config would satisfy any `must_die`-shaped assertion while being exactly the breaking change this design rejects.

```
  1 default profile          exit 0 (want 0), advisory no  (want no)
  2 zstd_comp_level 22       exit 0 (want 0), advisory yes (want yes), estimate 806879903 bytes
  3 zstd_long on             exit 0 (want 0), advisory yes (want yes), estimate 144328225 bytes
  4 zstd_window_log 27       exit 0 (want 0), advisory yes (want yes), estimate 135783969 bytes
  5 level 22 + budget 1024m  exit 0 (want 0), advisory no  (want no)
  6 level 22 + budget 0 (ack) exit 0 (want 0), advisory no  (want no)
  7 level 22 + budget 64m    exit 1 (want non-zero), advisory no  (want no)
  8 dictionary, default level exit 0 (want 0), advisory no  (want no)

OK: CCtx memory advisory policy (8/8 arms)
```

Arms 1, 5, 6 and 8 assert the advisory is **absent**, so the obvious wrong implementation — warn unconditionally — fails them.

**Negative controls, both observed red.** Compiling the advisory block out entirely (`if (0 && ...)`, module `.so` 157192 → 156192 bytes on rebuild) fails arms 2, 3 and 4 while 1, 5, 6, 7 and 8 stay green. Separately, reverting the merge to `ngx_conf_merge_value(..., 0)` — the original defect — also fails arms 2, 3 and 4, confirming the tri-state is load-bearing rather than incidental. Restored build is 157192 bytes and 8/8 green.

Regression: `ci/tools/test_ldm_budget_config.py` 5/5 (the #164 SIGFPE fix and the hard-check semantics survive the refactor), `ci/t/00-filter.t` **1191/1191**, `ci/t/02-conf-warn.t` **67/67**, `ci/tools/test_docs_ci_drift.sh` clean.

`review-lint.sh --branch master` reports all linters clean. `gcc -fanalyzer` on the full TU produces no `-Wanalyzer` diagnostics — verified non-vacuous by confirming the TU parsed (49 KB object, `estimate_cctx` symbol present) rather than trusting an empty result.
