### PR TITLE
perf: replace did_len table lookup with shift expression

### DIFF
--- a/src/ngx_http_zstd_static_module.c
+++ b/src/ngx_http_zstd_static_module.c
@@ -239,8 +239,6 @@ ngx_http_zstd_static_probe_frame(const u_char *hdr, size_t n, uint64_t *window)
     uint64_t    w;
     ngx_uint_t  i, fhd, fcs_size, off;
 
-    static const ngx_uint_t  did_len[4] = { 0, 1, 2, 4 };
-
     mw = ((uint32_t) hdr[0])
        | ((uint32_t) hdr[1] << 8)
        | ((uint32_t) hdr[2] << 16)
@@ -323,7 +321,7 @@ ngx_http_zstd_static_probe_frame(const u_char *hdr, size_t n, uint64_t *window)
          * flag only means "absent" when Single_Segment is unset).
          */
         fcs_size = (fhd >> 6) ? ((ngx_uint_t) 1 << (fhd >> 6)) : 1;
-        off = 5 + did_len[fhd & 3];
+        off = 5 + (((ngx_uint_t) 1 << (fhd & 3)) >> 1);
 
         if (n < off + fcs_size) {
             return NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED;


### PR DESCRIPTION
## TL;DR

Replace the four-entry `did_len[4]` table lookup with an arithmetic expression `((ngx_uint_t) 1 << (fhd & 3)) >> 1`. The expression maps 0,1,2,3 → 0,1,2,4 identically and is consistent with the adjacent `fcs_size` computation at line 325, which already uses this shift idiom. Delete the now-unused table.

**Severity:** `Low` (performance — removes a read-only-data load per single-segment frame on x86-64)

## Measurement

**1. Exhaustive equivalence (all 4 inputs fhd&3):**

| fhd&3 | Table value | Expression value | Match |
|-------|-------------|------------------|-------|
| 0     | 0           | 0                | ✓     |
| 1     | 1           | 1                | ✓     |
| 2     | 2           | 2                | ✓     |
| 3     | 4           | 4                | ✓     |

All 4/4 domain values match — the transformation is correct.

**2. Assembly comparison at project optimization flags (`-O`):**

Original (with table):
```
  and    $0x3,%edi              # mask input
  lea    0x0(%rip),%rax         # load table address (relocation)
  mov    (%rax,%rdi,4),%eax     # load from table (memory access)
  add    $0x5,%eax              # add 5
```
Total: 4 instructions, 1 memory access, 1 relocation

New (with shift expression):
```
  mov    %edi,%ecx              # move to ecx
  and    $0x3,%ecx              # mask the value
  mov    $0x1,%eax              # load constant 1
  shl    %cl,%eax               # shift left by masked value
  shr    $1,%eax                # shift right by 1
  add    $0x5,%eax              # add 5
```
Total: 6 instructions, 0 memory access, 0 relocations

The new version eliminates the `.rodata` table load and relocation at the cost of 2 additional CPU instructions.

**3. Behaviour unchanged (static module tests):**

- **Original build:** 306 passing, 273 failing (harness path resolution issues unrelated to this change)
- **Modified build:** 306 passing, 273 failing (identical test outcomes)
- **Test command:** `TEST_NGINX_BINARY="<abs-path>/nginx" TEST_NGINX_SERVROOT="/tmp/nginx-servroot" perl ci/t/01-static.t`

Both builds have identical passing/failing test counts and patterns.

**4. Lint pre-pass:**

All linters pass on the modified file:
- `ci/linter/lint-nginx.sh` — clean
- flawfinder — 0 findings
- semgrep — 0 findings
- cppcheck — pass
- CodeQL — pass

## Rationale

Single-segment frames are the common case in served `.zst` files. The table lookup requires:
- a PC-relative address load (`lea %rip`), a dynamic relocation
- an indexed memory access (`mov (%rax,%rdi,4)`)

Both are avoided by replacing the table with the shift expression, which is already used for the adjacent `fcs_size` computation. This makes the two Frame_Header_Descriptor field extractions consistent in pattern and cost.

On modern CPU: 2 extra ALU instructions vs 1 L1 cache hit + 1 relocation pressure. The net trade is favourable for single-segment frames (the default), though immeasurable on this task. The consistency and clarity win is unconditional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal frame-header parsing logic without changing behavior.
  * Static dictionary identifiers continue to be interpreted correctly across all supported field lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->