### PR TITLE
ci: add dcz CDict-vs-refPrefix equivalence probes (refutes the config-time CDict cache)

### DIFF
--- a/ci/tools/dcz-cdict-equivalence/README.md
+++ b/ci/tools/dcz-cdict-equivalence/README.md
@@ -1,0 +1,52 @@
+# dcz CDict-vs-refPrefix equivalence probes
+
+Standalone libzstd probes used to evaluate caching a `ZSTD_CDict` at config
+time in place of the per-request `ZSTD_CCtx_refPrefix()` on the dcz path
+(`ngx_http_zstd_filter_module.c`, `init_cctx`).
+
+Verdict: **not equivalent**. `ZSTD_CCtx_refCDict()` and
+`ZSTD_CCtx_refPrefix()` produce different wire bytes at every compression
+level, not only at the fast-strategy levels 1-2. Substituting one for the
+other changes the compressed output of every dcz response.
+
+## Build and run
+
+Both probes read `dict.bin` (1 MiB) and `body.bin` (256 KiB) from the
+working directory. Generate them with:
+
+    python3 gen_corpus.py
+
+The corpus must be realistic, non-degenerate text-like data: a synthetic
+periodic buffer compresses to a few dozen bytes, masks the effect, and
+reports spurious byte-identity.
+
+    gcc -O2 -o equivalence_probe equivalence_probe.c -lzstd
+    gcc -O2 -o timing_probe      timing_probe.c      -lzstd
+
+`equivalence_probe` sweeps dictionary sizes {4 KiB, 64 KiB, 256 KiB, 1 MiB}
+x body sizes {512 B, 8 KiB, 128 KiB} x levels 1..19, with the **full**
+compression-parameter set (windowLog, chainLog, hashLog, searchLog,
+minMatch, targetLength, strategy) pinned identically on both paths, and
+reports every combination whose output differs.
+
+`timing_probe` measures per-request cost of both paths and verifies that
+CDict output still round-trips through a decoder using the raw dictionary
+as a prefix.
+
+## Observed (libzstd 1.5.7)
+
+    identical 86/228   (142 of 228 combinations diverge)
+    diverging=142 cdict_worse=59 cdict_better=59 same_size=24
+    mean size delta +0.30%, worst single regression +12.31%
+
+Divergence is present at levels 1-19 and at every dictionary size, so no
+level cutoff exists that makes the substitution byte-safe.
+
+Timing (level 9, 8 KiB body):
+
+    dict 4 KiB    refPrefix  363.6 us/req   cachedCDict 301.7 us/req
+    dict 64 KiB   refPrefix  313.5 us/req   cachedCDict 217.1 us/req
+    dict 1 MiB    refPrefix 2012.3 us/req   cachedCDict 151.6 us/req
+
+The speed win is real and grows with dictionary size; it is the wire-byte
+equivalence, not the performance, that blocks the change.

