### PR TITLE
perf(cctx): return the CCtx loan through its lending slot, not a ring scan

### DIFF
--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -2280,7 +2280,7 @@ ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
 {
     ngx_uint_t                  i, borrowed;
     ngx_pool_cleanup_t         *cln;
-    ngx_http_zstd_cctx_slot_t  *slot, *free_slot;
+    ngx_http_zstd_cctx_slot_t  *slot, *free_slot, *lender;
 
     /*
      * The cleanup slot is registered BEFORE the context is claimed, so a
@@ -2294,6 +2294,7 @@ ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
 
     borrowed = 0;
     free_slot = NULL;
+    lender = NULL;
 
     /*
      * Borrow a slot whose context is free and was built for this location's
@@ -2329,6 +2330,7 @@ ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
         {
             ctx->cctx = slot->cctx;
             slot->busy = 1;
+            lender = slot;
             borrowed = 1;
 
             ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
@@ -2352,6 +2354,7 @@ ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
             free_slot->long_mode = zlcf->long_mode;
             free_slot->window_log = zlcf->window_log;
             free_slot->busy = 1;
+            lender = free_slot;
             borrowed = 1;
         }
 
@@ -2360,14 +2363,19 @@ ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
                        ctx->cctx, borrowed);
     }
 
+    /*
+     * The two handlers take different data: release_cctx() returns a loan
+     * and is given its lending slot, cleanup_cctx() owns an uncached
+     * context outright and is given the context itself.
+     */
     if (borrowed) {
         cln->handler = ngx_http_zstd_release_cctx;
+        cln->data = lender;
 
     } else {
         cln->handler = ngx_http_zstd_cleanup_cctx;
+        cln->data = ctx->cctx;
     }
-
-    cln->data = ctx->cctx;
 
     return NGX_OK;
 }
@@ -3934,33 +3942,29 @@ ngx_http_zstd_cleanup_cctx(void *data)
 static void
 ngx_http_zstd_release_cctx(void *data)
 {
-    ngx_uint_t   i;
-    ZSTD_CCtx   *cctx = data;
+    ngx_http_zstd_cctx_slot_t  *slot = data;
 
-    if (cctx == NULL) {
+    if (slot == NULL || slot->cctx == NULL) {
         return;
     }
 
     /*
-     * Find the slot this loan came from. The cleanup handler is given only
-     * the context pointer (nginx's cleanup contract), so the slot is located
-     * by pointer identity; NGX_HTTP_ZSTD_CCTX_SLOTS is a small compile-time
-     * constant, so this walk is a handful of comparisons on a hot-but-tiny
-     * array, not a lookup structure worth carrying.
+     * The lending slot is handed straight to this handler: acquire_cctx()
+     * already had it, and nginx's cleanup data is an opaque void *, not a
+     * CCtx-only contract. Returning the loan is therefore O(1) with no
+     * search.
+     *
+     * This replaced a pointer-identity walk over the ring. That walk also
+     * carried a "not found -> ZSTD_freeCCtx()" fallback for a slot replaced
+     * mid-loan; the fallback was already unreachable, because a slot on loan
+     * is never evicted or re-seeded (acquire_cctx() skips every busy slot,
+     * and only ever seeds one that is empty AND not busy). Any future
+     * eviction policy must preserve that invariant -- evicting a busy slot
+     * would free a context a live request is still writing into, which no
+     * amount of searching here could make safe.
      */
-    for (i = 0; i < NGX_HTTP_ZSTD_CCTX_SLOTS; i++) {
-        if (ngx_http_zstd_worker_cctx_slots[i].cctx == cctx) {
-            (void) ZSTD_CCtx_reset(cctx, ZSTD_reset_session_only);
-            ngx_http_zstd_worker_cctx_slots[i].busy = 0;
-            return;
-        }
-    }
-
-    /*
-     * Not in any slot: the slot was replaced while this request held its
-     * loan (only reachable if a future edit adds eviction). Own it.
-     */
-    ZSTD_freeCCtx(cctx);
+    (void) ZSTD_CCtx_reset(slot->cctx, ZSTD_reset_session_only);
+    slot->busy = 0;
 }
 
 


### PR DESCRIPTION
> Backlog NIT from the performance sweep, verified live against current code before dispatch (the row's line numbers had drifted). Independent of #172, which touched dcz negotiation.

## TL;DR

Each worker keeps a handful of compressor objects around so it does not have to build a new one for every response. When a response finished, the code had thrown away the note saying which shelf it borrowed from, so it searched all the shelves to put the object back. It had the shelf all along.

`ngx_http_zstd_release_cctx()` now receives the lending `ngx_http_zstd_cctx_slot_t *` as its cleanup data instead of the bare `ZSTD_CCtx *`, replacing a pointer-identity walk over the slot ring with a direct `slot->busy = 0`.

**Severity:** `Low` (`performance — avoidable per-request work at teardown`)

## Why the search existed

The handler's comment blamed nginx: "the cleanup handler is given only the context pointer (nginx's cleanup contract)". That is not a real constraint — `ngx_pool_cleanup_t.data` is an opaque `void *`, and `ngx_http_zstd_acquire_cctx()` already holds the exact slot on both paths that take a loan. The search was recovering information the caller never had to discard.

## What changed

`acquire_cctx()` records the lending slot in a new `lender` local, assigned at the same two sites that set `borrowed = 1` (reuse at `:2330`, seed at `:2354`) and nowhere else — so `borrowed` implies a non-NULL `lender` by construction. The two cleanup handlers now take the data each actually needs: `release_cctx()` its slot, `cleanup_cctx()` the context it owns outright.

The walk's `not found -> ZSTD_freeCCtx()` fallback goes with it. It was already unreachable: `acquire_cctx()` skips every busy slot and only ever seeds one that is empty **and** not busy, so a slot on loan is never evicted or re-seeded. The comment now states that as the invariant any future eviction policy has to preserve — evicting a busy slot would free a context a live request is still writing into, which no amount of searching in the release handler could make safe.

One incidental safety gain: `ngx_http_zstd_exit_process()` NULLs each `slot->cctx` after freeing it, and the new `slot->cctx == NULL` guard returns early on that state. The old code compared a freed pointer against the ring and would have fallen through to `ZSTD_freeCCtx()` on an already-freed context.

## Testing

Reuse witnesses over 12 sequential requests through one worker, `--with-debug` build:

| build | `reusing worker cctx` | `created cctx` |
|---|---|---|
| this branch | 11 | 1 |
| mutant: `slot->busy = 0` removed | 0 | 12 |

`ci/tools/test_cctx_reuse.py` already asserts exactly this invariant (one create, N-1 reuses) and runs in CI, so the change stays gated without a new test.

Also observed:

- `-Werror` clean.
- 160/160 correct responses interleaving the default, `zstd_long`, `zstd_window_log 20` and `zstd_comp_level 9` profiles — each forces a distinct slot, exercising borrow, seed and miss.
- 100/100 correct 200 KB multi-buffer streaming responses under ASan+UBSan, 0 reports.
- `review-lint.sh --diff HEAD` clean; the remaining cppcheck/lizard hits are pre-existing and on functions this diff does not touch.

One negative result worth recording: a `ZSTD_freeCCtx`-on-release mutant did **not** trip ASan, because the distro libzstd is uninstrumented — the same trap hit in #171. The reuse-witness counts above are the oracle that actually discriminates here.
