### PR TITLE
perf(dict): build static-API trained CDicts by reference, not by copy

### DIFF
--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -224,10 +224,24 @@ typedef struct {
      * cf->pool the first time each is created — never per-location. This
      * array itself lives in cf->pool alongside the main conf, so it is
      * torn down with the same pool that owns every CDict's cleanup
-     * handler; dict_buf outlives every CDict that referenced it during
-     * construction (ZSTD_dlm_byCopy copies the bytes into libzstd's own
-     * allocation, so dict_buf is not read again after the last build —
-     * it is freed by ordinary cf->pool cleanup, not explicitly).
+     * handler.
+     *
+     * On the static-linking build (ZSTD_dlm_byRef, see the CDict-build
+     * site) every CDict entry REFERENCES dict_buf directly rather than
+     * copying it — libzstd reads dict_buf for the entire lifetime of
+     * each CDict, not just at construction. This is safe only because
+     * dict_buf and every CDict built from it share the same cf->pool
+     * lifetime and teardown order: ngx_destroy_pool() runs every
+     * registered cleanup handler (including each ZSTD_freeCDict() below)
+     * BEFORE releasing pool allocations, so dict_buf is still mapped for
+     * every ZSTD_freeCDict() call, and it is never freed while any CDict
+     * that references it is still alive. Across a reload, old worker
+     * processes keep the entire old cycle (and its pool) alive until
+     * they exit, so an old CDict's reference into the old cycle's
+     * dict_buf is never dangling. On the public-API fallback build
+     * (plain ZSTD_createCDict(), #else branch below) the CDict still
+     * copies the bytes, so dict_buf is not read again there after the
+     * last build on that path.
      */
     u_char                      *dict_buf;
     size_t                       dict_buf_size;
@@ -3460,7 +3474,7 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
                 }
 
                 conf->dict = ZSTD_createCDict_advanced(buf, size,
-                                 ZSTD_dlm_byCopy, ZSTD_dct_auto, cparams,
+                                 ZSTD_dlm_byRef, ZSTD_dct_auto, cparams,
                                  ZSTD_defaultCMem);
             }
 #else
@@ -3475,12 +3489,16 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
             /* Register cleanup handler to free dictionary when
              * config is destroyed.
-             * Note: Using ZSTD_createCDict() (copy mode) instead
-             * of _byReference() to avoid use-after-free during
-             * config reloads. Dictionary buffer is copied into
-             * ZSTD's internal memory so config pool cleanup can
-             * safely free the original buf without affecting
-             * in-flight compressions. */
+             * Note: on this (static-API) path the CDict is built
+             * ZSTD_dlm_byRef — it holds a reference into dict_buf, not
+             * a private copy, for its entire lifetime. This is safe
+             * across reload because dict_buf and the CDict share the
+             * same cf->pool: ngx_destroy_pool() runs this cleanup
+             * handler (ZSTD_freeCDict) before releasing any pool
+             * allocation, so dict_buf outlives every CDict built from
+             * it, and an old worker retains its whole old cycle (pool
+             * included) until it exits. See the dict_buf field comment
+             * above for the full argument. */
             {
                 ngx_pool_cleanup_t  *cln;
 
@@ -3537,9 +3555,15 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
              * here: a later location at a DIFFERENT profile still needs
              * these same raw bytes to build its own CDict. It is
              * reclaimed by ordinary cf->pool cleanup at cycle teardown,
-             * the same point every CDict's cleanup handler runs — no
-             * explicit free needed, and freeing it early here would be a
-             * use-after-free for the very next distinct profile.
+             * the same point every CDict's cleanup handler runs.
+             *
+             * On the static-API (byRef) path this is stronger than "a
+             * later build needs it too": every CDict already built from
+             * dict_buf keeps reading it for its entire remaining
+             * lifetime, not just until its own construction finishes.
+             * Freeing dict_buf early here would be a use-after-free for
+             * EVERY profile built from it so far, not only the next
+             * distinct one — see the dict_buf field comment above.
              */
         }
     }


### PR DESCRIPTION
> TODO.md row: on the static-linking build, build trained CDicts `ZSTD_dlm_byRef` instead of `ZSTD_dlm_byCopy`.

## TL;DR

Every trained CDict on the static-API build used to hold its own private copy of the dictionary bytes. Now it holds a reference into the cycle-wide `dict_buf` instead, so a config with N distinct `(level, window_log)` profiles keeps one copy of the dictionary in memory instead of N.

`ZSTD_createCDict_advanced()` in `ngx_http_zstd_merge_loc_conf()` (`src/ngx_http_zstd_filter_module.c`) now passes `ZSTD_dlm_byRef` instead of `ZSTD_dlm_byCopy`. The `#else` public-API fallback (plain `ZSTD_createCDict()`) is untouched — `byRef` is not expressible through that entry point.

**Severity:** `Low` (`performance — avoidable per-profile dictionary memory duplication`)

## Why this is safe

`dict_buf` and every `ZSTD_CDict` built from it live on the same `cf->pool`. `ngx_destroy_pool()` runs every registered cleanup handler — including each CDict's `ZSTD_freeCDict()` — before releasing any pool allocation, so `dict_buf` is guaranteed to still be mapped for every `ZSTD_freeCDict()` call. Across a reload, an old worker keeps its entire old cycle (pool included) alive until it exits, so a live old-cycle CDict's reference into the old `dict_buf` never dangles.

Rewrote the three comments that asserted copy semantics (the `dict_buf` field comment, the cleanup-handler registration note, and the "don't free early" note at the registry-entry site) to describe the new reference lifetime instead.

## Testing

- **Byte-identical output.** Built both before/after binaries (`ci/tools/ci-build.sh`, static-linking define), served the same 700 KB trained-dictionary body through two distinct `(level, window_log)` profiles, `cmp`'d the compressed responses — identical in both profiles.
- **Memory win, measured.** Standalone harness against `ZSTD_createCDict_advanced()`: `ZSTD_sizeof_CDict()` for a 716800-byte dictionary is 11217472 bytes byCopy vs 10500672 bytes byRef — a 716800-byte (exactly the dictionary size) saving per unique profile.
- **ASan reload soak.** Rebuilt libzstd 1.5.7 from source with `-fsanitize=address` (the distro `.so` isn't instrumented, so a UAF inside libzstd's own reads is invisible to ASan against the shared build) and statically linked it into a `--add-module` ASan+UBSan nginx build. Ran 2 dict-backed locations under sustained load while sending SIGHUP every ~0.25s: 80 reloads, 640 requests, 0 non-200 responses, 0 ASan/UBSan reports, clean master exit.
- **Negative control.** Added a one-line `ngx_pfree(cf->pool, buf)` right after CDict construction (simulating the old comment's now-false assumption) and reran the same ASan-instrumented setup as an isolated probe: `ZSTD_RowFindBestMatch` reads the freed buffer directly, and ASan reports a clean heap-use-after-free at `mem.h:183` inside `MEM_read32`, confirming libzstd does read the dictionary bytes live during compression, not just at CDict construction. Reverted before commit.