--- a/ci/tools/dcz-cdict-equivalence/equivalence_probe.c
+++ b/ci/tools/dcz-cdict-equivalence/equivalence_probe.c
@@ -1,0 +1,72 @@
+#define ZSTD_STATIC_LINKING_ONLY
+#include <zstd.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+static char dict[1<<20],body[1<<18],o1[1<<21],o2[1<<21];
+#define P(o,c,k,v) ZSTD_CCtxParams_setParameter(o,k,v)
+static void setcp(ZSTD_CCtx_params*p,ZSTD_compressionParameters cp,int lvl){
+  P(p,0,ZSTD_c_compressionLevel,lvl);
+  P(p,0,ZSTD_c_windowLog,cp.windowLog);P(p,0,ZSTD_c_chainLog,cp.chainLog);
+  P(p,0,ZSTD_c_hashLog,cp.hashLog);P(p,0,ZSTD_c_searchLog,cp.searchLog);
+  P(p,0,ZSTD_c_minMatch,cp.minMatch);P(p,0,ZSTD_c_targetLength,cp.targetLength);
+  P(p,0,ZSTD_c_strategy,cp.strategy);
+}
+static void setcc(ZSTD_CCtx*c,ZSTD_compressionParameters cp,int lvl){
+  ZSTD_CCtx_setParameter(c,ZSTD_c_compressionLevel,lvl);
+  ZSTD_CCtx_setParameter(c,ZSTD_c_windowLog,cp.windowLog);
+  ZSTD_CCtx_setParameter(c,ZSTD_c_chainLog,cp.chainLog);
+  ZSTD_CCtx_setParameter(c,ZSTD_c_hashLog,cp.hashLog);
+  ZSTD_CCtx_setParameter(c,ZSTD_c_searchLog,cp.searchLog);
+  ZSTD_CCtx_setParameter(c,ZSTD_c_minMatch,cp.minMatch);
+  ZSTD_CCtx_setParameter(c,ZSTD_c_targetLength,cp.targetLength);
+  ZSTD_CCtx_setParameter(c,ZSTD_c_strategy,cp.strategy);
+}
+static size_t slurp(const char*path,char*buf,size_t cap){
+  FILE*f=fopen(path,"rb");
+  if(!f){fprintf(stderr,"cannot open %s\n",path);exit(1);}
+  size_t n=fread(buf,1,cap,f);
+  fclose(f);
+  if(n<cap){fprintf(stderr,"%s: need %zu bytes, got %zu\n",path,cap,n);exit(1);}
+  return n;
+}
+
+int main(void){
+  slurp("dict.bin",dict,sizeof dict);
+  slurp("body.bin",body,sizeof body);
+  size_t ds[]={4096,65536,262144,1048576},bs[]={512,8192,131072};
+  int bad=0,tot=0;
+  for(int di=0;di<4;di++)for(int bi=0;bi<3;bi++){
+    size_t dlen=ds[di],blen=bs[bi];
+    unsigned wlog=10;while(((size_t)1<<wlog)<dlen+blen&&wlog<23)wlog++;
+    for(int lvl=1;lvl<=19;lvl++){
+      /* PINNED cparams: derived from level + dict size only, with srcSize
+         left at 0 (unknown) so the set is config-time-derivable. The SAME
+         cp is then applied to both paths, so any surviving difference is
+         the match-finding path itself, not parameter drift. */
+      ZSTD_compressionParameters cp=ZSTD_getCParams(lvl,0,dlen);
+      if(cp.windowLog>wlog)cp.windowLog=wlog;
+      ZSTD_CCtx_params*p=ZSTD_createCCtxParams();setcp(p,cp,lvl);
+      ZSTD_CDict*cd=ZSTD_createCDict_advanced2(dict,dlen,ZSTD_dlm_byRef,ZSTD_dct_rawContent,p,ZSTD_defaultCMem);
+      ZSTD_CCtx*a=ZSTD_createCCtx();setcc(a,cp,lvl);
+      ZSTD_CCtx_setPledgedSrcSize(a,blen);ZSTD_CCtx_refPrefix(a,dict,dlen);
+      ZSTD_CCtx_setParameter(a,ZSTD_c_checksumFlag,1);
+      size_t r1=ZSTD_compress2(a,o1,sizeof o1,body,blen);
+      ZSTD_CCtx*b=ZSTD_createCCtx();setcc(b,cp,lvl);
+      ZSTD_CCtx_setPledgedSrcSize(b,blen);ZSTD_CCtx_refCDict(b,cd);
+      ZSTD_CCtx_setParameter(b,ZSTD_c_checksumFlag,1);
+      size_t r2=ZSTD_compress2(b,o2,sizeof o2,body,blen);
+      if(ZSTD_isError(r1)||ZSTD_isError(r2)){
+        printf("ERR d=%7zu b=%6zu lvl=%2d: %s / %s\n",dlen,blen,lvl,
+               ZSTD_isError(r1)?ZSTD_getErrorName(r1):"ok",
+               ZSTD_isError(r2)?ZSTD_getErrorName(r2):"ok");
+      } else {
+        tot++;
+        if(r1!=r2||memcmp(o1,o2,r1)){bad++;printf("DIFF d=%7zu b=%6zu lvl=%2d strategy=%d pfx=%zu cd=%zu\n",dlen,blen,lvl,cp.strategy,r1,r2);}
+      }
+      ZSTD_freeCCtx(a);ZSTD_freeCCtx(b);ZSTD_freeCDict(cd);ZSTD_freeCCtxParams(p);
+    }
+  }
+  printf("identical %d/%d\n",tot-bad,tot);
+  return 0;
+}

--- a/ci/tools/dcz-cdict-equivalence/equivalence_probe.c
+++ b/ci/tools/dcz-cdict-equivalence/equivalence_probe.c
@@ -1,4 +1,6 @@
+#ifndef ZSTD_STATIC_LINKING_ONLY
 #define ZSTD_STATIC_LINKING_ONLY
+#endif
 #include <zstd.h>
 #include <stdio.h>
 #include <string.h>

