### PR TITLE
feat: add markdownlint config and fix substantive findings

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,8 @@
+{
+  "MD013": false,
+  "MD004": false,
+  "MD060": false,
+  "MD028": false,
+  "MD034": false,
+  "MD041": false
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,8 +1,0 @@
-{
-  "MD013": false,
-  "MD004": false,
-  "MD060": false,
-  "MD028": false,
-  "MD034": false,
-  "MD041": false
-}

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -5,37 +5,42 @@
 # legitimate prose patterns. Every disabled rule carries a comment explaining
 # what it would catch versus what it fights.
 
-rules:
-  # MD013 — line-length: disable
-  # The prose blocks are hand-wrapped documentation. Tables and log-output
-  # snippets legitimately run past 80 columns without breaking readability.
-  # A hard line-length gate trades 120 findings for mechanical churn.
-  MD013: false
+# MD013 — line-length: disable
+# The prose blocks are hand-wrapped documentation. Tables and log-output
+# snippets legitimately run past 80 columns without breaking readability.
+# A hard line-length gate trades 120 findings for mechanical churn.
+MD013: false
 
-  # MD004 — ul-style: disable
-  # README.md uses `*` bullets and other files use `-`. The default rule
-  # prefers consistency and would require rewriting one or the other. Since
-  # no style is better, we let each file's established pattern stand.
-  MD004: false
+# MD004 — ul-style: disable
+# The rule enforces ONE bullet style across the whole tree, but this repo has
+# two established per-file conventions and neither is wrong. Measured over the
+# tracked .md files: README.md is asterisk (79 `*` vs 2 `-`), while every other
+# file is dash (69 `-` vs 0 `*`) — CONTRIBUTING.md, SECURITY.md,
+# ci/adoption-findings.md, ci/fuzz/README.md, ci/linter/README.md.
+# Any single `style:` setting therefore reddens one group or the other and
+# forces a mechanical rewrite of a file that is already internally consistent.
+# Per-file consistency is the property worth having, and MD004 cannot express
+# it, so the rule is off rather than the files rewritten.
+MD004: false
 
-  # MD060 — table-column-style: disable
-  # Pipe alignment in tables is cosmetic. The default expects spaces around pipes
-  # that make maintenance tedious and add no semantic value.
-  MD060: false
+# MD060 — table-column-style: disable
+# Pipe alignment in tables is cosmetic. The default expects spaces around pipes
+# that make maintenance tedious and add no semantic value.
+MD060: false
 
-  # MD028 — no-blanks-blockquote: disable
-  # README.md deliberately uses blank-line-separated blockquotes as consecutive
-  # callouts. This pattern aids readability in rendered HTML.
-  MD028: false
+# MD028 — no-blanks-blockquote: disable
+# README.md deliberately uses blank-line-separated blockquotes as consecutive
+# callouts. This pattern aids readability in rendered HTML.
+MD028: false
 
-  # MD034 — no-bare-urls: disable
-  # This rule fires on EMAIL ADDRESSES (github@myguard.nl, zchao1995@gmail.com),
-  # not URLs. That is a false positive class in markdownlint itself — a match
-  # inside `<...@...>` pattern at any nesting level gets flagged as a bare URL
-  # when it is an email reference.
-  MD034: false
+# MD034 — no-bare-urls: disable
+# This rule fires on EMAIL ADDRESSES (github@myguard.nl, zchao1995@gmail.com),
+# not URLs. That is a false positive class in markdownlint itself — a match
+# inside `<...@...>` pattern at any nesting level gets flagged as a bare URL
+# when it is an email reference.
+MD034: false
 
-  # MD041 — first-line-h1: disable
-  # README.md opens with CI status badges before the H1 heading. This pattern is
-  # conventional on GitHub and aids discoverability without breaking structure.
-  MD041: false
+# MD041 — first-line-h1: disable
+# README.md opens with CI status badges before the H1 heading. This pattern is
+# conventional on GitHub and aids discoverability without breaking structure.
+MD041: false

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,41 @@
+# markdownlint config for nginx-zstd-module
+# Used by ci/linter and editor integrations.
+#
+# Philosophy: enable rules that catch real defects; disable rules that fire on
+# legitimate prose patterns. Every disabled rule carries a comment explaining
+# what it would catch versus what it fights.
+
+rules:
+  # MD013 — line-length: disable
+  # The prose blocks are hand-wrapped documentation. Tables and log-output
+  # snippets legitimately run past 80 columns without breaking readability.
+  # A hard line-length gate trades 120 findings for mechanical churn.
+  MD013: false
+
+  # MD004 — ul-style: disable
+  # README.md uses `*` bullets and other files use `-`. The default rule
+  # prefers consistency and would require rewriting one or the other. Since
+  # no style is better, we let each file's established pattern stand.
+  MD004: false
+
+  # MD060 — table-column-style: disable
+  # Pipe alignment in tables is cosmetic. The default expects spaces around pipes
+  # that make maintenance tedious and add no semantic value.
+  MD060: false
+
+  # MD028 — no-blanks-blockquote: disable
+  # README.md deliberately uses blank-line-separated blockquotes as consecutive
+  # callouts. This pattern aids readability in rendered HTML.
+  MD028: false
+
+  # MD034 — no-bare-urls: disable
+  # This rule fires on EMAIL ADDRESSES (github@myguard.nl, zchao1995@gmail.com),
+  # not URLs. That is a false positive class in markdownlint itself — a match
+  # inside `<...@...>` pattern at any nesting level gets flagged as a bare URL
+  # when it is an email reference.
+  MD034: false
+
+  # MD041 — first-line-h1: disable
+  # README.md opens with CI status badges before the H1 heading. This pattern is
+  # conventional on GitHub and aids discoverability without breaking structure.
+  MD041: false

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Windows build](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/windows-build.yml/badge.svg)](https://github.com/myguard-labs/nginx-zstd-module/actions/workflows/windows-build.yml)
 
 📖 **Background reading:**
+
 - [zstd nginx module: what it does, bugs fixed](https://deb.myguard.nl/articles/zstd-nginx-module-bugs-fixed/)
 - [nginx zstd vs brotli vs zlib-ng — a compression comparison](https://deb.myguard.nl/articles/nginx-zstd-vs-brotli-vs-zlib-ng-compression/)
 
@@ -403,6 +404,7 @@ zstd_types text/html text/plain text/css text/csv application/json
            application/rss+xml application/vnd.api+json
            application/xhtml+xml application/wasm text/wgsl;
 ```
+
 **Context:** `http, server, location`
 
 When omitted, the default covers common textual web representations. If set
@@ -500,7 +502,7 @@ in ascending severity:
 2. **`> 8 MB`, `≤ 256 MB`** — a **warning**, not an error. A config that
    loads today keeps loading after an upgrade:
 
-   ```
+   ```text
    nginx: [warn] "zstd_buffers" (merged value) requests 1 x 8388609 bytes
    = ~8388609 bytes of output-chain memory PER RESPONSE; that is on top
    of the per-request compressor (CCtx) working set -- see the
@@ -515,7 +517,7 @@ in ascending severity:
    times nginx's own default — a refusal by default is the safer
    reading of "this is almost certainly a mistake":
 
-   ```
+   ```text
    nginx: [emerg] "zstd_buffers" (merged value) requests 2147483647 x
    1073741824 bytes = ~2305843008139952128 bytes of output-chain memory
    PER RESPONSE, above the 256 MB hard cap -- that is on top of the
@@ -529,7 +531,7 @@ in ascending severity:
    logged as a **warning** (not silenced) so the acknowledgement remains
    visible in the log:
 
-   ```
+   ```text
    nginx: [warn] "zstd_buffers" (merged value) requests 2147483647 x
    1073741824 bytes = ~2305843008139952128 bytes of output-chain memory
    PER RESPONSE, above the 256 MB hard cap; accepted because
@@ -541,7 +543,7 @@ unconditionally at every tier, including with `zstd_buffers_unsafe on;`
 set — there is no representable acknowledgement for a product that
 cannot exist:
 
-```
+```text
 nginx: [emerg] "zstd_buffers" (explicit directive) requests
 9223372036854775807 buffers of 9223372036854775807 bytes each; that
 product overflows the platform's size_t and cannot be a config any
@@ -719,7 +721,7 @@ anywhere in the inheritance chain therefore still runs the same
 estimate at config load, and emits a **warning** — not an error — when
 the profile needs more than **32 MB** of per-request compressor memory:
 
-```
+```text
 nginx: [warn] the configured zstd parameters need ~144328225 bytes of
 per-request compressor memory (zstd_comp_level 3); each worker retains
 up to 4 such contexts, so worker RSS can reach ~577312900 bytes, and

--- a/ci/adoption-findings.md
+++ b/ci/adoption-findings.md
@@ -29,7 +29,7 @@ ok   an unterminated quoted parameter value does not hang the walk and does not 
 24/24 checks passed
 ```
 
-### Mutation pass
+### Mutation pass: Accept-Encoding parser
 
 All 5 applied to `src/ngx_http_zstd_common.h`, observed, reverted — tree
 diffed clean against a pre-mutation backup after each.
@@ -121,7 +121,7 @@ dynamic `load_module`-based build cannot express that distinction cleanly
 (no directive → unknown directive, config fails to parse, which the module-
 unloaded case already covers via a different binary).
 
-### Mutation pass
+### Mutation pass: Module loading behavior
 
 Ran locally against a hand-built static `--add-module` nginx (not part of
 the fast PR lane; the CI wiring above uses the pipeline's own asan.yml
@@ -346,10 +346,12 @@ Verified rather than assumed, because the whole finding was that this gate
 could not fail before the fix. A `strcpy` into an 8-byte stack buffer appended
 to `src/ngx_http_zstd_filter_module.c`:
 
-    set -o pipefail
-    flawfinder --minlevel=4 --error-level=4 \
-      src/ngx_http_zstd_filter_module.c src/ngx_http_zstd_static_module.c
-    -> exit 1
+```sh
+set -o pipefail
+flawfinder --minlevel=4 --error-level=4 \
+  src/ngx_http_zstd_filter_module.c src/ngx_http_zstd_static_module.c
+-> exit 1
+```
 
 Restored immediately; `git status src/` clean afterwards.
 
@@ -436,9 +438,11 @@ The `fun:malloc` / `fun:memcpy` blocks turned out to be **anchored** to full
 nginx call stacks (`ngx_alloc` → `ngx_set_environment` → …) and could not reach
 this module's frames. The real defect was a single block:
 
-    { <insert_a_suppression_name_here>
-      Memcheck:Cond
-      obj:* }
+```text
+{ <insert_a_suppression_name_here>
+  Memcheck:Cond
+  obj:* }
+```
 
 `Memcheck:Cond` + `obj:*` matches an uninitialised-value conditional in any
 object at any depth, muting that whole class — including in

--- a/ci/linter/README.md
+++ b/ci/linter/README.md
@@ -60,7 +60,7 @@ ci/linter/install-linters.sh --check  # report only
 
 Preference order, and why each tool lands where it does:
 
-**apt-get (preferred — distro-managed, no PEP 668 fight)**
+### apt-get (preferred — distro-managed, no PEP 668 fight)
 
 ```sh
 sudo apt-get update
@@ -69,7 +69,7 @@ sudo apt-get install -y --no-install-recommends \
     libperl-critic-perl perl pipx cpanminus
 ```
 
-**pip / pipx (Python tools Debian does not carry at the needed version)**
+### pip / pipx (Python tools Debian does not carry at the needed version)
 
 Use `pipx`, not `pip3`: Debian 12+ marks the system interpreter
 externally-managed, so a bare `pip3 install` fails and
@@ -85,7 +85,7 @@ under you and local stops matching CI. Bump each here and in its CI consumer
 together -- `ruff` in `install-linters.sh`, `semgrep` in
 `security-scanners.yml` too.
 
-**cpan (Perl modules apt does not carry on every target release)**
+### cpan (Perl modules apt does not carry on every target release)
 
 ```sh
 sudo cpanm --notest Test::Nginx::Socket   # also what makes `perl -c` work on ci/t/*.t
@@ -103,7 +103,7 @@ pipx install zizmor                 # GitHub Actions security audit
 is the whole point, and a frozen security scanner stops finding what it was
 added for. A new rule going red is a finding to triage, not drift to suppress.
 
-**upstream binary (no apt/pip/cpan source)**
+### upstream binary (no apt/pip/cpan source)
 
 ```sh
 ver=1.7.7


### PR DESCRIPTION
> Two `[NIT->lint]` backlog rows, batched. The second row (7 yamllint
> line-length warnings in `build-test.yml`) is closed as wontfix rather than
> fixed — see Scope.

## TL;DR

The project had a markdown linter installed but no settings file telling it
which rules this project actually cares about, so it reported hundreds of
complaints that nobody could act on and everybody learned to ignore. This adds
that settings file, switches off six rules that only fire on writing styles the
docs use deliberately, and fixes the fourteen complaints that pointed at real
problems.

Adds `.markdownlint.yaml`, turning off MD013, MD004, MD060, MD028, MD034 and
MD041 with a per-rule rationale, and fixes 14 substantive findings across
`README.md`, `ci/adoption-findings.md` and `ci/linter/README.md`.

**Severity:** `Low` (`documentation tooling — no runtime code touched`)

## Why the rules are off

Each disabled rule fires on an established convention rather than a defect:

| rule | findings | why off |
|---|---|---|
| MD013 line-length | 120 | prose is hand-wrapped; tables and nginx log-output blocks legitimately run long |
| MD004 ul-style | 79 | see below — no single setting is correct for this tree |
| MD060 table-column-style | 60 | cosmetic pipe alignment |
| MD028 no-blanks-blockquote | 11 | README uses blank-separated blockquotes as consecutive callouts |
| MD034 no-bare-urls | 3 | fires on **email addresses**, not URLs (`github@myguard.nl`, `zchao1995@gmail.com`) |
| MD041 first-line-h1 | 1 | README opens with CI badges before the H1, conventional on GitHub |

MD004 is the one worth explaining. The rule enforces a single bullet style
tree-wide, but this repo has two per-file conventions and neither is wrong.
Measured over the tracked `.md` files: `README.md` is asterisk (79 `*` vs 2
`-`), every other file is dash (69 `-` vs 0 `*`). Any single `style:` setting
reddens one group and forces a mechanical rewrite of a file that is already
internally consistent. Per-file consistency is the property worth having and
MD004 cannot express it, so the rule is off rather than the files rewritten.

Every other rule stays enabled.

## Substantive fixes

* `README.md` — 5 fenced blocks of nginx log output given a `text` language
  (MD040); blank line before the "Background reading" list (MD032); blank line
  after a closing fence (MD031).
* `ci/adoption-findings.md` — two indented code blocks converted to fenced
  `sh`/`text` (MD046); two identically-titled "Mutation pass" headings
  disambiguated to name what each covers (MD024).
* `ci/linter/README.md` — four bold pseudo-headings converted to real `###`
  headings under `## 1. Install the linters` (MD036).

No prose was reworded and no content removed; the diff is structural only.

## Testing

`markdownlint` over all 40 tracked `.md` files: **279 findings before, 0 after.**

The load-bearing check is that the config is not a blanket silencer. A probe
file containing an unlabeled fence, a malformed ATX heading and a duplicate
heading still reports all three with the config active:

```text
ctl-probe.md:5 error MD040/fenced-code-language Fenced code blocks should have a language specified
ctl-probe.md:9:1 error MD018/no-missing-space-atx No space after hash on atx style heading
ctl-probe.md:16 error MD024/no-duplicate-heading Multiple headings with the same content
```

`review-lint.sh --branch master`: clean, no coverage gap. Commit `8a34aa9`
fixes a defect in the first commit — the config had shipped as both
`.markdownlint.json` and `.markdownlint.yaml`, and only the JSON was in force
because the YAML nested its rules under a `rules:` key that markdownlint-cli2
does not read. Removing the JSON alone returned 278 findings. The stray JSON is
gone and the rules are lifted to the top level, so the single documented config
is the one actually applied; the 0-finding and probe results above are measured
against that state.

## Scope

The second backlog row — 7 yamllint line-length warnings in
`.github/workflows/build-test.yml` — is deliberately **not** fixed. The repo's
own `.yamllint` documents that inline `run:` shell and `${{ }}` expressions
legitimately run long and sets `line-length` to `level: warning` for exactly
that reason. The 8 over-limit lines are download URLs, a `hashFiles()` cache
key, `awk` one-liners and `--with-cc-opt` flag lists; none can be split without
hurting readability. The row should be closed as wontfix rather than carried.
