### PR TITLE
perf: skip filter/static hook registration when the module is off everywhere

### DIFF
--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -245,6 +245,26 @@ typedef struct {
     u_char                      *dict_buf;
     size_t                       dict_buf_size;
     ngx_array_t                 *dict_registry;  /* dict_entry_t entries */
+
+    /*
+     * Conservative "could this cycle possibly serve a compressed
+     * response" latch for ngx_http_zstd_filter_init() (TODO row: skip
+     * installing the header/body filter hooks when the module is off
+     * everywhere). Set at DIRECTIVE PARSE TIME by
+     * ngx_http_zstd_set_enable_slot() whenever a "zstd on;" (or
+     * anything other than an explicit "zstd off;") is parsed ANYWHERE
+     * in the config -- main, srv, loc, or an NGX_HTTP_LIF_CONF location
+     * conf created for a rewrite-phase "if" block. Latching at parse
+     * time rather than during the location-conf merge walk sidesteps
+     * having to prove every "if" loc conf is reachable from that walk;
+     * a false positive here (installing the hooks when every merged
+     * location actually stays disabled) only costs the two no-op calls
+     * this row is about, while a false negative would silently drop
+     * compression for a live location. Never read at request time and
+     * never influences $zstd_ratio/$zstd_bytes_* (those stay wired
+     * unconditionally in ngx_http_zstd_add_variables()).
+     */
+    ngx_flag_t                   any_enabled;
 } ngx_http_zstd_main_conf_t;
 
 
@@ -534,6 +554,8 @@ static char *ngx_http_zstd_set_bufs_slot(ngx_conf_t *cf, ngx_command_t *cmd,
 static char *ngx_http_zstd_check_bufs_product(ngx_conf_t *cf,
     ngx_bufs_t *bufs, ngx_flag_t unsafe, const char *ctx, ngx_flag_t advise);
 static char *ngx_http_zstd_set_bypass_vary(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf);
+static char *ngx_http_zstd_set_enable_slot(ngx_conf_t *cf,
     ngx_command_t *cmd, void *conf);
 static void ngx_http_zstd_cleanup_dict(void *data);
 static void ngx_http_zstd_cleanup_cctx(void *data);
@@ -833,7 +855,7 @@ static ngx_command_t  ngx_http_zstd_filter_commands[] = {
     { ngx_string("zstd"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
       |NGX_CONF_FLAG,
-      ngx_conf_set_flag_slot,
+      ngx_http_zstd_set_enable_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_zstd_loc_conf_t, enable),
       NULL },
@@ -3904,6 +3926,26 @@ close:
 static ngx_int_t
 ngx_http_zstd_filter_init(ngx_conf_t *cf)
 {
+    ngx_http_zstd_main_conf_t  *zmcf;
+
+    zmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_zstd_filter_module);
+
+    /*
+     * TODO row: do not install request hooks when the module is
+     * disabled in every merged location. any_enabled is latched
+     * conservatively at directive PARSE time (see
+     * ngx_http_zstd_set_enable_slot() and the field's own comment on
+     * ngx_http_zstd_main_conf_t) by every "zstd on;"/non-"off" value
+     * parsed anywhere in this cycle's config, including inside an "if"
+     * block. Skipping registration here only removes the two no-op
+     * calls an all-disabled deployment currently pays on every
+     * response; any location that could compress still gets both
+     * filters wired exactly as before.
+     */
+    if (!zmcf->any_enabled) {
+        return NGX_OK;
+    }
+
     ngx_http_next_header_filter = ngx_http_top_header_filter;
     ngx_http_top_header_filter = ngx_http_zstd_header_filter;
 
@@ -4989,6 +5031,52 @@ ngx_http_zstd_set_bypass_vary(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     if (zlcf->bypass_vary.data == NULL) {
         return (char *) "allocation failed";
     }
+
+    return NGX_CONF_OK;
+}
+
+
+/*
+ * Wraps the stock ngx_conf_set_flag_slot() for the "zstd" directive so
+ * every "zstd on;"/"zstd <var>;" parsed ANYWHERE in the config — main,
+ * srv, loc, or an NGX_HTTP_LIF_CONF conf synthesized for a rewrite-phase
+ * "if" block — latches ngx_http_zstd_main_conf_t.any_enabled. See the
+ * field's own comment for why parse time (not the location-conf merge
+ * walk) is used and why a false positive here is harmless while a false
+ * negative is not: an "if" loc conf is not provably visited by the
+ * normal merge walk, so this is the deliberately conservative option.
+ *
+ * Only the literal "off" clears the possibility; every other value this
+ * directive can legally take at parse time — "on", or a variable/complex
+ * value from ngx_conf_set_flag_slot's own value table — must be assumed
+ * enabling, because ngx_conf_set_flag_slot() rejects anything that is
+ * not exactly "on"/"off" before we ever see it, and "if(cond) { zstd on;
+ * } if(!cond) { zstd off; }" plus nginx's "if" mechanics can still make
+ * the on-branch conf reachable regardless of what a sibling loc parses.
+ */
+static char *
+ngx_http_zstd_set_enable_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_str_t                  *value;
+    char                       *rc;
+    ngx_http_zstd_main_conf_t  *zmcf;
+
+    rc = ngx_conf_set_flag_slot(cf, cmd, conf);
+    if (rc != NGX_CONF_OK) {
+        return rc;
+    }
+
+    value = cf->args->elts;
+
+    /* value[1] is the directive's single argument: "on" or "off" (the
+     * only two ngx_conf_set_flag_slot accepts — anything else already
+     * made it return an error string above). */
+    if (value[1].len == 3 && ngx_strncmp(value[1].data, "off", 3) == 0) {
+        return NGX_CONF_OK;
+    }
+
+    zmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_zstd_filter_module);
+    zmcf->any_enabled = 1;
 
     return NGX_CONF_OK;
 }

