### PR TITLE
test: raise config_bench location-workload scale points to clear the 50ms floor

### DIFF
--- a/ci/tools/config_bench.py
+++ b/ci/tools/config_bench.py
@@ -135,8 +135,15 @@ DEFAULT_ROUNDS = 3
 # TODO rows actually name -- "thousands of same-profile locations" for the
 # location workloads and "~600 entries" for the dcz dictionary list.
 WORKLOAD_SCALES: dict[str, list[int]] = {
-    "locations-same-profile": [10, 500, 2000, 4000],
-    "locations-multi-profile": [10, 500, 2000, 4000],
+    # 16000 (not 4000) so the largest point clears SCALE_MIN_HI_SECONDS with
+    # margin on fast hardware: 4000 locations measured 27-33ms on a
+    # contemporary dev box in 2026-08, below the 50ms floor, aborting the
+    # self-check before either workload could report a curve. 16000 measured
+    # 91.7ms (same-profile) / 101.2ms (multi-profile) on that same box --
+    # roughly 2x the floor -- while staying inside the range the module
+    # docstring's baseline table already exercised (32000 locations, 246.5ms).
+    "locations-same-profile": [10, 500, 4000, 16000],
+    "locations-multi-profile": [10, 500, 4000, 16000],
     "dcz-dicts": [10, 150, 300, 600],
 }
 


### PR DESCRIPTION
## TL;DR

`config_bench.py`'s self-check floor (`SCALE_MIN_HI_SECONDS = 0.05`) rejects
any run whose largest scale point loads in under 50ms, since a timing below
that is dominated by process-startup jitter rather than config-parse cost. On
current hardware the location workloads' largest scale point (4000) loads in
27-33ms, so both `locations-same-profile` and `locations-multi-profile`
aborted before reporting a curve.

Raises `WORKLOAD_SCALES["locations-same-profile"]` and
`["locations-multi-profile"]` from `[10, 500, 2000, 4000]` to
`[10, 500, 4000, 16000]`.

**Severity:** `Low` (`test infra — benchmark harness unusable on fast hardware`)

## Why this option

The row gave two choices: raise the scale points, or make the floor adaptive
(calibrate against an empty-config load). Raising scale points is simpler,
keeps the guard's guarantee (a fixed, auditable noise floor) unchanged, and
stays inside the range the module's own baseline table already exercises
(up to 32000 locations, 246.5ms) — no new workload shape or code path is
introduced. `dcz-dicts`' largest point (600) already measures 6.7ms+ per the
recorded baseline and was untouched.

## Testing

Both workloads run to completion and report a curve (3 rounds each):

```
locations-same-profile
arm      scale   nginx -t   peak RSS
nginx       10     4.6ms     7.7MB
nginx      500     7.3ms    10.2MB
nginx     4000    24.5ms    37.8MB
nginx    16000    95.0ms   128.2MB

locations-multi-profile
arm      scale   nginx -t   peak RSS
nginx       10     4.9ms     7.1MB
nginx      500     6.8ms    10.3MB
nginx     4000    26.7ms    38.1MB
nginx    16000    99.5ms   129.1MB
```

Both largest points (95.0ms / 99.5ms) clear the 50ms floor with ~2x margin.

Guard still refuses noise-dominated input — forced tiny scale points via
`--scales 10,50`:

```
harness self-check FAILED: the largest scale point (50) loaded in 4.8ms,
below the 50ms floor. At that duration the measurement is dominated by
process startup jitter, so a ratio against the small config would be noise,
not a scale curve. Raise the scale points rather than lowering this floor.
```

`--self-test` (the pure-function suite, unaffected by real scale values)
still passes: rejects flat/inverted/sub-floor/boundary/rejected-config/
missing-sample input, accepts a genuine curve.

`ruff format --check` and `ruff check` on the file: clean. Full
`review-lint.sh --diff HEAD` roster (ruff, mypy, bandit, vulture, gitleaks,
trufflehog, codespell, lizard, semgrep, ast-grep): clean.
