### PR TITLE
security(buffers): bound the aggregate zstd_buffers number*size at config load

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1515,6 +1515,14 @@ jobs:
           python3 ci/tools/test_ldm_budget_config.py \
             --nginx-binary "$TEST_NGINX_BINARY" --port 18124
           echo "✓ zstd_long + zstd_max_cctx_memory config validation passed"
+          # Aggregate "zstd_buffers number size" bound: ngx_conf_set_bufs_slot()
+          # (nginx core) never checks the product, and neither does the
+          # merge that applies an inherited or defaulted value. Overflow
+          # is a hard error; a representable-but-large total is advisory
+          # only. ci/t cannot express "PASS and warns"; see the tool.
+          python3 ci/tools/test_bufs_bound_policy.py \
+            --nginx-binary "$TEST_NGINX_BINARY" --port 18141
+          echo "✓ zstd_buffers aggregate bound policy matrix passed"
 
       - name: Run RFC 9842 dcz end-to-end test
         timeout-minutes: 6
@@ -1958,6 +1966,8 @@ jobs:
             --nginx-binary "$TEST_NGINX_BINARY" --port 19104 --backend-port 19105
           python3 ci/tools/test_ldm_budget_config.py \
             --nginx-binary "$TEST_NGINX_BINARY" --port 19122
+          python3 ci/tools/test_bufs_bound_policy.py \
+            --nginx-binary "$TEST_NGINX_BINARY" --port 19141
           python3 ci/tools/test_zstd_long_ldm.py \
             --nginx-binary "$TEST_NGINX_BINARY" --port 19102 --backend-port 19103
           python3 ci/tools/test_dcz.py --nginx-binary "$TEST_NGINX_BINARY" \

--- a/CHANGES
+++ b/CHANGES
@@ -1,17 +1,23 @@
 Changes with http-zstd
 
     *) Feature: "zstd_buffers number size" now bounds the aggregate
-       number x size product at config load. The directive previously
-       delegated entirely to nginx core's ngx_conf_set_bufs_slot(),
-       which range-checks each argument but never the product, so a
-       typo ("zstd_buffers 100000 100000;" instead of "100 100k;") or a
-       value inherited unchanged from an outer block could request an
-       overflowing or merely enormous per-response output-chain pool.
-       An overflowing product is now a hard config-load error naming
-       both operands; a representable product above 8 MB is a warning
+       number x size product at config load, in four tiers. The
+       directive previously delegated entirely to nginx core's
+       ngx_conf_set_bufs_slot(), which range-checks each argument but
+       never the product, so a typo ("zstd_buffers 100000 100000;"
+       instead of "100 100k;") or a value inherited unchanged from an
+       outer block could request an overflowing, or merely enormous, or
+       even multi-exabyte per-response output-chain pool -- the last of
+       these previously passed with only a log line. An overflowing
+       product is a hard config-load error naming both operands,
+       unconditionally. A representable product above 8 MB is a warning
        (never a failure) naming the total, marked as per-response, and
        cross-referencing the "zstd_max_cctx_memory" advisory for the
-       other half of the per-request memory budget. The check covers an
+       other half of the per-request memory budget. A representable
+       product above 256 MB is now a hard config-load error unless the
+       new "zstd_buffers_unsafe on;" directive (http, server, location,
+       inherited) is also set, in which case it is accepted and still
+       logged as a warning rather than silenced. The check covers an
        explicit value, one inherited from an outer block, and the
        module's own default alike.
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,20 @@
 Changes with http-zstd
 
+    *) Feature: "zstd_buffers number size" now bounds the aggregate
+       number x size product at config load. The directive previously
+       delegated entirely to nginx core's ngx_conf_set_bufs_slot(),
+       which range-checks each argument but never the product, so a
+       typo ("zstd_buffers 100000 100000;" instead of "100 100k;") or a
+       value inherited unchanged from an outer block could request an
+       overflowing or merely enormous per-response output-chain pool.
+       An overflowing product is now a hard config-load error naming
+       both operands; a representable product above 8 MB is a warning
+       (never a failure) naming the total, marked as per-response, and
+       cross-referencing the "zstd_max_cctx_memory" advisory for the
+       other half of the per-request memory budget. The check covers an
+       explicit value, one inherited from an outer block, and the
+       module's own default alike.
+
     *) Bugfix: "nginx -t" no longer dies with SIGFPE when "zstd_long on"
        is combined with "zstd_max_cctx_memory". The config-load budget
        check calls ZSTD_estimateCStreamSize_usingCCtxParams(), which