--- a/src/ngx_http_zstd_static_module.c
+++ b/src/ngx_http_zstd_static_module.c
@@ -116,6 +116,28 @@ typedef struct {
      * holds the space.
      */
     ngx_uint_t  unused;
+
+    /*
+     * Conservative "could this cycle possibly serve a precompressed
+     * .zst file" latch for ngx_http_zstd_static_init() (TODO row: skip
+     * appending the always-declining content-phase handler when
+     * zstd_static is off in every merged location). Latched at
+     * DIRECTIVE PARSE TIME by ngx_http_zstd_static_set_enable_slot()
+     * whenever "zstd_static on;" or "zstd_static always;" is parsed
+     * anywhere in the config — main, srv, or loc. Unlike the filter
+     * module's "zstd" directive, "zstd_static"'s command flags (above)
+     * do not include NGX_HTTP_LIF_CONF, so nginx's config parser itself
+     * refuses it inside a rewrite-phase "if" block; there is no "if"
+     * loc conf case to reason about here. Latching at parse time rather
+     * than the location-conf merge walk is still the conservative
+     * choice for the same reason as the filter module: a false positive
+     * (installing the handler when every merged location stays off)
+     * only costs the handler's own early return, while a false negative
+     * would silently stop precompressed files being served. Independent
+     * of, and never influencing, the filter module's own any_enabled
+     * bit — the two modules latch separately.
+     */
+    ngx_flag_t  any_enabled;
 } ngx_http_zstd_static_main_conf_t;
 
 
@@ -127,11 +149,15 @@ static ngx_conf_enum_t  ngx_http_zstd_static[] = {
 };
 
 
+static char * ngx_http_zstd_static_set_enable_slot(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf);
+
+
 static ngx_command_t  ngx_http_zstd_static_commands[] = {
 
     { ngx_string("zstd_static"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_enum_slot,
+      ngx_http_zstd_static_set_enable_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_zstd_static_conf_t, enable),
       &ngx_http_zstd_static },
@@ -1006,11 +1032,65 @@ ngx_http_zstd_static_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 }
 
 
+/*
+ * Wraps the stock ngx_conf_set_enum_slot() for "zstd_static" so every
+ * "zstd_static on;"/"zstd_static always;" parsed anywhere in the config
+ * (main, srv, or loc — never inside an "if": see the any_enabled field's
+ * comment) latches ngx_http_zstd_static_main_conf_t.any_enabled. Only
+ * the literal "off" leaves it clear; ngx_conf_set_enum_slot() itself
+ * already rejects any value that is not one of the three enum entries
+ * (off/on/always), so by the time this runs the argument is always one
+ * of exactly those three.
+ */
+static char *
+ngx_http_zstd_static_set_enable_slot(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf)
+{
+    ngx_str_t                         *value;
+    char                              *rc;
+    ngx_http_zstd_static_main_conf_t  *zsmcf;
+
+    rc = ngx_conf_set_enum_slot(cf, cmd, conf);
+    if (rc != NGX_CONF_OK) {
+        return rc;
+    }
+
+    value = cf->args->elts;
+
+    if (value[1].len == 3 && ngx_strncmp(value[1].data, "off", 3) == 0) {
+        return NGX_CONF_OK;
+    }
+
+    zsmcf = ngx_http_conf_get_module_main_conf(cf,
+                                                ngx_http_zstd_static_module);
+    zsmcf->any_enabled = 1;
+
+    return NGX_CONF_OK;
+}
+
+
 static ngx_int_t
 ngx_http_zstd_static_init(ngx_conf_t *cf)
 {
     ngx_http_handler_pt               *h;
     ngx_http_core_main_conf_t         *cmcf;
+    ngx_http_zstd_static_main_conf_t  *zsmcf;
+
+    zsmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_zstd_static_module);
+
+    /*
+     * TODO row: do not append the always-declining content-phase
+     * handler when zstd_static is off in every merged location.
+     * any_enabled is latched conservatively at directive parse time
+     * (ngx_http_zstd_static_set_enable_slot(), see its own and the
+     * field's comment). Skipping registration here removes one
+     * always-false content-phase check per request in an all-disabled
+     * deployment; any location that could serve a .zst file still gets
+     * the handler installed exactly as before.
+     */
+    if (!zsmcf->any_enabled) {
+        return NGX_OK;
+    }
 
     cmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module);
 


