### PR TITLE
perf(cctx): refactor slot profile comparison into portable unit

### DIFF
--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -661,15 +661,40 @@ static ngx_int_t ngx_http_zstd_filter_emit_dcz_header(ngx_http_request_t *r,
 #endif
 
 typedef struct {
-    ZSTD_CCtx   *cctx;
     ngx_int_t    level;
     ngx_flag_t   long_mode;
     ngx_int_t    window_log;
-    ngx_uint_t   busy;
+} ngx_http_zstd_cctx_profile_t;
+
+typedef struct {
+    ZSTD_CCtx                       *cctx;
+    ngx_http_zstd_cctx_profile_t     profile;
+    ngx_uint_t                       busy;
 } ngx_http_zstd_cctx_slot_t;
 
 static ngx_http_zstd_cctx_slot_t
     ngx_http_zstd_worker_cctx_slots[NGX_HTTP_ZSTD_CCTX_SLOTS];
+
+
+static void
+ngx_http_zstd_cctx_profile_from_conf(ngx_http_zstd_cctx_profile_t *profile,
+    ngx_http_zstd_loc_conf_t *zlcf)
+{
+    profile->level = zlcf->level;
+    profile->long_mode = zlcf->long_mode;
+    profile->window_log = zlcf->window_log;
+}
+
+
+static ngx_int_t
+ngx_http_zstd_cctx_profiles_match(
+    const ngx_http_zstd_cctx_profile_t *a,
+    const ngx_http_zstd_cctx_profile_t *b)
+{
+    return a->level == b->level
+        && a->long_mode == b->long_mode
+        && a->window_log == b->window_log;
+}
 
 
 static ngx_conf_post_t  ngx_http_zstd_comp_level_bounds = {
@@ -1495,14 +1520,6 @@ ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
         return ngx_http_next_body_filter(r, in);
     }
 
-    /*
-     * Fetch the location conf once. It cannot change for the lifetime of
-     * a request, so resolving it per inner-loop iteration (as the
-     * zstd_max_length check below previously did) only adds module-index
-     * indirection to the hottest path.
-     */
-    zlcf = ngx_http_get_module_loc_conf(r, ngx_http_zstd_filter_module);
-
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                    "http zstd filter");
 
@@ -1518,6 +1535,13 @@ ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
     {
         return NGX_OK;
     }
+
+    /*
+     * Fetch the location conf once. It cannot change for the lifetime of
+     * a request, so resolving it only past the no-op early return avoids
+     * module-index indirection on paths that do not need it.
+     */
+    zlcf = ngx_http_get_module_loc_conf(r, ngx_http_zstd_filter_module);
 
     if (!ctx->cctx_ready) {
         /*
@@ -2278,9 +2302,10 @@ static ngx_int_t
 ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
     ngx_http_zstd_loc_conf_t *zlcf)
 {
-    ngx_uint_t                  i, borrowed;
-    ngx_pool_cleanup_t         *cln;
-    ngx_http_zstd_cctx_slot_t  *slot, *free_slot, *lender;
+    ngx_uint_t                      i, borrowed;
+    ngx_pool_cleanup_t             *cln;
+    ngx_http_zstd_cctx_slot_t      *slot, *free_slot, *lender;
+    ngx_http_zstd_cctx_profile_t    zlcf_profile;
 
     /*
      * The cleanup slot is registered BEFORE the context is claimed, so a
@@ -2291,6 +2316,8 @@ ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
     if (cln == NULL) {
         return NGX_ERROR;
     }
+
+    ngx_http_zstd_cctx_profile_from_conf(&zlcf_profile, zlcf);
 
     borrowed = 0;
     free_slot = NULL;
@@ -2324,9 +2351,8 @@ ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
             continue;
         }
 
-        if (slot->level == zlcf->level
-            && slot->long_mode == zlcf->long_mode
-            && slot->window_log == zlcf->window_log)
+        if (ngx_http_zstd_cctx_profiles_match(&slot->profile,
+                                              &zlcf_profile))
         {
             ctx->cctx = slot->cctx;
             slot->busy = 1;
@@ -2350,9 +2376,8 @@ ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
 
         if (free_slot != NULL) {
             free_slot->cctx = ctx->cctx;
-            free_slot->level = zlcf->level;
-            free_slot->long_mode = zlcf->long_mode;
-            free_slot->window_log = zlcf->window_log;
+            ngx_http_zstd_cctx_profile_from_conf(&free_slot->profile,
+                zlcf);
             free_slot->busy = 1;
             lender = free_slot;
             borrowed = 1;


### PR DESCRIPTION
## Summary

Two CCtx-slot nits, batched into one PR.

**ROW 1 (`ngx_http_zstd_body_filter`)** — move the loc-conf lookup below the
no-op initial-callback early return. `zlcf` had zero uses between the old
assignment site and that `return NGX_OK`, so the no-op path was paying a
module-index indirection for a value it never read.

**ROW 2 (`ngx_http_zstd_acquire_cctx`)** — pack the slot profile
(`level`, `long_mode`, `window_log`) into `ngx_http_zstd_cctx_profile_t` with
one fill helper and one compare helper. The match site and the seed site were
three open-coded field accesses each; adding a fourth memory-affecting
parameter meant editing both, and missing one silently widens reuse across
profiles. Both sites now go through the same two helpers, so they cannot drift.

Compare is field-by-field, deliberately **not** `memcmp` — struct padding bytes
are indeterminate and would make equal profiles compare unequal.

## Evidence

Built against pinned nginx 1.31.4, `--with-debug`, module rebuilt from this
branch. All numbers below were observed on this branch, not reasoned.

### Build
Clean at `-Werror` (`make modules`, exit 0, no diagnostics).

### Reuse oracle — `ci/tools/test_cctx_reuse.py` config, run by hand

12 sequential requests to the default-profile location plus 4 each to
`/alt/b` (`zstd_comp_level 9`), `/alt/long` (`zstd_long on`) and `/alt/wlog`
(`zstd_window_log 20`), counting the debug witnesses:

| build | `created cctx` | `reusing worker cctx` |
|---|---|---|
| this branch | **4** | **20** |
| mutant (`window_log` dropped from the compare) | **3** | **21** |

4/20 is exactly the tool's `WANT_CREATED = 1 + 3` and
`WANT_REUSED = (12-1) + 3*(4-1)`. The mutant collapses `/alt/wlog` into the
default slot — one fewer context created, one more spurious reuse — which is
precisely the memory-budget-defeating bug the profile key exists to prevent.
So the oracle is non-vacuous for this change.

All 24 requests returned 200 with `Content-Encoding: zstd`.

### Not verified locally
`ci/tools/test_cctx_reuse.py` itself aborts on this box in
`wait_for_port` — pre-existing on `master`, unrelated to this diff (the same
generated config starts and binds fine when driven by hand, and `nginx -t`
passes). The TAP suite and the full tool run are left to remote CI, which
gates this PR.

## Risk

Behaviour-identical by construction: same three fields, same comparison
semantics, same seeding values, just routed through helpers. Row 1 moves a
read across code that provably does not use it.