### PR TITLE
perf: add HEAD fast path in static handler

### DIFF
--- a/src/ngx_http_zstd_static_module.c
+++ b/src/ngx_http_zstd_static_module.c
@@ -908,6 +908,13 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
      * nothing stable to seek into. */
     r->allow_ranges = 1;
 
+    /* HEAD fast path: send headers only, skip body buffer allocation.
+     * r->header_only covers more than HEAD (304/204), so check method
+     * explicitly to avoid breaking other status codes. */
+    if (r->method == NGX_HTTP_HEAD) {
+        return ngx_http_send_header(r);
+    }
+
     b = ngx_calloc_buf(r->pool);
     if (b == NULL) {
         return NGX_HTTP_INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
Add an explicit-HEAD fast path in the static handler, before body buffer
construction. For `r->method == NGX_HTTP_HEAD` the handler sends the headers
and returns, skipping the `ngx_calloc_buf()` + `ngx_pcalloc(sizeof(ngx_file_t))`
pair that today is built and then immediately discarded when
`ngx_http_send_header()` sets `r->header_only`.

## The two constraints this respects

A previous attempt at this row was reverted for moving `send_header` above the
allocations for *all* requests. Both of its regressions are avoided here:

1. **Allocate-before-header is retained for every body-capable request.** Both
   allocation-failure paths return `NGX_HTTP_INTERNAL_SERVER_ERROR`, which is
   unusable once the status line is committed. Only the literal-HEAD path — which
   allocates nothing — moves ahead.
2. **`r->allow_ranges = 1` stays above `send_header`.** It is read by
   `ngx_http_range_header_filter()` inside the header-filter chain, so moving it
   below would silently make it a no-op and kill byte ranges on precompressed
   `.zst`. Its position is unchanged.

The guard is `r->method == NGX_HTTP_HEAD`, deliberately not `r->header_only`:
the latter also covers 304/204, which must keep flowing through the existing
`r->header_only` check on the body path.

## Observed evidence

All measured on a local `-Werror` build of this branch (nginx 1.31.4).

**HEAD/GET header parity** — byte-identical, `Accept-Ranges: bytes` present on both:

```
GET                                   HEAD
HTTP/1.1 200 OK                       HTTP/1.1 200 OK
Content-Type: text/plain              Content-Type: text/plain
Content-Length: 84                    Content-Length: 84
Last-Modified: Tue, 25 Aug 2026 ...   Last-Modified: Tue, 25 Aug 2026 ...
Vary: Accept-Encoding                 Vary: Accept-Encoding
ETag: "6a8cf408-54"                   ETag: "6a8cf408-54"
Content-Encoding: zstd                Content-Encoding: zstd
Accept-Ranges: bytes                  Accept-Ranges: bytes
```

**Range still works** (the regression that reverted the previous attempt):

```
Range: bytes=0-9  ->  HTTP/1.1 206 Partial Content
                      Content-Length: 10
                      Content-Range: bytes 0-9/84
```

**Negative control — fires.** Widening the guard to `r->method & (NGX_HTTP_HEAD|NGX_HTTP_GET)`:

| build | GET | HEAD |
|---|---|---|
| this branch | 200, 84 body bytes, decompresses to 2061 | 200, headers only |
| mutant (guard fires on GET) | **`curl: (52) Empty reply from server`, 0 body bytes** | 200, headers only |

The mutant breaks GET outright while leaving HEAD intact, so the check
discriminates on exactly the method guard under test — the strict `==` is
load-bearing.

**Suite parity:** `prove ci/t/01-static.t` — **579/579 pass on this branch,
579/579 on master**, including TEST 17 (HEAD) and TEST 36 (Accept-Ranges).

`ci/linter/lint-nginx.sh` clean on the changed file (80-column gate included).