### PR TITLE
warn: couple direct header/cookie zstd_bypass predicates to their cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -894,6 +894,16 @@ server {
 > `Cache-Control: private` / `no-store`. Bypass predicates that depend
 > only on `$request_uri`/`$uri` (already part of the cache key) do not
 > need this.
+>
+> The module warns at config load when a `zstd_bypass` predicate reads a
+> `$http_*` or `$cookie_*` variable **directly** with no
+> `zstd_bypass_vary` configured in the same location — the same
+> misconfiguration named above, caught before it reaches a shared cache.
+> The check only recognizes the literal `$http_*`/`$cookie_*` spellings;
+> an indirect predicate (e.g. a `map` result variable derived from a
+> header or cookie) is not resolved and stays silent — pairing
+> `zstd_bypass_vary` with a map-derived predicate remains an explicit
+> operator responsibility.
 
 ---
 

--- a/ci/t/02-conf-warn.t
+++ b/ci/t/02-conf-warn.t
@@ -87,6 +87,114 @@ Accept-Encoding: zstd
 
 
 
+=== TEST 2b: zstd_bypass on a direct $http_* predicate without vary warns
+# Inverse of TEST 1: a zstd_bypass predicate that reads a request header
+# DIRECTLY, with no zstd_bypass_vary alongside it, lets a shared cache
+# mix an identity response with a compressed one under the same key.
+--- config
+    location /warn2b {
+        zstd on;
+        zstd_bypass $http_x_no_compression;
+        default_type text/plain;
+        return 200 "hello world padding padding padding\n";
+    }
+--- request
+GET /warn2b
+--- more_headers
+Accept-Encoding: zstd
+--- error_log
+without a "zstd_bypass_vary"
+--- no_error_log
+[error]
+
+
+
+=== TEST 2c: zstd_bypass on a direct $cookie_* predicate without vary warns
+# Same hazard, cookie-driven bypass instead of a request header.
+--- config
+    location /warn2c {
+        zstd on;
+        zstd_bypass $cookie_no_compression;
+        default_type text/plain;
+        return 200 "hello world padding padding padding\n";
+    }
+--- request
+GET /warn2c
+--- more_headers
+Accept-Encoding: zstd
+--- error_log
+without a "zstd_bypass_vary"
+--- no_error_log
+[error]
+
+
+
+=== TEST 2d: direct predicate WITH zstd_bypass_vary stays silent
+# The correctly-paired configuration (TEST 2's config) must not trip the
+# new inverse warning either -- both directions of the coupling check
+# must agree on a valid config.
+--- config
+    location /paired2d {
+        zstd on;
+        zstd_bypass $http_x_no_compression;
+        zstd_bypass_vary X-No-Compression;
+        default_type text/plain;
+        return 200 "hello world padding padding padding\n";
+    }
+--- request
+GET /paired2d
+--- more_headers
+Accept-Encoding: zstd
+--- no_error_log eval
+[qr/without a "zstd_bypass_vary"/, qr/\[error\]/]
+
+
+
+=== TEST 2e: a map-based zstd_bypass predicate without vary stays silent
+# Indirect variables (map results, etc.) are a documented operator
+# responsibility, not something this module can resolve; the raw
+# predicate text here is "$zstd_off", which contains neither "$http_"
+# nor "$cookie_", so the new check must not fire a false positive.
+--- http_config
+    map $http_x_no_zstd $zstd_off {
+        default 0;
+        "1"     1;
+    }
+--- config
+    location /warn2e {
+        zstd on;
+        zstd_bypass $zstd_off;
+        default_type text/plain;
+        return 200 "hello world padding padding padding\n";
+    }
+--- request
+GET /warn2e
+--- more_headers
+Accept-Encoding: zstd
+--- no_error_log eval
+[qr/without a "zstd_bypass_vary"/, qr/\[error\]/]
+
+
+
+=== TEST 2f: a response-only variable predicate without vary stays silent
+# A predicate that references neither a request header nor a cookie --
+# here a response-side module variable -- must not trip the new check.
+--- config
+    location /warn2f {
+        zstd on;
+        zstd_bypass $zstd_ratio;
+        default_type text/plain;
+        return 200 "hello world padding padding padding\n";
+    }
+--- request
+GET /warn2f
+--- more_headers
+Accept-Encoding: zstd
+--- no_error_log eval
+[qr/without a "zstd_bypass_vary"/, qr/\[error\]/]
+
+
+
 === TEST 3: zstd_static rejects an invalid enum value cleanly
 # Regression for the missing ngx_null_string sentinel in the
 # ngx_http_zstd_static[] ngx_conf_enum_t array. ngx_conf_set_enum_slot()

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -3367,6 +3367,54 @@ ngx_http_zstd_estimate_cctx_memory(ngx_conf_t *cf,
 #endif
 
 
+/*
+ * Detects a DIRECT "$http_*" or "$cookie_*" reference in one zstd_bypass
+ * predicate's source text (ngx_http_complex_value_t.value keeps the raw
+ * argument as written, even for a script with embedded variables -- see
+ * ccv->complex_value->value = *v in ngx_http_compile_complex_value()).
+ *
+ * Deliberately narrow: only the literal "$http_" / "$cookie_" spellings
+ * count. A map or any other indirection (e.g. a "map" result variable) is
+ * an explicit documented operator responsibility and must stay silent --
+ * a false warning on a map is worse than missing the direct case.
+ */
+static ngx_uint_t
+ngx_http_zstd_predicate_is_direct_header_or_cookie(ngx_str_t *v)
+{
+    u_char  *p, *last;
+
+    p = v->data;
+    last = v->data + v->len;
+
+    while (p < last) {
+        p = ngx_strlchr(p, last, '$');
+        if (p == NULL) {
+            return 0;
+        }
+
+        p++;
+
+        if (p < last && *p == '{') {
+            p++;
+        }
+
+        if ((size_t) (last - p) >= sizeof("http_") - 1
+            && ngx_strncmp(p, "http_", sizeof("http_") - 1) == 0)
+        {
+            return 1;
+        }
+
+        if ((size_t) (last - p) >= sizeof("cookie_") - 1
+            && ngx_strncmp(p, "cookie_", sizeof("cookie_") - 1) == 0)
+        {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+
 static char *
 ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 {
@@ -3438,6 +3486,41 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
                            "field no response varies on. Add a "
                            "\"zstd_bypass\" directive or remove "
                            "\"zstd_bypass_vary\"", &conf->bypass_vary);
+    }
+
+    /*
+     * Inverse of the check above: a zstd_bypass predicate that reads a
+     * request header or cookie DIRECTLY (e.g.
+     * "zstd_bypass $http_x_no_compression;") without a matching
+     * zstd_bypass_vary lets a shared cache mix an identity response
+     * with a compressed one under the same cache key -- a
+     * cache-poisoning / wrong-variant-served hazard. Only the literal
+     * "$http_*" / "$cookie_*" spellings are checked; a map or other
+     * indirection stays an explicit documented operator responsibility
+     * (see ngx_http_zstd_predicate_is_direct_header_or_cookie()).
+     */
+    if (conf->bypass != NULL && conf->bypass_vary.len == 0) {
+        ngx_http_complex_value_t  *cv;
+        ngx_uint_t                 i;
+
+        cv = conf->bypass->elts;
+
+        for (i = 0; i < conf->bypass->nelts; i++) {
+            if (ngx_http_zstd_predicate_is_direct_header_or_cookie(
+                    &cv[i].value))
+            {
+                ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+                                   "\"zstd_bypass\" predicate \"%V\" reads "
+                                   "a request header or cookie directly "
+                                   "without a \"zstd_bypass_vary\"; a "
+                                   "shared cache may mix identity and "
+                                   "compressed responses under the same "
+                                   "key. Add a \"zstd_bypass_vary\" "
+                                   "directive naming the header this "
+                                   "varies on", &cv[i].value);
+                break;
+            }
+        }
     }
 
     if (ngx_http_merge_types(cf, &conf->types_keys, &conf->types,


### PR DESCRIPTION
## TL;DR

The module already warns when `zstd_bypass_vary` is set without a `zstd_bypass` predicate (a needless `Vary` field). It was silent in the dangerous inverse: `zstd_bypass $http_x_no_compression;` with no `zstd_bypass_vary` lets a shared cache mix an identity response with a compressed one under the same cache key.

Adds a config-load warning when a `zstd_bypass` predicate reads a `$http_*` or `$cookie_*` variable directly with no `zstd_bypass_vary` configured in the same merged location.

**Severity:** `Low` (`config-load diagnostic — no runtime behaviour change`)

## Scope

Deliberately narrow: only the literal `$http_*`/`$cookie_*` spellings in a predicate's raw source text are checked (`ngx_http_complex_value_t.value`, which nginx retains verbatim even for a compiled script). A `map`-derived or other indirect predicate variable is not resolved and stays silent — that pairing remains a documented operator responsibility, since a false positive on a map is worse than missing the direct case. Warn-only; no request is rejected and no runtime behaviour changes.

## Testing

`ci/t/02-conf-warn.t` (67 -> 82 tests) covers all six required arms:

- direct `$http_*` predicate, no vary -> warns (TEST 2b)
- direct `$cookie_*` predicate, no vary -> warns (TEST 2c)
- direct predicate with `zstd_bypass_vary` -> silent (TEST 2d)
- map-based predicate, no vary -> silent, no false positive (TEST 2e)
- response-only variable predicate, no vary -> silent (TEST 2f)
- existing inverse case (vary without bypass) still warns (TEST 1, unchanged)

Full suite before: 1967 (00:1206 01:579 02:67 03:115). After: 1982 (00:1206 01:579 02:82 03:115). All green both times.

Negative control: disabled the new check (`if (0 && ...)`), rebuilt (fresh `.so`, new mtime), and confirmed TEST 2b and TEST 2c go red on exactly the new assertion (`not ok 28`/`not ok 48`, "pattern ... should match a line in error.log"). Reverted and reran clean (82/82).

`README.md` documents the new warning next to the existing cache-safety note for header/cookie-driven bypass.
