### PR TITLE
Add early subrequest guard to header filter

### DIFF
--- a/ci/t/00-filter.t
+++ b/ci/t/00-filter.t
@@ -2417,14 +2417,13 @@ Vary: X-No-Compression, Accept-Encoding
 
 
 === TEST 91: an SSI subrequest is not separately zstd-compressed
-# ngx_http_zstd_accepts() declines when r != r->main, so only the main request
-# negotiates a content coding. A subrequest inherits the parent's
-# headers_in (including "Accept-Encoding: zstd"), so without that guard the
-# include is compressed on its own and its zstd frame is spliced into the
-# parent's body as opaque bytes.
+# The header filter checks r != r->main early and declines for subrequests,
+# so only the main request negotiates a content coding. Without that guard
+# the subrequest would be compressed on its own and its zstd frame would be
+# spliced into the parent's body as opaque bytes.
 #
-# The assertion is the error-log line the filter emits when it commits to
-# compressing, counted over the whole request: the parent here is text/html
+# The assertion is the error-log line the filter emits when declining the
+# subrequest, counted over the whole request: the parent here is text/html
 # with zstd off, so a correctly guarded run reaches "zstd: compressing
 # response" zero times. Asserting only on the assembled body would not work —
 # with the guard removed the page still reads correctly, because the parent's
@@ -2454,7 +2453,7 @@ Accept-Encoding: zstd
 --- response_body
 BEGININCLUDED-PAYLOAD-INCLUDED-PAYLOAD-INCLUDED-PAYLOADEND
 --- error_log
-zstd: skip, client did not accept zstd encoding
+zstd: skip, subrequest
 --- no_error_log
 zstd: compressing response
 [error]

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -1047,6 +1047,19 @@ ngx_http_zstd_header_filter(ngx_http_request_t *r)
         return ngx_http_next_header_filter(r);
     }
 
+    /* subrequest: both negotiators below reject r != r->main
+     * unconditionally (ngx_http_zstd_accepts() in common.h,
+     * ngx_http_zstd_dcz_negotiate()), so a subrequest can never be
+     * encoded here. Returning now skips the eligibility gates, the
+     * zstd-owned Vary pushes and zstd_bypass predicate evaluation,
+     * all of which are dead work on a response this filter will
+     * decline regardless. */
+    if (r != r->main) {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "zstd: skip, subrequest");
+        return ngx_http_next_header_filter(r);
+    }
+
     /* status not eligible: < 200, bodyless 204/205, 206 Partial Content,
      * or any > 299 except 403/404 (which carry compressible error bodies).
      *


### PR DESCRIPTION
## Summary

Move the subrequest check (r != r->main) to the header filter's early-return block, right after the enable check. The filter's negotiators already reject subrequests unconditionally, so this optimization skips dead work (eligibility gates, Vary header additions, predicate evaluation) on responses this filter will decline regardless.

## Test plan

- Verified existing TEST 58 (auth_request subrequest) and TEST 91 (SSI subrequest) pass
- Updated TEST 91 to expect the new "zstd: skip, subrequest" debug log message
- Full test suite (1206 tests) passes
- Negative control: inverted the guard (if (r == r->main)) and confirmed 309 tests fail with missing Content-Encoding headers
- Verified inline: nginx core's header_filter_module returns early for subrequests (src/http/ngx_http_header_filter_module.c:182-184), so subrequest Vary headers never reach the client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of subrequests by skipping unnecessary compression processing.
  * Preserved normal response header processing for subrequests.
  * Updated regression coverage to verify the correct subrequest behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->