### PR TITLE
perf: fuse chain-copy and tail-track in one pass

### DIFF
--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -1539,7 +1539,6 @@ ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 {
     ngx_int_t                  flush, rc;
     ngx_chain_t               *cl;
-    ngx_chain_t               *in_copy;
     ngx_http_zstd_ctx_t       *ctx;
     ngx_http_zstd_loc_conf_t  *zlcf;
 
@@ -1601,34 +1600,31 @@ ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
     if (in) {
         /*
-         * O(1) append: ngx_chain_add_copy() walks the destination chain
-         * from its head to find the tail before appending, which makes
-         * repeated callbacks against a pending (not yet fully drained)
-         * ctx->in chain O(n^2) in the number of links retained across
-         * callbacks -- reachable whenever upstream data arrives while
-         * downstream backpressure (NGX_AGAIN from
-         * ngx_http_next_body_filter) leaves prior links queued. Copy the
-         * incoming chain into a fresh, NULL-headed local chain first (so
-         * ngx_chain_add_copy's own head-walk is bounded by the size of
-         * just this callback's `in`, not the whole retained backlog), then
-         * splice that copy onto the tracked tail in O(1). Consumers of
-         * ctx->in (add_data) only ever advance it link-by-link from the
-         * head and never reorder it, so the tracked tail cannot go stale
-         * between calls.
+         * O(1) append: allocate and link each incoming buffer one-by-one
+         * directly onto the tracked tail, advancing the tail as we go.
+         * This avoids the redundant traversal that ngx_chain_add_copy()
+         * followed by a while loop would incur: ngx_chain_add_copy() walks
+         * the destination chain to find its tail, and then a subsequent
+         * loop walks that same freshly-built chain again. Instead, we walk
+         * and build in the same pass, tracking the tail as we splice.
+         * Consumers of ctx->in (add_data) only ever advance it
+         * link-by-link from the head and never reorder it, so the tracked
+         * tail cannot go stale between calls.
          */
-        in_copy = NULL;
+        ngx_chain_t  *link;
 
-        if (ngx_chain_add_copy(r->pool, &in_copy, in) != NGX_OK) {
-            goto failed;
+        for (ngx_chain_t *src = in; src; src = src->next) {
+            link = ngx_alloc_chain_link(r->pool);
+            if (link == NULL) {
+                goto failed;
+            }
+
+            link->buf = src->buf;
+            link->next = NULL;
+
+            *ctx->last_in = link;
+            ctx->last_in = &link->next;
         }
-
-        *ctx->last_in = in_copy;
-
-        while (in_copy->next) {
-            in_copy = in_copy->next;
-        }
-
-        ctx->last_in = &in_copy->next;
 
         r->connection->buffered |= NGX_HTTP_GZIP_BUFFERED;
     }

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -1538,7 +1538,7 @@ static ngx_int_t
 ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 {
     ngx_int_t                  flush, rc;
-    ngx_chain_t               *cl;
+    ngx_chain_t               *cl, *link;
     ngx_http_zstd_ctx_t       *ctx;
     ngx_http_zstd_loc_conf_t  *zlcf;
 
@@ -1611,15 +1611,13 @@ ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
          * link-by-link from the head and never reorder it, so the tracked
          * tail cannot go stale between calls.
          */
-        ngx_chain_t  *link;
-
-        for (ngx_chain_t *src = in; src; src = src->next) {
+        for (cl = in; cl; cl = cl->next) {
             link = ngx_alloc_chain_link(r->pool);
             if (link == NULL) {
                 goto failed;
             }
 
-            link->buf = src->buf;
+            link->buf = cl->buf;
             link->next = NULL;
 
             *ctx->last_in = link;
@@ -2038,9 +2036,9 @@ ngx_http_zstd_filter_add_data(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
     }
 
     /*
-     * ngx_chain_add_copy() above allocated a fresh chain link per incoming
-     * link. Once we have taken its buffer, return the consumed link to the
-     * pool's free list with ngx_free_chain(); otherwise the copied links
+     * The body filter's append loop above allocated a fresh chain link per
+     * incoming link. Once we have taken its buffer, return the consumed
+     * link to the pool's free list with ngx_free_chain(); otherwise the links
      * accumulate in the request pool for the whole request, so a long-lived
      * chunked/SSE response grows worker memory linearly with chunk count
      * even though the output buffers are recycled. The buffer itself stays


### PR DESCRIPTION
Fuse the chain copy and the tail advance in the body filter into a single pass.

## The redundancy

`ngx_chain_add_copy()` walks the destination chain internally to find its tail
while appending. Because `in_copy` started `NULL`, that internal walk covered
exactly the links the callback had just created — and the `while (in_copy->next)`
loop immediately afterwards walked that same freshly built chain a **second**
time, purely to recover a tail `ngx_chain_add_copy()` already had.

The replacement allocates each link with `ngx_alloc_chain_link()`, splices it
through `*ctx->last_in` and advances `ctx->last_in` in the same iteration, so
each incoming buffer is visited once instead of twice.

## Behaviour preserved

- **Failure handling is identical.** Every allocation failure still takes
  `goto failed;`. A partial chain already spliced onto `ctx->last_in` when a
  later link fails is not a corruption: `ctx->last_in` always points at the
  `&next` of the last *successfully* linked element, so the tracked tail stays
  consistent and the already-linked buffers remain reachable from `ctx->in`.
- **`ctx->last_in` ends at `&link->next` of the last appended link**, exactly as
  before. Single-link `in` is the same sequence of operations.
- `r->connection->buffered |= NGX_HTTP_GZIP_BUFFERED;` is unmoved.
- Only the body-filter call site changed; the other `ngx_chain_add_copy()` users
  in the file are untouched.

## Comments corrected

Both comments that described the old mechanism were rewritten rather than left
describing code that no longer exists:

- the block above the loop now describes the fused single pass;
- the comment above the `ngx_free_chain()` site credited
  `ngx_chain_add_copy()` for allocating the per-link wrappers. That call is
  gone. Its *premise* — each link is a fresh wrapper, so returning it to the
  pool free list is safe — is unchanged, so only the attribution was corrected.

## Evidence

Build: `NO_CACHE=1 ci/tools/ci-build.sh nginx` → **exit 0** at `-Werror`
(nginx 1.31.4, both modules produced).

Oracle: `ci/tools/test_proxy_unbuffered_truncation.py` — unbuffered proxying is
what actually produces multi-buffer callbacks, and it decodes and byte-compares
the **whole** body across a buffer-boundary size matrix.

| build | result |
|---|---|
| fixed | **exit 0** — 35 responses across 7 boundary sizes round-tripped byte-exact |
| mutant (`ctx->last_in` advance removed) | **exit 1** — `ConnectionResetError: [Errno 104]` |

The negative control **fires**: the mutant compiles cleanly and is caught only
because the oracle decodes and length-checks the full body. This confirms the
test can genuinely see this code path, and covers callbacks carrying more than
one buffer — the case the change is about.

Lint pre-pass (`review-lint.sh --branch master`): cppcheck / flawfinder /
clang-tidy / gitleaks / trufflehog / codespell / semgrep / ast-grep all ran, no
coverage gap; no findings on the changed lines. `ci/linter/lint-nginx.sh` clean
(it caught one 80-column overflow in the rewritten comment, since fixed).

## Note for the harness, not this diff

`test_proxy_unbuffered_truncation.py` does not resolve the module paths it is
given to absolute form, and `load_module` resolves relative paths against the
nginx **prefix** (`-p <tmpdir>`). A relative `--filter-module` therefore fails
to load and the test dies with `nothing listening on 127.0.0.1:18086`, which
reads as an environment problem rather than a usage one. Passing absolute paths
is the workaround; this is the long-standing "fails locally, nginx never binds"
symptom, and it is **not** a property of any particular box.