### PR DESCRIPTION
## TL;DR

Both the dynamic filter and the static module install their request-time hooks unconditionally at startup, even when every location in the config has the directive off. That means an all-disabled deployment still pays a header-filter call and a body-filter call on every response, plus an always-declining content-phase handler check on every request.

Latch a conservative `any_enabled` bit in each module's cycle-owned main conf (`ngx_http_zstd_main_conf_t`, `ngx_http_zstd_static_main_conf_t`), set at directive PARSE time by new wrapper setters (`ngx_http_zstd_set_enable_slot`, `ngx_http_zstd_static_set_enable_slot`) around the stock `ngx_conf_set_flag_slot`/`ngx_conf_set_enum_slot`. `ngx_http_zstd_filter_init()`/`ngx_http_zstd_static_init()` skip installing their hook only when the bit stays clear.

**Severity:** `Low` (`performance — avoidable per-request hook overhead when the module is unused`)

## Why parse time, not the merge walk

The bit is set whenever `zstd`/`zstd_static` is parsed as anything other than an explicit `off`, anywhere in the config — main, srv, loc, and (for `zstd`, which carries `NGX_HTTP_LIF_CONF`) a location conf synthesized for a rewrite-phase `if` block. `zstd_static`'s command flags don't include `NGX_HTTP_LIF_CONF`, so nginx itself refuses it inside `if`.

An `if`-block location conf is not provably visited by the ordinary location-conf merge walk, so reasoning about which merged locations end up enabled and latching there risked missing that case. Latching at parse time sidesteps the question entirely: a false positive (hooks installed when every merged location stays off) only costs the two no-op calls this PR removes in the all-disabled case; a false negative would silently drop compression for a live location. `$zstd_ratio`/`$zstd_bytes_*` variable registration is untouched — it stays wired unconditionally.

## Testing

Local `Test::Nginx::Socket` suite, before and after, nginx 1.31.4:

| Suite | Before | After |
|---|---|---|
| `ci/t/00-filter.t` | 1206 pass | 1206 pass |
| `ci/t/01-static.t` | 579 pass | 579 pass |
| `ci/t/02-conf-warn.t` | 67 pass | 67 pass |
| `ci/t/03-dcz.t` | 115 pass | 115 pass |

Manual matrix (temporary probe log lines at each hook's entry, counted per config, then reverted): no directive, explicit `off`, inherited `on` from a parent block, nested location, regex location, inside an `if` block, `zstd_static on`, `zstd_static always`, both modules enabled together, reload from disabled to enabled. Every case installed hooks exactly when expected and actual compression/serving worked where it should (confirmed via `Content-Encoding: zstd` and correct `Content-Length` on live requests, not just hook-call counts).

**Negative control:** mutated the filter's setter to skip latching when `cf->cmd_type == NGX_HTTP_LIF_CONF` (i.e., wrongly treat the `if`-block case as not-enabling). Rebuilt and re-ran the `if`-block config: the header filter was never invoked (0 calls, verified via probe log) and the response served uncompressed (`Content-Length: 60`, no `Content-Encoding`, no `Vary`) despite `zstd on;` inside the `if`. Reverted the mutation and confirmed the same config serves `Content-Encoding: zstd` again.

`review-lint.sh --diff HEAD`: no coverage-gap block (every lens in the roster ran); findings are pre-existing (complexity on untouched functions, a codespell hit at an unrelated line, gixy notes on test-fixture nginx.conf, generic ast-grep palloc candidates elsewhere in the file).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary processing when compression is disabled throughout the configuration.
  * Avoided registering inactive request-processing hooks for fully disabled deployments.
* **Bug Fixes**
  * Ensured compression processing is correctly enabled when configured in any supported context, including conditional configuration blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->