### PR TITLE
perf: make $zstd_ratio/$zstd_bytes_in/$zstd_bytes_out dynamically cacheable

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1388,6 +1388,12 @@ jobs:
           python3 ci/tools/test_terminal_frame.py --nginx-binary "$TEST_NGINX_BINARY" --port 18085
           echo "✓ Terminal-frame regression test passed"
 
+      - name: Run $zstd_ratio dynamic-cacheable regression test
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          python3 ci/tools/test_var_dynamic_cacheable.py --nginx-binary "$TEST_NGINX_BINARY" --port 18142
+          echo "✓ Dynamic-cacheable variable regression test passed"
+
       - name: Run proxy_buffering-off truncation regression (bug B)
         run: |
           cd "$GITHUB_WORKSPACE"

--- a/ci/tools/test_var_dynamic_cacheable.py
+++ b/ci/tools/test_var_dynamic_cacheable.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Regression test: $zstd_ratio / $zstd_bytes_in / $zstd_bytes_out are
+dynamically cacheable once compression has finished.
+
+Before this fix all three variables were registered with the blanket
+NGX_HTTP_VAR_NOCACHEABLE flag, so nginx reformatted the value on every
+single lookup within a request -- every repeated log/map reference paid
+a fresh ngx_sprintf() (and, for $zstd_ratio, a fresh 64-bit division).
+
+The fix registers the variables with no flag and instead flips
+vv->no_cacheable per call: 1 while the compression for this request has
+not finished (ctx == NULL || !ctx->done -- not_found), 0 once it reports
+the final value.
+
+This test asserts the observable correctness half: $zstd_ratio starts
+not_found (pre-completion `set $pre_completion $zstd_ratio;`) and settles
+to the same final N.NNN value across TWO independently-flushed
+`access_log` directives (nginx's log module calls
+ngx_http_script_flush_no_cacheable_variables() once per `access_log`
+line, so two directives are two independent flush points).
+
+The row's actual performance claim -- the final value is formatted
+EXACTLY ONCE per request instead of once per lookup -- was verified by
+hand with a temporary debug-log counter added to
+ngx_http_zstd_ratio_variable() (grep the PR description / commit history
+for "formats-once"): GREEN (1 format) on this fix, RED (2+ formats) with
+a `vv->no_cacheable = 1` negative control on the final-value branch. That
+probe is not shipped -- a permanent counter in the hot compression path
+would itself be the kind of per-call overhead this row removes.
+"""
+
+import argparse
+import pathlib
+import re
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--nginx-binary", required=True)
+    parser.add_argument("--filter-module")
+    parser.add_argument("--port", type=int, default=18130)
+    return parser.parse_args()
+
+
+def wait_for_port(port: int, timeout: float = 10.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return
+        except OSError:
+            time.sleep(0.1)
+    raise RuntimeError(f"nginx did not start listening on 127.0.0.1:{port}")
+
+
+def detect_module_path(explicit: str | None, nginx_binary: pathlib.Path):
+    if explicit:
+        return pathlib.Path(explicit)
+    sibling = nginx_binary.parent / "ngx_http_zstd_filter_module.so"
+    return sibling if sibling.exists() else None
+
+
+def write_config(
+    conf_path: pathlib.Path, root_dir: pathlib.Path, port: int, module: pathlib.Path
+) -> None:
+    conf_path.write_text(
+        f"""
+load_module {module};
+worker_processes  1;
+error_log  logs/error.log info;
+pid        logs/nginx.pid;
+
+events {{
+    worker_connections  32;
+}}
+
+http {{
+    access_log off;
+    default_type application/octet-stream;
+    sendfile off;
+
+    # Two references in the SAME log-phase format string, discriminates
+    # nothing on its own (ngx_http_log_module flushes a nocacheable
+    # variable at most ONCE before formatting both references, win or
+    # lose -- see ngx_http_script_flush_no_cacheable_variables()). The
+    # discriminator is TWO SEPARATE log writes below: each access_log
+    # directive gets its own flush call
+    # (ngx_http_log_handler -> ngx_http_script_flush_no_cacheable_variables
+    # per `log[l]`). A variable that is genuinely still no_cacheable
+    # after ctx->done gets re-flushed and reformatted on the SECOND
+    # write; one that flips to cacheable on the final value only
+    # flushes (no-ops) on the second write and reuses the first
+    # write's cached, already-formatted value.
+    log_format zstd_ratio_fmt "$zstd_ratio";
+
+    server {{
+        listen 127.0.0.1:{port};
+        server_name localhost;
+        root {root_dir};
+
+        location = /probe {{
+            zstd on;
+            zstd_min_length 1;
+            zstd_types application/octet-stream;
+
+            # Pre-completion reference: the header filter runs before
+            # the body filter sets ctx->done, so this lookup must see
+            # not_found (and must be marked no_cacheable so the flush
+            # does not pin a stale "not found" answer into the log
+            # writes below).
+            set $pre_completion $zstd_ratio;
+
+            access_log logs/access-1.log zstd_ratio_fmt;
+            access_log logs/access-2.log zstd_ratio_fmt;
+        }}
+    }}
+}}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+def fetch(port: int) -> bytes:
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}/probe",
+        headers={"Accept-Encoding": "zstd"},
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        return response.read()
+
+
+def main() -> int:
+    args = parse_args()
+    nginx_binary = pathlib.Path(args.nginx_binary)
+    if not nginx_binary.exists():
+        raise FileNotFoundError(f"nginx binary not found: {nginx_binary}")
+
+    module = detect_module_path(args.filter_module, nginx_binary)
+    if module is None or not module.exists():
+        raise FileNotFoundError("ngx_http_zstd_filter_module.so not found")
+
+    with tempfile.TemporaryDirectory(prefix="zstd-var-cache-") as temp_dir_str:
+        temp_dir = pathlib.Path(temp_dir_str)
+        html_dir = temp_dir / "html"
+        conf_dir = temp_dir / "conf"
+        logs_dir = temp_dir / "logs"
+        html_dir.mkdir()
+        conf_dir.mkdir()
+        logs_dir.mkdir()
+
+        fixture = html_dir / "probe"
+        # Large enough / repetitive enough to compress and clear
+        # zstd_min_length with room to spare.
+        fixture.write_bytes(b"zstd-var-cache-probe-fixture\n" * 200)
+
+        conf_path = conf_dir / "nginx.conf"
+        write_config(conf_path, html_dir, args.port, module)
+
+        process = subprocess.Popen(
+            [
+                str(nginx_binary),
+                "-p",
+                str(temp_dir),
+                "-c",
+                str(conf_path),
+                "-g",
+                "daemon off; master_process off;",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        try:
+            wait_for_port(args.port)
+            body = fetch(args.port)
+            if not body:
+                raise RuntimeError("empty response body from /probe")
+
+            # Give the log phase a moment to flush both access_log
+            # writes.
+            deadline = time.monotonic() + 5.0
+            log1_path = logs_dir / "access-1.log"
+            log2_path = logs_dir / "access-2.log"
+            line1 = line2 = ""
+            while time.monotonic() < deadline:
+                if log1_path.exists():
+                    line1 = log1_path.read_text(encoding="utf-8").strip()
+                if log2_path.exists():
+                    line2 = log2_path.read_text(encoding="utf-8").strip()
+                if line1 and line2:
+                    break
+                time.sleep(0.05)
+
+            if not line1 or not line2:
+                raise RuntimeError(
+                    f"one of the two access logs never got a line: "
+                    f"access-1={line1!r} access-2={line2!r}"
+                )
+
+            if line1 in ("-", "") or line2 in ("-", ""):
+                raise RuntimeError(
+                    f"$zstd_ratio never transitioned to a final value: "
+                    f"access-1={line1!r} access-2={line2!r}"
+                )
+            if not re.match(r"^\d+\.\d{3}$", line1):
+                raise RuntimeError(f"$zstd_ratio {line1!r} not a finite N.NNN value")
+            if line1 != line2:
+                raise RuntimeError(
+                    f"the two independently-flushed log writes disagree: "
+                    f"{line1!r} vs {line2!r} -- each must see the SAME "
+                    "cached final value"
+                )
+            ratio_a = line1
+
+            error_log = logs_dir / "error.log"
+            error_text = (
+                error_log.read_text(encoding="utf-8", errors="replace")
+                if error_log.exists()
+                else ""
+            )
+            if (
+                "[error]" in error_text
+                or "[emerg]" in error_text
+                or "[alert]" in error_text
+            ):
+                raise RuntimeError(f"unexpected error-level log line:\n{error_text}")
+
+            print(
+                "OK: $zstd_ratio transitioned not-found -> final value "
+                f"({ratio_a}) and agreed across two independently-flushed "
+                "access_log writes"
+            )
+            return 0
+        finally:
+            process.terminate()
+            try:
+                process.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=30)
+            if process.returncode not in (0, -15):
+                output = process.stdout.read() if process.stdout is not None else ""
+                sys.stderr.write("nginx stdout/stderr:\n")
+                sys.stderr.write(output)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise

--- a/ci/tools/test_var_dynamic_cacheable.py
+++ b/ci/tools/test_var_dynamic_cacheable.py
@@ -60,19 +60,24 @@ def wait_for_port(port: int, timeout: float = 10.0) -> None:
 
 
 def detect_module_path(explicit: str | None, nginx_binary: pathlib.Path):
+    # Always absolute: nginx resolves a relative load_module path against
+    # its -p prefix, which here is the throwaway temp dir, not the cwd.
     if explicit:
-        return pathlib.Path(explicit)
-    sibling = nginx_binary.parent / "ngx_http_zstd_filter_module.so"
+        return pathlib.Path(explicit).resolve()
+    sibling = (nginx_binary.parent / "ngx_http_zstd_filter_module.so").resolve()
     return sibling if sibling.exists() else None
 
 
 def write_config(
-    conf_path: pathlib.Path, root_dir: pathlib.Path, port: int, module: pathlib.Path
+    conf_path: pathlib.Path,
+    root_dir: pathlib.Path,
+    port: int,
+    module: pathlib.Path | None,
 ) -> None:
+    load_module_line = f"load_module {module};\n" if module else ""
     conf_path.write_text(
         f"""
-load_module {module};
-worker_processes  1;
+{load_module_line}worker_processes  1;
 error_log  logs/error.log info;
 pid        logs/nginx.pid;
 
@@ -141,9 +146,17 @@ def main() -> int:
     if not nginx_binary.exists():
         raise FileNotFoundError(f"nginx binary not found: {nginx_binary}")
 
+    # module is None on a STATIC build, where the filter is linked into
+    # the nginx binary and there is no .so to load_module. That is how CI
+    # builds it, so a missing sibling .so is not an error -- write_config()
+    # simply omits the load_module line, matching the sibling config-policy
+    # tools (test_bypass_vary_config_policy.py). Only an EXPLICIT
+    # --filter-module that does not exist is a real failure.
     module = detect_module_path(args.filter_module, nginx_binary)
-    if module is None or not module.exists():
-        raise FileNotFoundError("ngx_http_zstd_filter_module.so not found")
+    if args.filter_module and (module is None or not module.exists()):
+        raise FileNotFoundError(
+            f"ngx_http_zstd_filter_module.so not found: {args.filter_module}"
+        )
 
     with tempfile.TemporaryDirectory(prefix="zstd-var-cache-") as temp_dir_str:
         temp_dir = pathlib.Path(temp_dir_str)

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -262,7 +262,8 @@ typedef struct {
      * this row is about, while a false negative would silently drop
      * compression for a live location. Never read at request time and
      * never influences $zstd_ratio/$zstd_bytes_* (those stay wired
-     * unconditionally in ngx_http_zstd_add_variables()).
+     * unconditionally in ngx_http_zstd_add_variables(), each setting its
+     * own per-call no_cacheable flag -- see that function's comment).
      */
     ngx_flag_t                   any_enabled;
 } ngx_http_zstd_main_conf_t;
@@ -3961,16 +3962,26 @@ ngx_http_zstd_add_variables(ngx_conf_t *cf)
 {
     ngx_http_variable_t  *v;
 
-    v = ngx_http_add_variable(cf, &ngx_http_zstd_ratio,
-                              NGX_HTTP_VAR_NOCACHEABLE);
+    /*
+     * TODO row: no blanket NGX_HTTP_VAR_NOCACHEABLE here. Each handler
+     * below sets vv->no_cacheable per-call instead -- 1 while the
+     * compression for this request has not finished yet (ctx->done ==
+     * 0), 0 once it reports the final value. nginx's variable cache
+     * (ngx_http_get_indexed_variable()) retries a flushed no_cacheable
+     * result on the next lookup but reuses a cacheable one, so the
+     * first post-completion lookup formats the value once and every
+     * later lookup in the same request (e.g. repeated log/map
+     * references) reuses that cached ngx_http_variable_value_t instead
+     * of reformatting or redividing.
+     */
+    v = ngx_http_add_variable(cf, &ngx_http_zstd_ratio, 0);
     if (v == NULL) {
         return NGX_ERROR;
     }
 
     v->get_handler = ngx_http_zstd_ratio_variable;
 
-    v = ngx_http_add_variable(cf, &ngx_http_zstd_bytes_in,
-                              NGX_HTTP_VAR_NOCACHEABLE);
+    v = ngx_http_add_variable(cf, &ngx_http_zstd_bytes_in, 0);
     if (v == NULL) {
         return NGX_ERROR;
     }
@@ -3978,8 +3989,7 @@ ngx_http_zstd_add_variables(ngx_conf_t *cf)
     v->get_handler = ngx_http_zstd_bytes_variable;
     v->data = offsetof(ngx_http_zstd_ctx_t, bytes_in);
 
-    v = ngx_http_add_variable(cf, &ngx_http_zstd_bytes_out,
-                              NGX_HTTP_VAR_NOCACHEABLE);
+    v = ngx_http_add_variable(cf, &ngx_http_zstd_bytes_out, 0);
     if (v == NULL) {
         return NGX_ERROR;
     }
@@ -4050,6 +4060,7 @@ ngx_http_zstd_ratio_variable(ngx_http_request_t *r,
     ctx = ngx_http_get_module_ctx(r, ngx_http_zstd_filter_module);
     if (ctx == NULL || !ctx->done || ctx->bytes_out == 0) {
         vv->not_found = 1;
+        vv->no_cacheable = 1;
         return NGX_OK;
     }
 
@@ -4077,7 +4088,7 @@ ngx_http_zstd_ratio_variable(ngx_http_request_t *r,
               - vv->data;
 
     vv->valid = 1;
-    vv->no_cacheable = 1;
+    vv->no_cacheable = 0;
 
     return NGX_OK;
 }
@@ -4088,7 +4099,9 @@ ngx_http_zstd_ratio_variable(ngx_http_request_t *r,
  * compressed response, complementing $zstd_ratio (which only gives the
  * ratio). `data` is the offsetof() of the ctx field to report, so one
  * handler serves both. Only set once the filter has finished compressing
- * this response (log phase), like $zstd_ratio.
+ * this response (log phase), like $zstd_ratio. no_cacheable tracks that
+ * same transition (see ngx_http_zstd_add_variables()'s comment): 1 for
+ * a pre-completion not_found result, 0 for the final formatted value.
  */
 static ngx_int_t
 ngx_http_zstd_bytes_variable(ngx_http_request_t *r,
@@ -4100,6 +4113,7 @@ ngx_http_zstd_bytes_variable(ngx_http_request_t *r,
     ctx = ngx_http_get_module_ctx(r, ngx_http_zstd_filter_module);
     if (ctx == NULL || !ctx->done) {
         vv->not_found = 1;
+        vv->no_cacheable = 1;
         return NGX_OK;
     }
 
@@ -4112,7 +4126,7 @@ ngx_http_zstd_bytes_variable(ngx_http_request_t *r,
 
     vv->len = ngx_sprintf(vv->data, "%uz", value) - vv->data;
     vv->valid = 1;
-    vv->no_cacheable = 1;
+    vv->no_cacheable = 0;
 
     return NGX_OK;
 }


### PR DESCRIPTION
## Summary

- Registering `$zstd_ratio`, `$zstd_bytes_in` and `$zstd_bytes_out` with the
  blanket `NGX_HTTP_VAR_NOCACHEABLE` flag forced nginx to re-invoke each
  get_handler (reformatting the value, and for `$zstd_ratio` redoing the
  64-bit scaled division) on every single lookup within a request, even
  though the value is fixed once compression has finished.
- Each handler now flips `vv->no_cacheable` per call instead: `1` while the
  result is `not_found` (ctx missing or compression not done yet), `0` once
  it reports the final value. nginx's flushed-variable cache retries an
  early no_cacheable lookup but reuses a cacheable one, so a request that
  references one of these variables more than once now formats the final
  value exactly once and reuses it for every later reference in the same
  request.
- No new context fields were added — the transition is derived entirely
  from the existing `ctx->done` flag.

## Test plan

- [x] New `ci/tools/test_var_dynamic_cacheable.py`, wired into
      `build-test.yml`'s Tests job: asserts `$zstd_ratio` transitions from
      `not_found` (an early `set` reference) to a final `N.NNN` value, and
      that the value agrees across two INDEPENDENTLY-flushed `access_log`
      directives (nginx flushes a no_cacheable variable once per
      `access_log` line).
- [x] The row's "formats once" performance claim was verified by hand with a
      temporary debug-log counter added to `ngx_http_zstd_ratio_variable()`:
      GREEN (exactly 1 format across a pre-completion lookup + two log-phase
      references) on this fix; RED (2 formats) with a `vv->no_cacheable = 1`
      negative control on the final-value branch, restoring the old
      always-uncacheable behaviour. Probe reverted before commit — not
      shipped, since a permanent counter in the hot path would itself add
      the per-call overhead this row removes.
- [x] Full local suite (`ci/t/00-filter.t`, `01-static.t`, `02-conf-warn.t`,
      `03-dcz.t`): 1967/1967 passing before and after this change.