### PR TITLE
Raise dcz-dicts scale points to clear 50ms harness floor

### DIFF
--- a/ci/tools/config_bench.py
+++ b/ci/tools/config_bench.py
@@ -144,7 +144,11 @@ WORKLOAD_SCALES: dict[str, list[int]] = {
     # docstring's baseline table already exercised (32000 locations, 246.5ms).
     "locations-same-profile": [10, 500, 4000, 16000],
     "locations-multi-profile": [10, 500, 4000, 16000],
-    "dcz-dicts": [10, 150, 300, 600],
+    # 16000 (not 600) so the largest point clears SCALE_MIN_HI_SECONDS with
+    # margin: 600 entries measured 5.8ms, below the 50ms floor. 5000 measured
+    # 30.9ms, 10000 measured 98.7ms, and 16000 measured 182.3ms on a
+    # contemporary dev box in 2026-08 -- the largest point ~3.6x the floor.
+    "dcz-dicts": [10, 600, 5000, 16000],
 }
 
 # The distinct (level, long_mode, window_log) tuples cycled through by the


### PR DESCRIPTION
## Summary

The dcz-dicts workload was capped at 600 entries, loaded in ~5.8ms, and failed the harness self-check before reporting any results. Raised scale points to [10, 600, 5000, 16000] so the largest point (16000) clears the 50ms floor with ~3.6x margin, unblocking measurement of the O(n^2) dcz duplicate-hash TODO row.

## Measurements (median of 2 rounds on dev box, nginx 1.31.4)

### Before (old scales [10, 150, 300, 600]):
Harness self-check FAILED: the largest scale point (600) loaded in 5.9ms, below the 50ms floor. Exit code 2.

### After (new scales [10, 600, 5000, 16000]):
| arm | scale  | nginx -t | peak RSS |
|-----|--------|----------|----------|
| m   | 10     | 2.6ms    | 0.4MB    |
| m   | 600    | 8.1ms    | 9.3MB    |
| m   | 5000   | 34.2ms   | 29.3MB   |
| m   | 16000  | 181.3ms  | 77.9MB   |

Exit code 0.

## Verification

- [x] `python3 ci/tools/config_bench.py --self-test` exits 0
- [x] Real run with new scales passes, prints table, exit code 0
- [x] Negative control with old scales fails with floor message, exit code 2
- [x] Only dcz-dicts changed; locations-* workloads and floor constants untouched
- [x] Lint: ruff clean, no formatting issues