--- a/ci/tools/dcz-cdict-equivalence/gen_corpus.py
+++ b/ci/tools/dcz-cdict-equivalence/gen_corpus.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Generate dict.bin / body.bin for the dcz CDict-vs-refPrefix probes.
+
+The corpus must be realistic text-like data. A degenerate periodic buffer
+compresses to a few dozen bytes and hides the refCDict/refPrefix divergence
+entirely -- that artifact is what previously made the substitution look
+byte-safe at levels 3-19.
+"""
+
+import random
+
+WORDS = [
+    "<div>",
+    "</div>",
+    "class=",
+    '"container"',
+    "user",
+    "id",
+    "name",
+    "value",
+    "true",
+    "false",
+    "null",
+    "data",
+    "<span>",
+    "</span>",
+    "href",
+    "https://example.com/",
+    "item",
+    "list",
+    "2026",
+    "response",
+    "header",
+    "content",
+    "zstd",
+    "dictionary",
+    "compression",
+    "the",
+    "and",
+    "of",
+    "a",
+]
+
+
+def gen(n, seed):
+    rnd = random.Random(seed)
+    out, length = [], 0
+    while length < n:
+        w = rnd.choice(WORDS) + rnd.choice([" ", "\n", ""])
+        out.append(w)
+        length += len(w)
+    return "".join(out)[:n].encode()
+
+
+if __name__ == "__main__":
+    # Distinct seeds: the body shares the dictionary's vocabulary and
+    # statistics without being a literal copy of it.
+    with open("dict.bin", "wb") as f:
+        f.write(gen(1 << 20, 7))
+    with open("body.bin", "wb") as f:
+        f.write(gen(1 << 18, 99))
+    print("wrote dict.bin (1 MiB) and body.bin (256 KiB)")

--- a/ci/tools/dcz-cdict-equivalence/timing_probe.c
+++ b/ci/tools/dcz-cdict-equivalence/timing_probe.c
@@ -1,0 +1,59 @@
+#define ZSTD_STATIC_LINKING_ONLY
+#include <zstd.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+static char dict[1<<20],body[1<<18],o[1<<21],dec[1<<19];
+static double now(void){struct timespec t;clock_gettime(CLOCK_MONOTONIC,&t);return t.tv_sec+t.tv_nsec/1e9;}
+static void slurp(const char*path,char*buf,size_t cap){
+  FILE*f=fopen(path,"rb");
+  if(!f){fprintf(stderr,"cannot open %s\n",path);exit(1);}
+  size_t n=fread(buf,1,cap,f);
+  fclose(f);
+  if(n<cap){fprintf(stderr,"%s: need %zu bytes, got %zu\n",path,cap,n);exit(1);}
+}
+
+int main(void){
+  slurp("dict.bin",dict,sizeof dict);
+  slurp("body.bin",body,sizeof body);
+  size_t ds[]={4096,65536,1048576}; size_t blen=8192; int lvl=9; int N=300;
+  for(int i=0;i<3;i++){
+    size_t dlen=ds[i];
+    unsigned wlog=10;while(((size_t)1<<wlog)<dlen+blen&&wlog<23)wlog++;
+    double t0=now();size_t r1=0;
+    for(int k=0;k<N;k++){
+      ZSTD_CCtx*c=ZSTD_createCCtx();
+      ZSTD_CCtx_setParameter(c,ZSTD_c_compressionLevel,lvl);
+      ZSTD_CCtx_setParameter(c,ZSTD_c_windowLog,wlog);
+      ZSTD_CCtx_setPledgedSrcSize(c,blen);
+      ZSTD_CCtx_refPrefix(c,dict,dlen);
+      ZSTD_CCtx_setParameter(c,ZSTD_c_checksumFlag,1);
+      r1=ZSTD_compress2(c,o,sizeof o,body,blen);ZSTD_freeCCtx(c);}
+    double t1=now();
+    ZSTD_CCtx_params*p=ZSTD_createCCtxParams();
+    ZSTD_CCtxParams_setParameter(p,ZSTD_c_compressionLevel,lvl);
+    ZSTD_CCtxParams_setParameter(p,ZSTD_c_windowLog,wlog);
+    ZSTD_CDict*cd=ZSTD_createCDict_advanced2(dict,dlen,ZSTD_dlm_byRef,ZSTD_dct_rawContent,p,ZSTD_defaultCMem);
+    double t2=now();size_t r2=0;
+    for(int k=0;k<N;k++){
+      ZSTD_CCtx*c=ZSTD_createCCtx();
+      ZSTD_CCtx_setParameter(c,ZSTD_c_compressionLevel,lvl);
+      ZSTD_CCtx_setParameter(c,ZSTD_c_windowLog,wlog);
+      ZSTD_CCtx_setPledgedSrcSize(c,blen);
+      ZSTD_CCtx_refCDict(c,cd);
+      ZSTD_CCtx_setParameter(c,ZSTD_c_checksumFlag,1);
+      r2=ZSTD_compress2(c,o,sizeof o,body,blen);ZSTD_freeCCtx(c);}
+    double t3=now();
+    /* decode the CDict output with the raw dict as prefix -> must roundtrip */
+    ZSTD_DCtx*d=ZSTD_createDCtx();
+    ZSTD_DCtx_setParameter(d,ZSTD_d_windowLogMax,23);
+    ZSTD_DCtx_refPrefix(d,dict,dlen);
+    size_t dr=ZSTD_decompressDCtx(d,dec,sizeof dec,o,r2);
+    int ok=!ZSTD_isError(dr)&&dr==blen&&!memcmp(dec,body,blen);
+    printf("dict=%8zu wlog=%2u  refPrefix %7.1f us/req (%zu B)  cachedCDict %6.1f us/req (%zu B)  roundtrip=%s\n",
+      dlen,wlog,(t1-t0)/N*1e6,r1,(t3-t2)/N*1e6,r2,ok?"OK":"FAIL");
+    ZSTD_freeDCtx(d);ZSTD_freeCDict(cd);ZSTD_freeCCtxParams(p);
+  }
+  return 0;
+}

--- a/ci/tools/dcz-cdict-equivalence/timing_probe.c
+++ b/ci/tools/dcz-cdict-equivalence/timing_probe.c
@@ -1,4 +1,6 @@
+#ifndef ZSTD_STATIC_LINKING_ONLY
 #define ZSTD_STATIC_LINKING_ONLY
+#endif
 #include <zstd.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
> Result of investigating the open TODO row "dcz rebuilds the dictionary match table on EVERY request". No module source is changed: the investigation refuted the change's premise, so this PR lands the reproducible probes and the measurement instead.

## TL;DR

We looked at making dictionary-compressed responses faster by preparing the dictionary once when the server starts, instead of re-preparing it on every request. The faster method turns out to produce different compressed bytes than the current one, so every such response would come out slightly different — sometimes larger. That is a visible change to what clients receive, so it is a decision for a human rather than a straightforward speed fix.

Adds `ci/tools/dcz-cdict-equivalence/` (two standalone libzstd probes, a corpus generator, and a README recording the observed numbers); no change to `ngx_http_zstd_filter_module.c`.

**Severity:** `Low` (`tooling — investigation artifact, no runtime code path touched`)

## What was tested

Substituting `ZSTD_CCtx_refCDict()` (dictionary prepared once, at config time) for the per-request `ZSTD_CCtx_refPrefix()` at `src/ngx_http_zstd_filter_module.c:2457`.

`equivalence_probe.c` sweeps dictionary sizes {4 KiB, 64 KiB, 256 KiB, 1 MiB} x body sizes {512 B, 8 KiB, 128 KiB} x levels 1-19. Critically, it pins the **full** compression-parameter set — `windowLog`, `chainLog`, `hashLog`, `searchLog`, `minMatch`, `targetLength`, `strategy` — identically on both paths, so any surviving difference is the match-finding path itself rather than parameter drift.

## Result — the substitution is not wire-compatible

    identical 86/228        (142 of 228 combinations diverge)
    cdict_worse=59  cdict_better=59  same_size=24
    mean size delta +0.30%, worst single regression +12.31%

Divergence appears at **every** level 1-19 and every dictionary size. Pinning the compression parameters does not converge the two paths; they are different match-finding implementations, not one algorithm with different tuning.

This matters because it contradicts an earlier reading that found byte-identity at levels 3-19 with only levels 1-2 diverging. That reading came from a degenerate periodic test corpus, which compresses to a few dozen bytes and hides the effect entirely. `gen_corpus.py` produces the realistic text-like data needed to observe it.

A second, independent obstacle: the dcz `windowLog` is derived per-request from `dict.len + ctx->pledged_size` (`:2424`), so there is no small config-time tuple space to cache against in the first place.

## What is not in dispute

The speed win is real and grows with dictionary size (level 9, 8 KiB body):

| dict | refPrefix | cached CDict |
|---|---|---|
| 4 KiB | 377 us/req | 306 us/req |
| 64 KiB | 319 us/req | 221 us/req |
| 1 MiB | 1898 us/req | 149 us/req |

CDict output also round-trips correctly against the raw dictionary prefix (`roundtrip=OK` for all three sizes). The blocker is wire bytes, not performance or correctness.

## Testing

Probes compile clean under `gcc -O2 -Wall -Wextra` and were run from a clean directory via `gen_corpus.py` to confirm end-to-end reproducibility (`identical 86/228`, reproduced across four runs). libzstd 1.5.7.

`review-lint.sh --branch origin/master`: all lenses clean, empty `== coverage gap ==` block. Two findings surfaced during the pre-open pass and were fixed here — unchecked `fopen`/`fread` (probes now fail loudly on a short or missing corpus) and a leak of four zstd objects on the compression-error path.

No module source changed, so the existing test suite is unaffected.