--- a/README.md
+++ b/README.md
@@ -483,6 +483,49 @@ http {
 > directive unset so the size always tracks the library — only write it
 > explicitly when you are deliberately overriding it.
 
+#### Aggregate bound on `number × size`
+
+`number` and `size` are each range-checked on their own by nginx core,
+but the **product** was not checked at all until this policy was added —
+a typo (`zstd_buffers 100000 100000;` instead of `100 100k;`) or a value
+inherited unchanged from an outer block could request an overflowing or
+merely enormous per-response output-chain pool, multiplied by every
+concurrent response under load.
+
+* **`number × size` overflowing the platform's `size_t`** is a hard
+  config-load error, unconditionally — there is no representable
+  acknowledgement for a product that cannot exist:
+
+  ```
+  nginx: [emerg] "zstd_buffers" (explicit directive) requests
+  9223372036854775807 buffers of 9223372036854775807 bytes each; that
+  product overflows the platform's size_t and cannot be a config any
+  operator meant to write
+  ```
+
+* **A representable-but-large product** (above **8 MB**, generous
+  headroom over both nginx's own `zstd_buffers 32 4k` default and this
+  module's own `2 × ZSTD_CStreamOutSize()` default) is a **warning**, not
+  an error — a config that loads today keeps loading after an upgrade:
+
+  ```
+  nginx: [warn] "zstd_buffers" (merged value) requests 1 x 8388609 bytes
+  = ~8388609 bytes of output-chain memory PER RESPONSE; that is on top
+  of the per-request compressor (CCtx) working set -- see the
+  "zstd_max_cctx_memory" advisory above for that figure -- and both are
+  multiplied by concurrent responses under load
+  ```
+
+  The total is **per response**; add it to the CCtx figure from the
+  [`zstd_max_cctx_memory`](#zstd_max_cctx_memory) advisory to size the
+  full per-request compressor + output-chain budget, then multiply by
+  expected concurrency.
+
+The check runs once the value is fully resolved (explicit, inherited
+from an outer block, or this module's own default) so all three sources
+are covered by the same bound; an explicit value that also happens to be
+the one that ends up in effect is warned about once, not twice.
+
 ---
 
 ### zstd_target_cblock_size

--- a/README.md
+++ b/README.md
@@ -490,41 +490,78 @@ but the **product** was not checked at all until this policy was added —
 a typo (`zstd_buffers 100000 100000;` instead of `100 100k;`) or a value
 inherited unchanged from an outer block could request an overflowing or
 merely enormous per-response output-chain pool, multiplied by every
-concurrent response under load.
+concurrent response under load. Four tiers apply to the resolved value,
+in ascending severity:
 
-* **`number × size` overflowing the platform's `size_t`** is a hard
-  config-load error, unconditionally — there is no representable
-  acknowledgement for a product that cannot exist:
+1. **`≤ 8 MB`** — silent. This covers nginx's own `zstd_buffers 32 4k`
+   default (128 KB) and this module's own `2 × ZSTD_CStreamOutSize()`
+   default (~256 KB at level 6) with generous headroom.
 
-  ```
-  nginx: [emerg] "zstd_buffers" (explicit directive) requests
-  9223372036854775807 buffers of 9223372036854775807 bytes each; that
-  product overflows the platform's size_t and cannot be a config any
-  operator meant to write
-  ```
+2. **`> 8 MB`, `≤ 256 MB`** — a **warning**, not an error. A config that
+   loads today keeps loading after an upgrade:
 
-* **A representable-but-large product** (above **8 MB**, generous
-  headroom over both nginx's own `zstd_buffers 32 4k` default and this
-  module's own `2 × ZSTD_CStreamOutSize()` default) is a **warning**, not
-  an error — a config that loads today keeps loading after an upgrade:
+   ```
+   nginx: [warn] "zstd_buffers" (merged value) requests 1 x 8388609 bytes
+   = ~8388609 bytes of output-chain memory PER RESPONSE; that is on top
+   of the per-request compressor (CCtx) working set -- see the
+   "zstd_max_cctx_memory" advisory above for that figure -- and both are
+   multiplied by concurrent responses under load
+   ```
 
-  ```
-  nginx: [warn] "zstd_buffers" (merged value) requests 1 x 8388609 bytes
-  = ~8388609 bytes of output-chain memory PER RESPONSE; that is on top
-  of the per-request compressor (CCtx) working set -- see the
-  "zstd_max_cctx_memory" advisory above for that figure -- and both are
-  multiplied by concurrent responses under load
-  ```
+3. **`> 256 MB`, no acknowledgement** — a **hard config-load error**.
+   Unlike the CCtx memory estimate (which depends on libzstd internals
+   the operator never directly sees), `number` and `size` are two
+   integers the operator typed out literally, so at 256 MB — two hundred
+   times nginx's own default — a refusal by default is the safer
+   reading of "this is almost certainly a mistake":
 
-  The total is **per response**; add it to the CCtx figure from the
-  [`zstd_max_cctx_memory`](#zstd_max_cctx_memory) advisory to size the
-  full per-request compressor + output-chain budget, then multiply by
-  expected concurrency.
+   ```
+   nginx: [emerg] "zstd_buffers" (merged value) requests 2147483647 x
+   1073741824 bytes = ~2305843008139952128 bytes of output-chain memory
+   PER RESPONSE, above the 256 MB hard cap -- that is on top of the
+   per-request compressor (CCtx) working set (see the
+   "zstd_max_cctx_memory" advisory above) and both are multiplied by
+   concurrent responses under load. Lower "zstd_buffers", or set
+   "zstd_buffers_unsafe on;" to acknowledge this total is intentional
+   ```
+
+4. **`> 256 MB`, with `zstd_buffers_unsafe on;`** — accepted, still
+   logged as a **warning** (not silenced) so the acknowledgement remains
+   visible in the log:
+
+   ```
+   nginx: [warn] "zstd_buffers" (merged value) requests 2147483647 x
+   1073741824 bytes = ~2305843008139952128 bytes of output-chain memory
+   PER RESPONSE, above the 256 MB hard cap; accepted because
+   "zstd_buffers_unsafe on;" acknowledges it. ...
+   ```
+
+`number × size` **overflowing the platform's `size_t`** is refused
+unconditionally at every tier, including with `zstd_buffers_unsafe on;`
+set — there is no representable acknowledgement for a product that
+cannot exist:
+
+```
+nginx: [emerg] "zstd_buffers" (explicit directive) requests
+9223372036854775807 buffers of 9223372036854775807 bytes each; that
+product overflows the platform's size_t and cannot be a config any
+operator meant to write
+```
+
+The total named in tiers 2–4 is **per response**; add it to the CCtx
+figure from the [`zstd_max_cctx_memory`](#zstd_max_cctx_memory) advisory
+to size the full per-request compressor + output-chain budget, then
+multiply by expected concurrency.
+
+`zstd_buffers_unsafe` is `http, server, location` scoped and inherits
+like any other directive here — set it once at the level that also sets
+`zstd_buffers`, or higher up if every location beneath needs the same
+acknowledgement.
 
 The check runs once the value is fully resolved (explicit, inherited
 from an outer block, or this module's own default) so all three sources
 are covered by the same bound; an explicit value that also happens to be
-the one that ends up in effect is warned about once, not twice.
+the one that ends up in effect is reported once, not twice.
 
 ---
 

--- a/ci/tools/test_bufs_bound_policy.py
+++ b/ci/tools/test_bufs_bound_policy.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Config-load policy: bound the aggregate ``zstd_buffers number size``.
+
+``zstd_buffers`` delegates to nginx core's ``ngx_conf_set_bufs_slot()``,
+which rejects only a parse error or either argument being zero -- it never
+looks at the PRODUCT. ``ngx_conf_merge_bufs_value()`` (invoked from
+``ngx_http_zstd_merge_loc_conf()``) then either keeps an explicit value,
+inherits the parent's, or applies this module's own default
+(``2 x ZSTD_CStreamOutSize()``); none of those three paths re-validates the
+pair either. A typo ("zstd_buffers 100000 100000;" instead of
+"100 100k;") or a value inherited from an outer block could therefore
+request an overflowing or merely enormous per-response output-chain pool
+that nginx would happily commit per concurrent response.
+
+The policy under test
+----------------------
+  * ``num * size`` overflowing ``size_t`` is a hard config-load error,
+    unconditionally -- there is no representable acknowledgement for a
+    product that cannot exist.
+  * A representable-but-large product (> ``NGX_HTTP_ZSTD_BUFS_ADVISORY_BYTES``,
+    8 MB) is a ``[warn]`` naming the total, PER RESPONSE, cross-referencing
+    the ``zstd_max_cctx_memory`` advisory for the CCtx half of the budget.
+    It never fails the configuration -- a config that loads today keeps
+    loading.
+  * The check runs once at merge time, which is the single point that
+    covers an EXPLICIT value, one INHERITED from an outer block, and the
+    module's own DEFAULT alike (all three land in the same ``conf->bufs``
+    the filter reads from). The parse-time slot additionally catches an
+    overflowing explicit value at the earliest point, but does not repeat
+    the advisory -- so a bare explicit large value warns exactly once, not
+    twice.
+
+Why this test and not ``ci/t/02-conf-warn.t``: Test::Nginx's error-log
+greps can assert a substring appeared, but cannot assert a config-load run
+PASSED with the warning present, is REFUSED with a specific message for
+overflow, and passed with NO warning at all for the near-boundary/ack
+cases -- all as one matrix with an explicit non-zero exit code check. A
+signal death (e.g. a bad cast crashing "nginx -t") would still satisfy a
+plain string grep; this harness explicitly separates that case out.
+
+Arms
+----
+1. default zstd_buffers (module default, 2 x stream_out_size)  -> PASS,
+   no warning (the ordinary case must stay silent).
+2. cap - 1 byte (``zstd_buffers 1 8388607``)                    -> PASS,
+   no warning.
+3. cap exact (``zstd_buffers 1 8388608``)                       -> PASS,
+   no warning (the boundary itself is inclusive of "not advised").
+4. cap + 1 byte (``zstd_buffers 1 8388609``)                    -> PASS,
+   warning naming ~8388609 bytes.
+5. product overflow (``zstd_buffers <huge> <huge>``)            -> REFUSED,
+   naming both operands, never a signal death.
+6. inherited from an outer (http) block, over the cap           -> PASS,
+   warning fires at the location that merges it in (proves inheritance is
+   covered, not just the location that wrote the directive).
+7. explicit large value fires exactly ONCE, not twice (parse-time slot
+   must not duplicate the merge-time advisory).
+
+Arms 1-3 are the controls that keep this test from being vacuous: a build
+that warns unconditionally on any zstd_buffers value fails them.
+"""
+
+import argparse
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+# NGX_HTTP_ZSTD_BUFS_ADVISORY_BYTES in src/ngx_http_zstd_filter_module.c.
+ADVISORY_BYTES = 8 * 1024 * 1024
+
+WARN_RE = re.compile(
+    r'"zstd_buffers" \((?P<ctx>[^)]+)\) requests (?P<num>\d+) x '
+    r"(?P<size>\d+) bytes = ~(?P<total>\d+) bytes"
+)
+OVERFLOW_RE = re.compile(
+    r'"zstd_buffers" \([^)]+\) requests (\d+) buffers of (\d+) bytes each; '
+    r"that product overflows"
+)
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--nginx-binary", required=True)
+    p.add_argument("--filter-module")
+    p.add_argument("--port", type=int, default=18140)
+    return p.parse_args()
+
+
+def detect_module(explicit, nginx: pathlib.Path):
+    if explicit:
+        return pathlib.Path(explicit)
+    sib = nginx.parent / "ngx_http_zstd_filter_module.so"
+    return sib if sib.exists() else None
+
+
+def config_test(nginx, module, port, http_directives, srv_directives):
+    """Run ``nginx -t``; return (returncode, combined output)."""
+    with tempfile.TemporaryDirectory() as td:
+        root = pathlib.Path(td)
+        (root / "conf").mkdir()
+        (root / "logs").mkdir()
+
+        load = f"load_module {module};\n" if module else ""
+        (root / "conf" / "nginx.conf").write_text(
+            f"{load}"
+            "events {}\n"
+            "http {\n"
+            f"    {http_directives}\n"
+            f"    server {{\n"
+            f"        listen 127.0.0.1:{port};\n"
+            "        zstd on;\n"
+            f"        {srv_directives}\n"
+            "    }\n"
+            "}\n"
+        )
+
+        proc = subprocess.run(
+            [str(nginx), "-p", str(root), "-c", "conf/nginx.conf", "-t"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        return proc.returncode, proc.stdout + proc.stderr
+
+
+def check_not_a_signal(name, rc, out):
+    if rc < 0:
+        return [f"{name}: nginx -t died on signal {-rc}; output: {out.strip()!r}"]
+    if rc > 128:
+        return [
+            (
+                f"{name}: nginx -t exited {rc} (128+{rc - 128}), a signal "
+                f"death, not a diagnostic; output: {out.strip()!r}"
+            )
+        ]
+    return []
+
+
+def run_arm(
+    nginx,
+    module,
+    port,
+    name,
+    http_directives,
+    srv_directives,
+    want_pass,
+    want_warning,
+    want_overflow_error=False,
+    min_total=None,
+    max_warn_count=1,
+):
+    """One matrix cell. Returns (failures, printable summary)."""
+    rc, out = config_test(nginx, module, port, http_directives, srv_directives)
+    failures = check_not_a_signal(name, rc, out)
+
+    if want_pass and rc != 0:
+        failures.append(
+            f"{name}: expected nginx -t to PASS but it exited {rc}. The "
+            f"bufs bound policy must never turn a working config into a "
+            f"config-load failure; output: {out.strip()!r}"
+        )
+    if not want_pass and rc == 0:
+        failures.append(
+            f"{name}: expected nginx -t to be REFUSED but it exited 0; "
+            f"output: {out.strip()!r}"
+        )
+
+    warns = WARN_RE.findall(out)
+
+    if want_warning and not warns:
+        failures.append(
+            f"{name}: expected the [warn] advisory naming the aggregate "
+            f"buffer total, but it was not emitted; output: {out.strip()!r}"
+        )
+    if not want_warning and warns:
+        failures.append(
+            f"{name}: the advisory was emitted but must NOT be. Either "
+            f"the threshold is wrong or the boundary is off-by-one; "
+            f"output: {out.strip()!r}"
+        )
+    if warns and len(warns) > max_warn_count:
+        failures.append(
+            f"{name}: advisory fired {len(warns)} times (want at most "
+            f"{max_warn_count}) -- the parse-time slot and the merge-time "
+            f"check are double-reporting the same explicit value; output: "
+            f"{out.strip()!r}"
+        )
+
+    if warns and "[warn]" not in out:
+        failures.append(
+            f"{name}: matched the advisory text but not at [warn] level; "
+            f"output: {out.strip()!r}"
+        )
+
+    total = None
+    if warns:
+        total = int(warns[0][3])
+        if total <= ADVISORY_BYTES:
+            failures.append(
+                f"{name}: advisory fired at {total} bytes, which is <= the "
+                f"{ADVISORY_BYTES}-byte threshold. The condition is not "
+                f"the documented one."
+            )
+        if min_total is not None and total < min_total:
+            failures.append(
+                f"{name}: advisory reports {total} bytes, below the "
+                f"expected {min_total}. Computed from the wrong operands."
+            )
+        if "per response" not in out.lower():
+            failures.append(
+                f"{name}: advisory does not state the total is PER "
+                f"RESPONSE; output: {out.strip()!r}"
+            )
+        if "zstd_max_cctx_memory" not in out:
+            failures.append(
+                f"{name}: advisory does not cross-reference the CCtx "
+                f'memory advisory ("zstd_max_cctx_memory"); output: '
+                f"{out.strip()!r}"
+            )
+
+    if want_overflow_error:
+        m = OVERFLOW_RE.search(out)
+        if m is None:
+            failures.append(
+                f"{name}: expected the overflow diagnostic naming both "
+                f"operands, but it was not found; output: {out.strip()!r}"
+            )
+        elif "[emerg]" not in out:
+            failures.append(
+                f"{name}: overflow diagnostic present but not at [emerg] "
+                f"level; output: {out.strip()!r}"
+            )
+
+    summary = (
+        f"  {name:<38} exit {rc} (want {'0' if want_pass else 'non-zero'}), "
+        f"warnings {len(warns)} (want {'>=1' if want_warning else '0'})"
+        + (f", total {total} bytes" if total is not None else "")
+    )
+    return failures, summary
+
+
+def main() -> int:
+    args = parse_args()
+    nginx = pathlib.Path(args.nginx_binary).resolve()
+    if not nginx.exists():
+        print(f"FAIL: nginx binary not found: {nginx}", file=sys.stderr)
+        return 1
+
+    module = detect_module(args.filter_module, nginx)
+    if module is not None:
+        module = module.resolve()
+        if not module.exists():
+            print(f"FAIL: filter module not found: {module}", file=sys.stderr)
+            return 1
+
+    huge = 9223372036854775807  # ngx_int_t / int64_t max on a 64-bit build.
+
+    matrix = [
+        {
+            "name": "1 default bufs",
+            "http_directives": "",
+            "srv_directives": "",
+            "want_pass": True,
+            "want_warning": False,
+        },
+        {
+            "name": "2 cap-1 (8388607)",
+            "http_directives": "",
+            "srv_directives": "zstd_buffers 1 8388607;",
+            "want_pass": True,
+            "want_warning": False,
+        },
+        {
+            "name": "3 cap exact (8388608)",
+            "http_directives": "",
+            "srv_directives": "zstd_buffers 1 8388608;",
+            "want_pass": True,
+            "want_warning": False,
+        },
+        {
+            "name": "4 cap+1 (8388609)",
+            "http_directives": "",
+            "srv_directives": "zstd_buffers 1 8388609;",
+            "want_pass": True,
+            "want_warning": True,
+            "min_total": 8388609,
+            "max_warn_count": 1,
+        },
+        {
+            "name": "5 product overflow",
+            "http_directives": "",
+            "srv_directives": f"zstd_buffers {huge} {huge};",
+            "want_pass": False,
+            "want_warning": False,
+            "want_overflow_error": True,
+        },
+        {
+            "name": "6 inherited from http block",
+            "http_directives": "zstd_buffers 1 8388609;",
+            "srv_directives": "",
+            "want_pass": True,
+            "want_warning": True,
+            "min_total": 8388609,
+            # Merged twice on this call graph: once into the (unused)
+            # http-level location conf, once into the server/location
+            # that actually serves -- both are real ngx_conf merges of
+            # the SAME inherited value, so 2 is the correct count here,
+            # not a duplicate-reporting defect (see arm 7 for that check,
+            # which pins the explicit single-location case to exactly 1).
+            "max_warn_count": 2,
+        },
+        {
+            "name": "7 explicit large value warns once",
+            "http_directives": "",
+            "srv_directives": "zstd_buffers 1 16777217;",
+            "want_pass": True,
+            "want_warning": True,
+            "min_total": 16777217,
+            "max_warn_count": 1,
+        },
+    ]
+
+    failures = []
+    print("zstd_buffers aggregate bound policy matrix:")
+    for i, arm in enumerate(matrix):
+        name = arm.pop("name")
+        f, summary = run_arm(nginx, module, args.port + i, name, **arm)
+        failures += f
+        print(summary)
+
+    if failures:
+        print("\nFAIL: zstd_buffers bound policy", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+
+    print(f"\nOK: zstd_buffers bound policy ({len(matrix)}/{len(matrix)} arms)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/tools/test_bufs_bound_policy.py
+++ b/ci/tools/test_bufs_bound_policy.py
@@ -9,55 +9,101 @@ inherits the parent's, or applies this module's own default
 (``2 x ZSTD_CStreamOutSize()``); none of those three paths re-validates the
 pair either. A typo ("zstd_buffers 100000 100000;" instead of
 "100 100k;") or a value inherited from an outer block could therefore
-request an overflowing or merely enormous per-response output-chain pool
+request an overflowing OR merely enormous per-response output-chain pool
 that nginx would happily commit per concurrent response.
 
-The policy under test
-----------------------
-  * ``num * size`` overflowing ``size_t`` is a hard config-load error,
-    unconditionally -- there is no representable acknowledgement for a
-    product that cannot exist.
-  * A representable-but-large product (> ``NGX_HTTP_ZSTD_BUFS_ADVISORY_BYTES``,
-    8 MB) is a ``[warn]`` naming the total, PER RESPONSE, cross-referencing
-    the ``zstd_max_cctx_memory`` advisory for the CCtx half of the budget.
-    It never fails the configuration -- a config that loads today keeps
-    loading.
-  * The check runs once at merge time, which is the single point that
-    covers an EXPLICIT value, one INHERITED from an outer block, and the
-    module's own DEFAULT alike (all three land in the same ``conf->bufs``
-    the filter reads from). The parse-time slot additionally catches an
-    overflowing explicit value at the earliest point, but does not repeat
-    the advisory -- so a bare explicit large value warns exactly once, not
-    twice.
+A first version of this policy only warned above 8 MB and refused only an
+actual ``size_t`` overflow -- which meant ``zstd_buffers 2147483647 1024m``
+(~2.3 EB per response) loaded successfully with nothing but a log line,
+because ``size_t`` overflow needs operands nginx's own integer parsing
+barely admits. That is not a bound; it is a warning that the config commits
+2.3 exabytes. This version adds a real hard cap in between.
+
+The policy under test -- four tiers on the representable (non-overflowing)
+product, ascending severity
+--------------------------------------------------------------------------
+  1. ``<= NGX_HTTP_ZSTD_BUFS_ADVISORY_BYTES`` (8 MB)          -- silent.
+  2. ``>  ADVISORY_BYTES``, ``<= NGX_HTTP_ZSTD_BUFS_HARD_CAP_BYTES``
+     (256 MB)                                                  -- ``[warn]``,
+     never fails; a config that loads today keeps loading.
+  3. ``>  HARD_CAP_BYTES``, no ``zstd_buffers_unsafe on;``      -- ``[emerg]``,
+     config REFUSED.
+  4. ``>  HARD_CAP_BYTES``, WITH ``zstd_buffers_unsafe on;``    -- ``[warn]``
+     (not silent -- the operator still sees what they acknowledged),
+     config PASSES.
+
+``num * size`` overflowing ``size_t`` is refused unconditionally at every
+tier, including with the acknowledgement flag set -- there is no
+representable size for which "the operator meant this".
+
+The hard-cap tier is deliberately NOT advisory-shaped like the CCtx budget
+or the 8 MB tier below it: unlike a libzstd memory ESTIMATE (which depends
+on library internals the operator never directly sees), ``number`` and
+``size`` are two integers the operator typed out literally. At the 256 MB
+scale, refusing by default and requiring an explicit
+``zstd_buffers_unsafe on;`` is the correct default reading of "this is
+almost certainly a mistake, but if you really mean it, say so."
+
+The check runs once at merge time (``ngx_http_zstd_merge_loc_conf()``),
+which is the single point that sees the value however it got there --
+explicit, inherited via ``ngx_conf_merge_bufs_value()``, or this module's
+own default (all three land in the same ``conf->bufs`` the filter reads
+from, and ``conf->bufs_unsafe`` merges by the same inheritance rule). The
+parse-time slot (``ngx_http_zstd_set_bufs_slot()``) additionally catches
+an overflowing EXPLICIT value at the earliest point, but never repeats the
+advisory/cap tiers -- so a bare explicit large value is reported exactly
+once, not twice.
 
 Why this test and not ``ci/t/02-conf-warn.t``: Test::Nginx's error-log
 greps can assert a substring appeared, but cannot assert a config-load run
-PASSED with the warning present, is REFUSED with a specific message for
-overflow, and passed with NO warning at all for the near-boundary/ack
-cases -- all as one matrix with an explicit non-zero exit code check. A
-signal death (e.g. a bad cast crashing "nginx -t") would still satisfy a
-plain string grep; this harness explicitly separates that case out.
+PASSED with a specific warning present, is REFUSED with a specific message,
+and PASSES again once acknowledged -- all as one matrix with an explicit
+exit-code check per cell. A signal death (e.g. a bad cast crashing
+"nginx -t") would still satisfy a plain string grep; this harness
+explicitly separates that case out.
 
 Arms
 ----
-1. default zstd_buffers (module default, 2 x stream_out_size)  -> PASS,
-   no warning (the ordinary case must stay silent).
-2. cap - 1 byte (``zstd_buffers 1 8388607``)                    -> PASS,
-   no warning.
-3. cap exact (``zstd_buffers 1 8388608``)                       -> PASS,
-   no warning (the boundary itself is inclusive of "not advised").
-4. cap + 1 byte (``zstd_buffers 1 8388609``)                    -> PASS,
-   warning naming ~8388609 bytes.
-5. product overflow (``zstd_buffers <huge> <huge>``)            -> REFUSED,
-   naming both operands, never a signal death.
-6. inherited from an outer (http) block, over the cap           -> PASS,
-   warning fires at the location that merges it in (proves inheritance is
-   covered, not just the location that wrote the directive).
-7. explicit large value fires exactly ONCE, not twice (parse-time slot
-   must not duplicate the merge-time advisory).
+1. default zstd_buffers (module default, 2 x stream_out_size)     -> PASS,
+   silent.
+2. advisory cap - 1 byte (``zstd_buffers 1 8388607``)               -> PASS,
+   silent.
+3. advisory cap + 1 byte (``zstd_buffers 1 8388609``)               -> PASS,
+   warn.
+4. hard cap - 1 byte (``zstd_buffers 1 268435455``)                 -> PASS,
+   warn (still tier 2 -- the boundary is inclusive of "advisory, not
+   refused").
+5. hard cap exact (``zstd_buffers 1 268435456``)                    -> PASS,
+   warn (same reason as arm 4 -- the cap itself is not yet a breach).
+6. hard cap + 1 byte, NO acknowledgement (``zstd_buffers 1
+   268435457``)                                                     -> REFUSED,
+   naming the cap and the acknowledgement spelling.
+7. hard cap + 1 byte, WITH ``zstd_buffers_unsafe on;``              -> PASS,
+   warn (not silent).
+8. the reported gap's exact reproduction (``zstd_buffers 2147483647
+   1024m`` -- ~2.3 EB per response), NO acknowledgement              -> REFUSED.
+   This is the realistic-typo-shaped operand pair the first version of
+   this policy let straight through with only a log line; it must now be
+   the hard-refused case, not the overflow case.
+9. same reproduction, WITH acknowledgement                          -> PASS,
+   warn.
+10. product overflow (``zstd_buffers <huge> <huge>``), acknowledgement
+    flag ALSO set                                                    -> REFUSED,
+    naming both operands. Proves the acknowledgement never reaches the
+    overflow tier -- there is no spelling that accepts an unrepresentable
+    product.
+11. inherited from an outer (http) block: both ``zstd_buffers`` and
+    ``zstd_buffers_unsafe on;`` written at http level, a bare ``location``
+    underneath                                                        -> PASS,
+    warn (proves the acknowledgement flag inherits the same way the
+    aggregate bound does, not just the location that wrote it).
+12. explicit large value in the 8-256 MB band fires exactly ONCE, not
+    twice (parse-time slot must not duplicate the merge-time advisory).
 
-Arms 1-3 are the controls that keep this test from being vacuous: a build
-that warns unconditionally on any zstd_buffers value fails them.
+Arms 1, 2, 4, 5 are the controls that keep this test from being vacuous: a
+build that warns or refuses unconditionally on any zstd_buffers value
+fails them. Arm 8 is the regression control for the exact gap this policy
+exists to close.
 """
 
 import argparse
@@ -67,17 +113,25 @@ import subprocess
 import sys
 import tempfile
 
-# NGX_HTTP_ZSTD_BUFS_ADVISORY_BYTES in src/ngx_http_zstd_filter_module.c.
-ADVISORY_BYTES = 8 * 1024 * 1024
+# NGX_HTTP_ZSTD_BUFS_HARD_CAP_BYTES in src/ngx_http_zstd_filter_module.c.
+# (NGX_HTTP_ZSTD_BUFS_ADVISORY_BYTES, 8 MB, is exercised by the boundary
+# arms below but not compared against directly in this file.)
+HARD_CAP_BYTES = 256 * 1024 * 1024
 
+# Matched only on a line carrying "[warn]" (see WARN_RE usage below) so a
+# [emerg] hard-cap refusal -- which restates the same "requests N x M
+# bytes = ~T bytes" figure in its own message -- is never miscounted as a
+# warning.
 WARN_RE = re.compile(
-    r'"zstd_buffers" \((?P<ctx>[^)]+)\) requests (?P<num>\d+) x '
+    r'\[warn\].*"zstd_buffers" \((?P<ctx>[^)]+)\) requests (?P<num>\d+) x '
     r"(?P<size>\d+) bytes = ~(?P<total>\d+) bytes"
 )
 OVERFLOW_RE = re.compile(
     r'"zstd_buffers" \([^)]+\) requests (\d+) buffers of (\d+) bytes each; '
     r"that product overflows"
 )
+HARD_CAP_ACK_RE = re.compile(r"acknowledges it")
+HARD_CAP_REFUSE_RE = re.compile(r"above the \d+ MB hard cap")
 
 
 def parse_args():
@@ -139,20 +193,17 @@ def check_not_a_signal(name, rc, out):
     return []
 
 
-def run_arm(
-    nginx,
-    module,
-    port,
-    name,
-    http_directives,
-    srv_directives,
-    want_pass,
-    want_warning,
-    want_overflow_error=False,
-    min_total=None,
-    max_warn_count=1,
-):
-    """One matrix cell. Returns (failures, printable summary)."""
+def run_arm(nginx, module, port, name, http_directives, srv_directives, spec):
+    """One matrix cell. ``spec`` carries the expectations. Returns
+    (failures, printable summary)."""
+    want_pass = spec["want_pass"]
+    want_warning = spec.get("want_warning", False)
+    want_overflow_error = spec.get("want_overflow_error", False)
+    want_hard_cap_refuse = spec.get("want_hard_cap_refuse", False)
+    want_hard_cap_ack = spec.get("want_hard_cap_ack", False)
+    min_total = spec.get("min_total")
+    max_warn_count = spec.get("max_warn_count", 1)
+
     rc, out = config_test(nginx, module, port, http_directives, srv_directives)
     failures = check_not_a_signal(name, rc, out)
 
@@ -160,7 +211,7 @@ def run_arm(
         failures.append(
             f"{name}: expected nginx -t to PASS but it exited {rc}. The "
             f"bufs bound policy must never turn a working config into a "
-            f"config-load failure; output: {out.strip()!r}"
+            f"config-load failure at this tier; output: {out.strip()!r}"
         )
     if not want_pass and rc == 0:
         failures.append(
@@ -172,18 +223,18 @@ def run_arm(
 
     if want_warning and not warns:
         failures.append(
-            f"{name}: expected the [warn] advisory naming the aggregate "
-            f"buffer total, but it was not emitted; output: {out.strip()!r}"
+            f"{name}: expected the [warn] naming the aggregate buffer "
+            f"total, but it was not emitted; output: {out.strip()!r}"
         )
     if not want_warning and warns:
         failures.append(
-            f"{name}: the advisory was emitted but must NOT be. Either "
-            f"the threshold is wrong or the boundary is off-by-one; "
+            f"{name}: a warning was emitted but must NOT be at this tier. "
+            f"Either a threshold is wrong or a boundary is off-by-one; "
             f"output: {out.strip()!r}"
         )
     if warns and len(warns) > max_warn_count:
         failures.append(
-            f"{name}: advisory fired {len(warns)} times (want at most "
+            f"{name}: warning fired {len(warns)} times (want at most "
             f"{max_warn_count}) -- the parse-time slot and the merge-time "
             f"check are double-reporting the same explicit value; output: "
             f"{out.strip()!r}"
@@ -191,33 +242,27 @@ def run_arm(
 
     if warns and "[warn]" not in out:
         failures.append(
-            f"{name}: matched the advisory text but not at [warn] level; "
+            f"{name}: matched warning text but not at [warn] level; "
             f"output: {out.strip()!r}"
         )
 
     total = None
     if warns:
         total = int(warns[0][3])
-        if total <= ADVISORY_BYTES:
-            failures.append(
-                f"{name}: advisory fired at {total} bytes, which is <= the "
-                f"{ADVISORY_BYTES}-byte threshold. The condition is not "
-                f"the documented one."
-            )
         if min_total is not None and total < min_total:
             failures.append(
-                f"{name}: advisory reports {total} bytes, below the "
-                f"expected {min_total}. Computed from the wrong operands."
+                f"{name}: reports {total} bytes, below the expected "
+                f"{min_total}. Computed from the wrong operands."
             )
         if "per response" not in out.lower():
             failures.append(
-                f"{name}: advisory does not state the total is PER "
-                f"RESPONSE; output: {out.strip()!r}"
+                f"{name}: does not state the total is PER RESPONSE; "
+                f"output: {out.strip()!r}"
             )
         if "zstd_max_cctx_memory" not in out:
             failures.append(
-                f"{name}: advisory does not cross-reference the CCtx "
-                f'memory advisory ("zstd_max_cctx_memory"); output: '
+                f"{name}: does not cross-reference the CCtx memory "
+                f'advisory ("zstd_max_cctx_memory"); output: '
                 f"{out.strip()!r}"
             )
 
@@ -234,9 +279,46 @@ def run_arm(
                 f"level; output: {out.strip()!r}"
             )
 
+    if want_hard_cap_refuse:
+        if HARD_CAP_REFUSE_RE.search(out) is None:
+            failures.append(
+                f"{name}: expected the hard-cap refusal naming the cap, "
+                f"but it was not found; output: {out.strip()!r}"
+            )
+        elif "[emerg]" not in out:
+            failures.append(
+                f"{name}: hard-cap diagnostic present but not at [emerg] "
+                f"level; output: {out.strip()!r}"
+            )
+        if "zstd_buffers_unsafe" not in out:
+            failures.append(
+                f"{name}: hard-cap refusal does not name the "
+                f'acknowledgement spelling ("zstd_buffers_unsafe"); '
+                f"output: {out.strip()!r}"
+            )
+
+    if want_hard_cap_ack and HARD_CAP_ACK_RE.search(out) is None:
+        failures.append(
+            f"{name}: expected the hard-cap ACKNOWLEDGED wording "
+            f"(the acknowledgement must still be visible, not "
+            f"silent), but it was not found; output: {out.strip()!r}"
+        )
+
+    if (
+        total is not None
+        and total > HARD_CAP_BYTES
+        and not (want_hard_cap_refuse or want_hard_cap_ack)
+    ):
+        failures.append(
+            f"{name}: total {total} bytes exceeds the {HARD_CAP_BYTES}-byte "
+            f"hard cap but this arm did not mark either the refuse or the "
+            f"acknowledge expectation -- the matrix spec is wrong for this "
+            f"arm."
+        )
+
     summary = (
-        f"  {name:<38} exit {rc} (want {'0' if want_pass else 'non-zero'}), "
-        f"warnings {len(warns)} (want {'>=1' if want_warning else '0'})"
+        f"  {name:<52} exit {rc} (want {'0' if want_pass else 'non-zero'}), "
+        f"warnings {len(warns)}"
         + (f", total {total} bytes" if total is not None else "")
     )
     return failures, summary
@@ -257,77 +339,121 @@ def main() -> int:
             return 1
 
     huge = 9223372036854775807  # ngx_int_t / int64_t max on a 64-bit build.
+    ack = "zstd_buffers_unsafe on;"
 
     matrix = [
-        {
-            "name": "1 default bufs",
-            "http_directives": "",
-            "srv_directives": "",
-            "want_pass": True,
-            "want_warning": False,
-        },
-        {
-            "name": "2 cap-1 (8388607)",
-            "http_directives": "",
-            "srv_directives": "zstd_buffers 1 8388607;",
-            "want_pass": True,
-            "want_warning": False,
-        },
-        {
-            "name": "3 cap exact (8388608)",
-            "http_directives": "",
-            "srv_directives": "zstd_buffers 1 8388608;",
-            "want_pass": True,
-            "want_warning": False,
-        },
-        {
-            "name": "4 cap+1 (8388609)",
-            "http_directives": "",
-            "srv_directives": "zstd_buffers 1 8388609;",
-            "want_pass": True,
-            "want_warning": True,
-            "min_total": 8388609,
-            "max_warn_count": 1,
-        },
-        {
-            "name": "5 product overflow",
-            "http_directives": "",
-            "srv_directives": f"zstd_buffers {huge} {huge};",
-            "want_pass": False,
-            "want_warning": False,
-            "want_overflow_error": True,
-        },
-        {
-            "name": "6 inherited from http block",
-            "http_directives": "zstd_buffers 1 8388609;",
-            "srv_directives": "",
-            "want_pass": True,
-            "want_warning": True,
-            "min_total": 8388609,
-            # Merged twice on this call graph: once into the (unused)
-            # http-level location conf, once into the server/location
-            # that actually serves -- both are real ngx_conf merges of
-            # the SAME inherited value, so 2 is the correct count here,
-            # not a duplicate-reporting defect (see arm 7 for that check,
-            # which pins the explicit single-location case to exactly 1).
-            "max_warn_count": 2,
-        },
-        {
-            "name": "7 explicit large value warns once",
-            "http_directives": "",
-            "srv_directives": "zstd_buffers 1 16777217;",
-            "want_pass": True,
-            "want_warning": True,
-            "min_total": 16777217,
-            "max_warn_count": 1,
-        },
+        (
+            "1 default bufs (silent tier)",
+            "",
+            "",
+            {"want_pass": True, "want_warning": False},
+        ),
+        (
+            "2 advisory cap-1 (8388607, silent)",
+            "",
+            "zstd_buffers 1 8388607;",
+            {"want_pass": True, "want_warning": False},
+        ),
+        (
+            "3 advisory cap+1 (8388609, warn)",
+            "",
+            "zstd_buffers 1 8388609;",
+            {"want_pass": True, "want_warning": True, "min_total": 8388609},
+        ),
+        (
+            "4 hard cap-1 (268435455, still warn)",
+            "",
+            "zstd_buffers 1 268435455;",
+            {"want_pass": True, "want_warning": True, "min_total": 268435455},
+        ),
+        (
+            "5 hard cap exact (268435456, still warn)",
+            "",
+            "zstd_buffers 1 268435456;",
+            {"want_pass": True, "want_warning": True, "min_total": 268435456},
+        ),
+        (
+            "6 hard cap+1, NO ack -> REFUSED",
+            "",
+            "zstd_buffers 1 268435457;",
+            {
+                "want_pass": False,
+                "want_warning": False,
+                "want_hard_cap_refuse": True,
+            },
+        ),
+        (
+            "7 hard cap+1, WITH ack -> PASS+warn",
+            "",
+            f"zstd_buffers 1 268435457;\n        {ack}",
+            {
+                "want_pass": True,
+                "want_warning": True,
+                "want_hard_cap_ack": True,
+                "min_total": 268435457,
+            },
+        ),
+        (
+            "8 reported gap repro, NO ack -> REFUSED",
+            "",
+            "zstd_buffers 2147483647 1024m;",
+            {
+                "want_pass": False,
+                "want_warning": False,
+                "want_hard_cap_refuse": True,
+            },
+        ),
+        (
+            "9 reported gap repro, WITH ack -> PASS+warn",
+            "",
+            f"zstd_buffers 2147483647 1024m;\n        {ack}",
+            {
+                "want_pass": True,
+                "want_warning": True,
+                "want_hard_cap_ack": True,
+                "min_total": 2305843008139952128,
+            },
+        ),
+        (
+            "10 product overflow, ack ALSO set -> still REFUSED",
+            "",
+            f"zstd_buffers {huge} {huge};\n        {ack}",
+            {
+                "want_pass": False,
+                "want_warning": False,
+                "want_overflow_error": True,
+            },
+        ),
+        (
+            "11 inherited hard-cap breach + ack from http block",
+            f"{ack}\n    zstd_buffers 1 268435457;",
+            "",
+            {
+                "want_pass": True,
+                "want_warning": True,
+                "want_hard_cap_ack": True,
+                "min_total": 268435457,
+            },
+        ),
+        (
+            "12 explicit 16 MB value warns once, not twice",
+            "",
+            "zstd_buffers 1 16777217;",
+            {
+                "want_pass": True,
+                "want_warning": True,
+                "min_total": 16777217,
+                "max_warn_count": 1,
+            },
+        ),
     ]
 
     failures = []
     print("zstd_buffers aggregate bound policy matrix:")
-    for i, arm in enumerate(matrix):
-        name = arm.pop("name")
-        f, summary = run_arm(nginx, module, args.port + i, name, **arm)
+    for i, (name, http_directives, srv_directives, spec) in enumerate(matrix):
+        f, summary = run_arm(
+            nginx, module, args.port + i, name, http_directives, srv_directives, spec
+        )
         failures += f
         print(summary)
 

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -185,6 +185,15 @@ typedef struct {
 
     ngx_bufs_t                   bufs;
 
+    /*
+     * Acknowledgement for an aggregate "zstd_buffers number * size"
+     * above NGX_HTTP_ZSTD_BUFS_HARD_CAP_BYTES. Mirrors
+     * "zstd_dict_file_unsafe" and "zstd_max_cctx_memory 0": the operator
+     * has to say, explicitly and in words, that a total this large is
+     * intentional -- the check does not just log and move on.
+     */
+    ngx_flag_t                   bufs_unsafe;
+
     ngx_array_t                 *types_keys;
 
     ZSTD_CDict                  *dict;
@@ -398,7 +407,7 @@ static char *ngx_conf_zstd_set_num_slot_with_negatives(ngx_conf_t *cf,
 static char *ngx_http_zstd_set_bufs_slot(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 static char *ngx_http_zstd_check_bufs_product(ngx_conf_t *cf,
-    ngx_bufs_t *bufs, const char *ctx, ngx_flag_t advise);
+    ngx_bufs_t *bufs, ngx_flag_t unsafe, const char *ctx, ngx_flag_t advise);
 static void ngx_http_zstd_cleanup_dict(void *data);
 static void ngx_http_zstd_cleanup_cctx(void *data);
 static void ngx_http_zstd_release_cctx(void *data);
@@ -590,6 +599,13 @@ static ngx_command_t  ngx_http_zstd_filter_commands[] = {
       ngx_http_zstd_set_bufs_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_zstd_loc_conf_t, bufs),
+      NULL },
+
+    { ngx_string("zstd_buffers_unsafe"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_zstd_loc_conf_t, bufs_unsafe),
       NULL },
 
     { ngx_string("zstd_min_length"),
@@ -2605,6 +2621,7 @@ ngx_http_zstd_create_loc_conf(ngx_conf_t *cf)
     conf->window_log = NGX_CONF_UNSET;
     conf->long_mode = NGX_CONF_UNSET;
     conf->max_cctx_memory = NGX_CONF_UNSET;
+    conf->bufs_unsafe = NGX_CONF_UNSET;
     conf->bypass = NGX_CONF_UNSET_PTR;
     conf->dcz_dicts = NGX_CONF_UNSET_PTR;
     conf->dcz_assume_secure = NGX_CONF_UNSET;
@@ -3115,6 +3132,7 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
      */
     ngx_conf_merge_bufs_value(conf->bufs, prev->bufs,
                               2, zmcf->stream_out_size);
+    ngx_conf_merge_value(conf->bufs_unsafe, prev->bufs_unsafe, 0);
 
     /*
      * The parse-time slot (ngx_http_zstd_set_bufs_slot()) only sees an
@@ -3129,8 +3147,9 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
      * once.
      */
     if (rc == NGX_CONF_OK
-        && ngx_http_zstd_check_bufs_product(cf, &conf->bufs, "merged value",
-                                             1)
+        && ngx_http_zstd_check_bufs_product(cf, &conf->bufs,
+                                             conf->bufs_unsafe,
+                                             "merged value", 1)
            != NGX_CONF_OK)
     {
         rc = NGX_CONF_ERROR;
@@ -4284,46 +4303,75 @@ ngx_conf_zstd_set_num_slot_with_negatives(ngx_conf_t *cf,
  * additive with the per-request CCtx working set the
  * "zstd_max_cctx_memory" advisory above already covers.
  *
- * NGX_HTTP_ZSTD_BUFS_ADVISORY_BYTES mirrors the CCtx advisory's shape:
- * overflow is refused unconditionally (there is no representable size for
- * which "the operator meant this"), and a representable-but-large product
- * warns rather than fails, so a config that loads today keeps loading
- * after an upgrade to this check. 8 MB is chosen generously above nginx's
- * own "zstd_buffers 32 4k" default (128 KB) and this module's own
- * 2 x CStreamOutSize() default (~256 KB at level 6): both stay silent, and
- * only a config that requests substantially more per response is named.
- * The warning states the total is PER RESPONSE and points at the CCtx
- * section so an operator sizing worker RSS adds the two: this directive's
- * total plus the up-to-NGX_HTTP_ZSTD_CCTX_SLOTS-times CCtx figure that
- * "zstd_max_cctx_memory" (undocumented) or its advisory (documented above)
- * reports.
+ * Three tiers on the representable (non-overflowing) product, in
+ * ascending severity:
+ *
+ *   <= NGX_HTTP_ZSTD_BUFS_ADVISORY_BYTES (8 MB)   silent. This is the
+ *       ordinary range: nginx's own "zstd_buffers 32 4k" default (128 KB)
+ *       and this module's own 2 x CStreamOutSize() default (~256 KB at
+ *       level 6) both land far under it.
+ *
+ *   >  NGX_HTTP_ZSTD_BUFS_ADVISORY_BYTES,
+ *   <= NGX_HTTP_ZSTD_BUFS_HARD_CAP_BYTES (256 MB)  [warn]. Large but a
+ *       config that loads today must keep loading -- same non-breaking
+ *       posture as the zstd_max_cctx_memory advisory.
+ *
+ *   >  NGX_HTTP_ZSTD_BUFS_HARD_CAP_BYTES            [emerg], refused
+ *       UNLESS "zstd_buffers_unsafe on;" is also set. Unlike the advisory
+ *       tier, this one is NOT "operator typed a big number and can live
+ *       with the log line" -- number and size are two integers the
+ *       operator wrote out literally (unlike the CCtx estimate, which
+ *       depends on libzstd internals the operator never sees), so at
+ *       this magnitude a refusal-by-default is the safe reading of "the
+ *       operator probably made a mistake", with an explicit opt-out for
+ *       the rare deployment that means it. 256 MB is two hundred times
+ *       nginx's own default and comfortably past any legitimate output
+ *       buffer size; a real deployment tuning zstd_buffers for throughput
+ *       does so in the single-digit MB range, not hundreds.
+ *
+ * Overflow is refused unconditionally at every tier -- there is no
+ * representable size for which "the operator meant this", so no
+ * acknowledgement spelling exists for it.
+ *
+ * The warning/refusal states the total is PER RESPONSE and points at the
+ * CCtx section so an operator sizing worker RSS adds the two: this
+ * directive's total plus the up-to-NGX_HTTP_ZSTD_CCTX_SLOTS-times CCtx
+ * figure that "zstd_max_cctx_memory" (undocumented) or its advisory
+ * (documented above) reports.
  */
 #ifndef NGX_HTTP_ZSTD_BUFS_ADVISORY_BYTES
 #define NGX_HTTP_ZSTD_BUFS_ADVISORY_BYTES  (8 * 1024 * 1024)
+#endif
+
+#ifndef NGX_HTTP_ZSTD_BUFS_HARD_CAP_BYTES
+#define NGX_HTTP_ZSTD_BUFS_HARD_CAP_BYTES  (256 * 1024 * 1024)
 #endif
 
 
 /*
  * Shared by the parse-time slot (explicit "zstd_buffers") and the
  * post-merge check (inherited or defaulted value): division-based
- * overflow pre-check, then -- when "advise" is set -- an advisory-shaped
- * threshold on the representable product. "ctx" names which of the two
- * callers is reporting so the operator can tell an explicit typo from an
- * inherited value without re-deriving it themselves.
+ * overflow pre-check, then -- when "advise" is set -- the
+ * advisory/hard-cap tiers on the representable product. "ctx" names
+ * which of the two callers is reporting so the operator can tell an
+ * explicit typo from an inherited value without re-deriving it
+ * themselves. "unsafe" is the merged conf->bufs_unsafe flag; it is only
+ * consulted when the hard-cap tier fires.
  *
  * The overflow check always runs (both callers pass advise or not, but
- * overflow is unconditional either way); the advisory WARN is emitted
- * only from the merge-time caller ("advise" true), never from the
- * parse-time slot. Every value ends up merged exactly once per location
- * -- the merge site is what conf->bufs is actually read from at request
- * time -- so gating the advisory there is what keeps a single explicit
- * "zstd_buffers" from printing the same warning twice (once at parse,
- * again at merge) while still failing an overflowing product at the
- * earliest possible point.
+ * overflow is unconditional either way, with no acknowledgement
+ * spelling); the advisory/cap tiers are evaluated only from the
+ * merge-time caller ("advise" true), never from the parse-time slot.
+ * Every value ends up merged exactly once per location -- the merge
+ * site is what conf->bufs is actually read from at request time -- so
+ * gating those tiers there is what keeps a single explicit
+ * "zstd_buffers" from being reported twice (once at parse, again at
+ * merge) while still failing an overflowing product at the earliest
+ * possible point.
  */
 static char *
 ngx_http_zstd_check_bufs_product(ngx_conf_t *cf, ngx_bufs_t *bufs,
-    const char *ctx, ngx_flag_t advise)
+    ngx_flag_t unsafe, const char *ctx, ngx_flag_t advise)
 {
     size_t  total;
 
@@ -4357,6 +4405,42 @@ ngx_http_zstd_check_bufs_product(ngx_conf_t *cf, ngx_bufs_t *bufs,
 
     total = (size_t) bufs->num * bufs->size;
 
+    if (total > NGX_HTTP_ZSTD_BUFS_HARD_CAP_BYTES) {
+        if (unsafe) {
+            ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                               "\"zstd_buffers\" (%s) requests %i x %uz "
+                               "bytes = ~%uz bytes of output-chain memory "
+                               "PER RESPONSE, above the %d MB hard cap; "
+                               "accepted because \"zstd_buffers_unsafe "
+                               "on;\" acknowledges it. That total is on "
+                               "top of the per-request compressor (CCtx) "
+                               "working set -- see the "
+                               "\"zstd_max_cctx_memory\" advisory above "
+                               "-- and both are multiplied by concurrent "
+                               "responses under load",
+                               ctx, bufs->num, bufs->size, total,
+                               (int) (NGX_HTTP_ZSTD_BUFS_HARD_CAP_BYTES
+                                      / (1024 * 1024)));
+            return NGX_CONF_OK;
+        }
+
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "\"zstd_buffers\" (%s) requests %i x %uz bytes "
+                           "= ~%uz bytes of output-chain memory PER "
+                           "RESPONSE, above the %d MB hard cap -- that is "
+                           "on top of the per-request compressor (CCtx) "
+                           "working set (see the \"zstd_max_cctx_memory\" "
+                           "advisory above) and both are multiplied by "
+                           "concurrent responses under load. Lower "
+                           "\"zstd_buffers\", or set "
+                           "\"zstd_buffers_unsafe on;\" to acknowledge "
+                           "this total is intentional",
+                           ctx, bufs->num, bufs->size, total,
+                           (int) (NGX_HTTP_ZSTD_BUFS_HARD_CAP_BYTES
+                                  / (1024 * 1024)));
+        return NGX_CONF_ERROR;
+    }
+
     if (total > NGX_HTTP_ZSTD_BUFS_ADVISORY_BYTES) {
         ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
                            "\"zstd_buffers\" (%s) requests %i x %uz bytes "
@@ -4379,14 +4463,19 @@ ngx_http_zstd_check_bufs_product(ngx_conf_t *cf, ngx_bufs_t *bufs,
  * for those cases are preserved verbatim, and this wrapper only adds the
  * overflow check on the ngx_bufs_t that parse produced -- fast, hard
  * feedback on an unrepresentable explicit value at the earliest possible
- * point. It deliberately does NOT run the advisory-threshold warning
+ * point. It deliberately does NOT run the advisory/hard-cap tiers
  * (advise=0): the post-merge check below (ngx_http_zstd_merge_loc_conf())
- * is the single owner of that warning, because it is the only point that
- * also covers a value this location never wrote itself but inherited
- * from an outer block, or the module's own computed default -- neither
- * of which runs through this slot handler at all. Running the advisory
- * here too would print it twice for the common case of an explicit
- * large value that also survives to the merge unchanged.
+ * is the single owner of those, because it is the only point that also
+ * covers a value this location never wrote itself but inherited from an
+ * outer block, or the module's own computed default -- neither of which
+ * runs through this slot handler at all. It is also the only point where
+ * conf->bufs_unsafe is guaranteed to already hold its final, merged
+ * value: "zstd_buffers_unsafe" can appear before OR after "zstd_buffers"
+ * in the same block, or at an outer level entirely, and this slot fires
+ * the moment "zstd_buffers" is parsed -- reading bufs_unsafe here could
+ * see it still unset. Running the hard-cap tier here too would also
+ * double-report it for the common case of an explicit large value that
+ * survives to the merge unchanged.
  */
 static char *
 ngx_http_zstd_set_bufs_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
@@ -4402,6 +4491,6 @@ ngx_http_zstd_set_bufs_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     bufs = (ngx_bufs_t *) (p + cmd->offset);
 
-    return ngx_http_zstd_check_bufs_product(cf, bufs, "explicit directive",
-                                             0);
+    return ngx_http_zstd_check_bufs_product(cf, bufs, 0,
+                                             "explicit directive", 0);
 }

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -395,6 +395,10 @@ static char *ngx_http_zstd_check_num_int_max(ngx_conf_t *cf, void *post,
     void *data);
 static char *ngx_conf_zstd_set_num_slot_with_negatives(ngx_conf_t *cf,
     ngx_command_t *cmd, void *conf);
+static char *ngx_http_zstd_set_bufs_slot(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+static char *ngx_http_zstd_check_bufs_product(ngx_conf_t *cf,
+    ngx_bufs_t *bufs, const char *ctx, ngx_flag_t advise);
 static void ngx_http_zstd_cleanup_dict(void *data);
 static void ngx_http_zstd_cleanup_cctx(void *data);
 static void ngx_http_zstd_release_cctx(void *data);
@@ -583,7 +587,7 @@ static ngx_command_t  ngx_http_zstd_filter_commands[] = {
 
     { ngx_string("zstd_buffers"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE2,
-      ngx_conf_set_bufs_slot,
+      ngx_http_zstd_set_bufs_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_zstd_loc_conf_t, bufs),
       NULL },
@@ -2838,6 +2842,26 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_bufs_value(conf->bufs, prev->bufs,
                               2, zmcf->stream_out_size);
 
+    /*
+     * The parse-time slot (ngx_http_zstd_set_bufs_slot()) only sees an
+     * EXPLICIT "zstd_buffers" written at this exact location. A value
+     * this location inherited from an outer block via
+     * ngx_conf_merge_bufs_value() above, or the module's own computed
+     * default (2 x stream_out_size when nothing was written anywhere in
+     * the chain), never passes through that slot handler and so is
+     * otherwise never checked at all. Re-run the same product bound here
+     * so every value conf->bufs can hold by the time the filter reads it
+     * -- explicit, inherited, or defaulted -- has been validated exactly
+     * once.
+     */
+    if (rc == NGX_CONF_OK
+        && ngx_http_zstd_check_bufs_product(cf, &conf->bufs, "merged value",
+                                             1)
+           != NGX_CONF_OK)
+    {
+        rc = NGX_CONF_ERROR;
+    }
+
     if (conf->enable && zmcf->dict_file.len > 0) {
 
         if (prev->dict != NULL
@@ -4078,4 +4102,146 @@ ngx_conf_zstd_set_num_slot_with_negatives(ngx_conf_t *cf,
     }
 
     return NGX_CONF_OK;
+}
+
+
+/*
+ * Aggregate memory bound for "zstd_buffers number size" and its inherited
+ * value.
+ *
+ * ngx_conf_set_bufs_slot() (nginx core) parses each of the two arguments
+ * independently and rejects only a parse error or a zero -- it never looks
+ * at the product. ngx_conf_merge_bufs_value() (invoked from
+ * ngx_http_zstd_merge_loc_conf()) then either keeps an explicit value,
+ * inherits the parent's, or applies this module's own default
+ * (2 x ZSTD_CStreamOutSize()); none of those three paths re-validates the
+ * pair either. A typo ("zstd_buffers 100000 100000;" instead of
+ * "100 100k;") or an inherited value from an outer block can therefore
+ * request an overflowing or merely enormous per-response pool that nginx
+ * happily commits per concurrent response -- this directive sizes the
+ * OUTPUT chain nginx allocates from ngx_http_zstd_filter_module's own
+ * ngx_http_zstd_bufs_t path (see the merge site), separate from and
+ * additive with the per-request CCtx working set the
+ * "zstd_max_cctx_memory" advisory above already covers.
+ *
+ * NGX_HTTP_ZSTD_BUFS_ADVISORY_BYTES mirrors the CCtx advisory's shape:
+ * overflow is refused unconditionally (there is no representable size for
+ * which "the operator meant this"), and a representable-but-large product
+ * warns rather than fails, so a config that loads today keeps loading
+ * after an upgrade to this check. 8 MB is chosen generously above nginx's
+ * own "zstd_buffers 32 4k" default (128 KB) and this module's own
+ * 2 x CStreamOutSize() default (~256 KB at level 6): both stay silent, and
+ * only a config that requests substantially more per response is named.
+ * The warning states the total is PER RESPONSE and points at the CCtx
+ * section so an operator sizing worker RSS adds the two: this directive's
+ * total plus the up-to-NGX_HTTP_ZSTD_CCTX_SLOTS-times CCtx figure that
+ * "zstd_max_cctx_memory" (undocumented) or its advisory (documented above)
+ * reports.
+ */
+#ifndef NGX_HTTP_ZSTD_BUFS_ADVISORY_BYTES
+#define NGX_HTTP_ZSTD_BUFS_ADVISORY_BYTES  (8 * 1024 * 1024)
+#endif
+
+
+/*
+ * Shared by the parse-time slot (explicit "zstd_buffers") and the
+ * post-merge check (inherited or defaulted value): division-based
+ * overflow pre-check, then -- when "advise" is set -- an advisory-shaped
+ * threshold on the representable product. "ctx" names which of the two
+ * callers is reporting so the operator can tell an explicit typo from an
+ * inherited value without re-deriving it themselves.
+ *
+ * The overflow check always runs (both callers pass advise or not, but
+ * overflow is unconditional either way); the advisory WARN is emitted
+ * only from the merge-time caller ("advise" true), never from the
+ * parse-time slot. Every value ends up merged exactly once per location
+ * -- the merge site is what conf->bufs is actually read from at request
+ * time -- so gating the advisory there is what keeps a single explicit
+ * "zstd_buffers" from printing the same warning twice (once at parse,
+ * again at merge) while still failing an overflowing product at the
+ * earliest possible point.
+ */
+static char *
+ngx_http_zstd_check_bufs_product(ngx_conf_t *cf, ngx_bufs_t *bufs,
+    const char *ctx, ngx_flag_t advise)
+{
+    size_t  total;
+
+    if (bufs->num <= 0 || bufs->size == 0) {
+        /* Neither ngx_conf_set_bufs_slot() nor the module's own default
+         * can produce this; defend anyway rather than assume. */
+        return NGX_CONF_OK;
+    }
+
+    /*
+     * Division-based pre-check, not "num * size < num": bufs->num is a
+     * signed ngx_int_t, so a post-hoc "a * b < a" comparison on the
+     * wrapped product is itself operating on a signed overflow, which is
+     * undefined behaviour rather than merely wrong. Comparing against
+     * NGX_MAX_SIZE_T_VALUE / size first never multiplies past the type's
+     * range at all.
+     */
+    if ((size_t) bufs->num > NGX_MAX_SIZE_T_VALUE / bufs->size) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "\"zstd_buffers\" (%s) requests %i buffers of "
+                           "%uz bytes each; that product overflows the "
+                           "platform's size_t and cannot be a config any "
+                           "operator meant to write",
+                           ctx, bufs->num, bufs->size);
+        return NGX_CONF_ERROR;
+    }
+
+    if (!advise) {
+        return NGX_CONF_OK;
+    }
+
+    total = (size_t) bufs->num * bufs->size;
+
+    if (total > NGX_HTTP_ZSTD_BUFS_ADVISORY_BYTES) {
+        ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                           "\"zstd_buffers\" (%s) requests %i x %uz bytes "
+                           "= ~%uz bytes of output-chain memory PER "
+                           "RESPONSE; that is on top of the per-request "
+                           "compressor (CCtx) working set -- see the "
+                           "\"zstd_max_cctx_memory\" advisory above for "
+                           "that figure -- and both are multiplied by "
+                           "concurrent responses under load",
+                           ctx, bufs->num, bufs->size, total);
+    }
+
+    return NGX_CONF_OK;
+}
+
+
+/*
+ * Wraps nginx's own ngx_conf_set_bufs_slot() rather than reimplementing
+ * argument parsing: nginx's parse/zero rejection and its exact error text
+ * for those cases are preserved verbatim, and this wrapper only adds the
+ * overflow check on the ngx_bufs_t that parse produced -- fast, hard
+ * feedback on an unrepresentable explicit value at the earliest possible
+ * point. It deliberately does NOT run the advisory-threshold warning
+ * (advise=0): the post-merge check below (ngx_http_zstd_merge_loc_conf())
+ * is the single owner of that warning, because it is the only point that
+ * also covers a value this location never wrote itself but inherited
+ * from an outer block, or the module's own computed default -- neither
+ * of which runs through this slot handler at all. Running the advisory
+ * here too would print it twice for the common case of an explicit
+ * large value that also survives to the merge unchanged.
+ */
+static char *
+ngx_http_zstd_set_bufs_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    char        *p = conf;
+    char        *rc;
+    ngx_bufs_t  *bufs;
+
+    rc = ngx_conf_set_bufs_slot(cf, cmd, conf);
+    if (rc != NGX_CONF_OK) {
+        return rc;
+    }
+
+    bufs = (ngx_bufs_t *) (p + cmd->offset);
+
+    return ngx_http_zstd_check_bufs_product(cf, bufs, "explicit directive",
+                                             0);
 }


### PR DESCRIPTION
## TL;DR

`zstd_buffers number size` sets how many output buffers the compressor gets and how big each one is. nginx already checks that `number` and `size` are each sane on their own, but nobody ever checked what happens when you multiply them together — like a form that validates the width field and the height field separately but never notices the area is bigger than the building.

`ngx_conf_set_bufs_slot()` (nginx core) range-checks each argument independently; `number * size` was never checked, at parse time or at merge time (explicit, inherited from an outer block, or this module's own default). An earlier version of this PR added an advisory-only warning above 8 MB, but that let `zstd_buffers 2147483647 1024m;` (~2.3 EB per response) load with nothing but a log line — review caught that a warning is not a bound, so this now adds a real hard cap.

**Severity:** `Low` (`configuration hardening — an operator typo or inherited value could commit an overflowing or effectively unbounded per-response output-chain pool, multiplied by concurrency; no known exploitable remote input path`)

## Proposed fix

Four tiers on the config-resolved `number * size`, ascending severity:

1. **`≤ 8 MB`** — silent (covers nginx's own `zstd_buffers 32 4k` default and this module's own `2 x ZSTD_CStreamOutSize()` default with headroom).
2. **`> 8 MB`, `≤ 256 MB`** — `[warn]` naming the per-response total, cross-referencing the `zstd_max_cctx_memory` advisory for the CCtx half of the budget. Never fails — a config that loads today keeps loading.
3. **`> 256 MB`, no acknowledgement** — `[emerg]`, config REFUSED. `number` and `size` are two integers the operator typed literally (unlike the CCtx estimate, which depends on libzstd internals the operator never sees), so a refusal-by-default at this magnitude is the safer reading of "probably a mistake."
4. **`> 256 MB`, with the new `zstd_buffers_unsafe on;`** — accepted, still logged as `[warn]` (not silenced), so the acknowledgement stays visible.

`number * size` overflowing `size_t` is refused unconditionally at every tier, acknowledgement or not — there is no representable value for a product that cannot exist.

- `ngx_http_zstd_set_bufs_slot()` wraps `ngx_conf_set_bufs_slot()` (parse/zero rejection and error text unchanged) and adds only the overflow check at parse time, on the explicit value.
- `ngx_http_zstd_check_bufs_product()` (shared) does the division-based overflow pre-check (`num > NGX_MAX_SIZE_T_VALUE / size`, avoiding signed-overflow UB from a post-hoc `a*b < a`), then the advisory/hard-cap tiers, gated by a new `advise` parameter so the parse-time slot never repeats them.
- The full check runs once at merge time (`ngx_http_zstd_merge_loc_conf()`), the only point that sees the value however it arrived — explicit, inherited via `ngx_conf_merge_bufs_value()`, or the module's own default.
- `zstd_buffers_unsafe` (new directive, `http`/`server`/`location`, `NGX_CONF_FLAG`) follows the module's existing `*_unsafe` convention (`zstd_dict_file_unsafe`). It is a `ngx_flag_t` in `ngx_http_zstd_loc_conf_t`, must be initialized to `NGX_CONF_UNSET` in `create_loc_conf` (not left at the `ngx_pcalloc` zero-fill default) because `ngx_conf_set_flag_slot()` treats any non-`NGX_CONF_UNSET` value as "already set" and would reject the directive's own first use as a duplicate — caught by testing the directive standalone, not by the C compiler.

## Testing

`ci/tools/test_bufs_bound_policy.py`, a 12-arm `nginx -t` matrix (same shape as `test_cctx_advisory_policy.py` from #166 — Test::Nginx's `must_die`/grep blocks can't express "must PASS *and* must have warned *and* passes again once acknowledged"):

```
zstd_buffers aggregate bound policy matrix:
  1 default bufs (silent tier)                         exit 0 (want 0), warnings 0
  2 advisory cap-1 (8388607, silent)                    exit 0 (want 0), warnings 0
  3 advisory cap+1 (8388609, warn)                       exit 0 (want 0), warnings 1, total 8388609 bytes
  4 hard cap-1 (268435455, still warn)                   exit 0 (want 0), warnings 1, total 268435455 bytes
  5 hard cap exact (268435456, still warn)                exit 0 (want 0), warnings 1, total 268435456 bytes
  6 hard cap+1, NO ack -> REFUSED                         exit 1 (want non-zero), warnings 0
  7 hard cap+1, WITH ack -> PASS+warn                     exit 0 (want 0), warnings 1, total 268435457 bytes
  8 reported gap repro, NO ack -> REFUSED                 exit 1 (want non-zero), warnings 0
  9 reported gap repro, WITH ack -> PASS+warn              exit 0 (want 0), warnings 1, total 2305843008139952128 bytes
  10 product overflow, ack ALSO set -> still REFUSED       exit 1 (want non-zero), warnings 0
  11 inherited hard-cap breach + ack from http block       exit 0 (want 0), warnings 1, total 268435457 bytes
  12 explicit 16 MB value warns once, not twice             exit 0 (want 0), warnings 1, total 16777217 bytes

OK: zstd_buffers bound policy (12/12 arms)
```

Arm 8 is the exact reported gap (`zstd_buffers 2147483647 1024m;`), which now refuses instead of loading with a log line; arm 9 is the same input with the acknowledgement.

Negative control: guarded the merge-time call with `if (0 && ...)`, rebuilt (`.so` 161608 -> 159064 bytes), reran — 9 of 12 arms failed (3, 4, 5, 6, 7, 8, 9, 11, 12), including arm 8 (the regression this PR closes) and arm 6 (hard-cap refusal); arm 10 stayed green because it's covered independently by the still-active parse-time overflow check. Reverted, rebuilt (`.so` back to 161608), matrix green again. Built with `-Werror` against nginx 1.31.4 (`--add-dynamic-module`, `-DZSTD_STATIC_LINKING_ONLY`); no warnings.

`review-lint.sh --branch master` clean across the whole roster (ruff, clang-tidy, semgrep, ast-grep, zizmor, gitleaks, vulture) after removing one dead constant vulture caught in the test file; no coverage-gap block, every listed tool ran. `lizard` still flags `run_arm()`'s complexity, matching the pre-existing style of this repo's sibling `test_*_policy.py` tools; not refactored here to stay within scope. Remaining `markdownlint`/`yamllint`/pool-alloc ast-grep findings are pre-existing lines this diff does not touch.

**Not verified:** the "many concurrent slow-drain responses" half of the original done criterion. `ci/tools/test_slow_drain.py` exists but drives a fixed, unrelated `zstd_buffers 2 8k` config for a different race; repurposing it to measure worker RSS under concurrent load at the new cap boundary is a soak-shaped experiment out of scope for this pass. Ledgered in `memory/labs/http-zstd/TODO.md`.
