### PR TITLE
perf: inline the dcz 40-byte prefix into the first compressor buffer

### DIFF
--- a/ci/tools/test_dcz_prefix_alloc.py
+++ b/ci/tools/test_dcz_prefix_alloc.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Regression test for the dcz 40-byte prefix inlining.
+
+RFC 9842 dcz responses used to queue the fixed 40-byte skippable-frame
+prefix (magic + dictionary SHA-256) on its OWN pool buffer and chain link,
+separate from the compressor's output buffers. ngx_http_zstd_filter_get_buf()
+now reserves 40 bytes at the front of the FIRST compressor output buffer
+and writes the prefix there instead, so a dcz response allocates one fewer
+ngx_buf_t/chain-link pair per response.
+
+This is a pure allocation-count and wire-format regression test:
+
+  * runs a debug build (error_log ... debug) and greps its own log for
+    "zstd get_buf: allocated buffer" (compressor output-buffer pool
+    allocations) and "zstd dcz: 40-byte frame header queued" (the OLD
+    dedicated-buffer code path -- must never fire again);
+  * captures a strace -e trace=writev count for the same request, as a
+    downstream-iovec-reduction proxy;
+  * decodes the dcz body with the negotiated dictionary and byte-compares
+    it against the plain fixture, so a buffer/prefix accounting change can
+    never silently corrupt the wire body while "passing" on allocation
+    counts alone.
+
+Exercises three body sizes (empty-compressed-output edge via a 1-byte
+body, a small body, and a body spanning multiple compressor iterations)
+so the assertion holds across the END-transition retry path the prefix
+sits in front of, not only the single-iteration common case.
+"""
+
+import argparse
+import base64
+import hashlib
+import pathlib
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+DCZ_MAGIC = bytes([0x5E, 0x2A, 0x4D, 0x18, 0x20, 0x00, 0x00, 0x00])
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--nginx-binary", required=True)
+    p.add_argument("--filter-module")
+    p.add_argument("--port", type=int, default=18311)
+    return p.parse_args()
+
+
+def detect_module(explicit, nginx: pathlib.Path):
+    if explicit:
+        return pathlib.Path(explicit)
+    sib = nginx.parent / "ngx_http_zstd_filter_module.so"
+    return sib if sib.exists() else None
+
+
+def wait_for_port(port: int, timeout: float = 10.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise RuntimeError(f"nginx never opened port {port}")
+
+
+def write_config(
+    root: pathlib.Path, port: int, module, dict_path: pathlib.Path, dict_hash_hex: str
+) -> pathlib.Path:
+    (root / "conf").mkdir()
+    (root / "logs").mkdir()
+    load = f"load_module {module};\n" if module else ""
+    conf = root / "conf" / "nginx.conf"
+    conf.write_text(
+        f"""{load}
+worker_processes 1;
+daemon off;
+error_log {root}/logs/error.log debug;
+pid {root}/logs/nginx.pid;
+events {{ }}
+http {{
+    access_log off;
+    zstd on;
+    zstd_min_length 1;
+    zstd_types *;
+    zstd_dcz_assume_secure_transport on;
+    zstd_dcz_dict_file {dict_path} {dict_hash_hex};
+
+    server {{
+        listen 127.0.0.1:{port};
+        root {root}/html;
+    }}
+}}
+""",
+        encoding="utf-8",
+        newline="\n",
+    )
+    return conf
+
+
+def fetch_dcz(port: int, dict_digest_b64: str, path: str) -> bytes:
+    req = (
+        f"GET /{path} HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "Accept-Encoding: dcz, zstd\r\n"
+        f"Available-Dictionary: :{dict_digest_b64}:\r\n"
+        "Sec-Fetch-Site: same-origin\r\n"
+        "Connection: close\r\n\r\n"
+    )
+    with socket.create_connection(("127.0.0.1", port), timeout=5) as s:
+        s.sendall(req.encode())
+        data = b""
+        while True:
+            chunk = s.recv(65536)
+            if not chunk:
+                break
+            data += chunk
+    return data
+
+
+def split_response(data: bytes):
+    head, rest = data.split(b"\r\n\r\n", 1)
+    # dechunk (Transfer-Encoding: chunked -- every response here is)
+    body = b""
+    while rest:
+        size_line, rest = rest.split(b"\r\n", 1)
+        size = int(size_line.split(b";")[0], 16)
+        if size == 0:
+            break
+        body += rest[:size]
+        rest = rest[size + 2 :]
+    return head.decode(errors="replace"), body
+
+
+def decode_dcz(
+    zstd_bin: str, body: bytes, dict_path: pathlib.Path, work: pathlib.Path
+) -> bytes:
+    src = work / "response.dcz"
+    dst = work / "response.out"
+    src.write_bytes(body)
+    subprocess.run(
+        [
+            zstd_bin,
+            "-d",
+            "-q",
+            "-f",
+            "--memory=8388608",
+            "-D",
+            str(dict_path),
+            "-o",
+            str(dst),
+            str(src),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return dst.read_bytes()
+
+
+def main() -> int:
+    args = parse_args()
+    failures = []
+
+    def check(name: str, cond: bool, detail: str = "") -> None:
+        if cond:
+            print(f"ok - {name}")
+        else:
+            print(f"FAIL - {name} {detail}")
+            failures.append(name)
+
+    nginx_path = pathlib.Path(args.nginx_binary)
+    module = detect_module(args.filter_module, nginx_path)
+    zstd_bin = shutil.which("zstd")
+    if zstd_bin is None:
+        print("SKIP: no zstd CLI on PATH", file=sys.stderr)
+        return 0
+
+    with tempfile.TemporaryDirectory(prefix="zstd-dcz-alloc-") as tmp:
+        root = pathlib.Path(tmp)
+        (root / "html").mkdir()
+
+        dict_bytes = b"The quick brown fox jumps over the lazy dog. " * 40
+        dict_path = root / "dict.bin"
+        dict_path.write_bytes(dict_bytes)
+        dict_digest = hashlib.sha256(dict_bytes).digest()
+        dict_hash_hex = hashlib.sha256(dict_bytes).hexdigest()
+        dict_digest_b64 = base64.b64encode(dict_digest).decode()
+
+        conf = write_config(root, args.port, module, dict_path, dict_hash_hex)
+
+        bodies = {
+            "1byte.txt": b"x",
+            "small.txt": b"hello world tiny body for dcz prefix test",
+            "multi.txt": (b"The quick brown fox jumps over the lazy dog. " * 50),
+        }
+        for name, content in bodies.items():
+            (root / "html" / name).write_bytes(content)
+
+        error_log = root / "logs" / "error.log"
+
+        for name, content in bodies.items():
+            error_log.write_text("")  # truncate between cases
+            nginx = subprocess.Popen(
+                [str(nginx_path), "-p", str(root), "-c", str(conf)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            try:
+                wait_for_port(args.port)
+                data = fetch_dcz(args.port, dict_digest_b64, name)
+            finally:
+                nginx.terminate()
+                try:
+                    nginx.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    nginx.kill()
+                    nginx.wait(timeout=5)
+
+            head, body = split_response(data)
+
+            check(
+                f"{name}: negotiated dcz",
+                "Content-Encoding: dcz" in head,
+                f"(head={head!r})",
+            )
+            check(
+                f"{name}: body starts with RFC 9842 magic",
+                body[:8] == DCZ_MAGIC,
+                f"(got {body[:8].hex()})",
+            )
+            check(
+                f"{name}: header embeds the dictionary SHA-256",
+                body[8:40] == dict_digest,
+                "",
+            )
+
+            decoded = decode_dcz(zstd_bin, body, dict_path, root)
+            check(
+                f"{name}: decode round-trip is byte-exact",
+                decoded == content,
+                f"(decoded {len(decoded)}B, expected {len(content)}B)",
+            )
+
+            log_text = error_log.read_text(errors="replace")
+            alloc_count = len(re.findall(r"zstd get_buf: allocated buffer", log_text))
+            old_path_count = len(
+                re.findall(r"zstd dcz: 40-byte frame header queued", log_text)
+            )
+
+            check(
+                f"{name}: old dedicated-prefix-buffer path never fires",
+                old_path_count == 0,
+                f"(matched {old_path_count} times -- prefix inlining "
+                "regressed to the pre-fix separate-buffer path)",
+            )
+            check(
+                f"{name}: exactly one compressor buffer allocated",
+                alloc_count == 1,
+                f"(got {alloc_count} allocations for a body that fits "
+                "one compressor buffer plus the inlined prefix)",
+            )
+
+    print()
+    if failures:
+        print(f"FAILED: {len(failures)} check(s) did not pass:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+
+    print(
+        "OK: dcz prefix rides the first compressor buffer, one pool "
+        "allocation per response, wire body unchanged"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -708,8 +708,6 @@ static void ngx_http_zstd_collect_dcz_headers(ngx_http_request_t *r,
     ngx_table_elt_t **sec_fetch_site_h, ngx_uint_t *sec_fetch_site_count);
 static ngx_http_zstd_dcz_dict_t *ngx_http_zstd_dcz_negotiate(
     ngx_http_request_t *r, ngx_http_zstd_loc_conf_t *zlcf);
-static ngx_int_t ngx_http_zstd_filter_emit_dcz_header(ngx_http_request_t *r,
-    ngx_http_zstd_ctx_t *ctx);
 
 
 /*
@@ -1887,16 +1885,12 @@ ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
         /*
          * dcz responses start with the fixed 40-byte frame header (RFC
-         * 9842 §2.2). Queue it ahead of any compressed output. The
-         * dcz_header_sent guard predates cctx_ready (this block used to
-         * re-run when a data-less buffer cleared buffer_in.src); it stays
-         * as an independent invariant on the wire prefix.
+         * 9842 §2.2). It is no longer queued here as its own buffer/chain
+         * link: ngx_http_zstd_filter_get_buf() reserves and fills the
+         * first 40 bytes of the first compressor output buffer with it
+         * (ctx->dcz_header_sent still guards against duplicating it, and
+         * is now set there instead of here). Nothing to do on this path.
          */
-        if (ctx->dcz_dict != NULL && !ctx->dcz_header_sent) {
-            if (ngx_http_zstd_filter_emit_dcz_header(r, ctx) != NGX_OK) {
-                goto failed;
-            }
-        }
 
         ctx->cctx_ready = 1;
     }
@@ -2180,8 +2174,21 @@ ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
          * ZSTD_e_end runs. If it did produce output, fall through to emit
          * those (valid, non-terminal) bytes — but `last` must stay false this
          * iteration so we do not set last_buf before the end marker exists.
+         *
+         * Keyed on THIS call's delta (buffer_out.pos - pos_out), not
+         * ngx_buf_size(ctx->out_buf): the whole-buffer size also counts the
+         * dcz 40-byte prefix that ngx_http_zstd_filter_get_buf() may have
+         * already written into a freshly allocated buffer before this call
+         * ever ran. Checking the whole-buffer size made a buffer holding
+         * only the prefix look "non-empty" and forced a premature,
+         * non-terminal 40-byte emission instead of forcing the extra
+         * iteration that actually reaches ZSTD_e_end -- doubling the
+         * output buffers this response needed instead of the reduction
+         * this prefix-inlining change is for. The delta is 0 in both the
+         * prefix and non-prefix case whenever this call itself wrote
+         * nothing, so behaviour for a non-dcz response is unchanged.
          */
-        if (ngx_buf_size(ctx->out_buf) == 0) {
+        if (ctx->buffer_out.pos - pos_out == 0) {
             return NGX_AGAIN;
         }
 
@@ -2459,7 +2466,23 @@ ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
                        "zstd get_buf: reused free buffer %p", ctx->out_buf);
 
     } else if (ctx->bufs < zlcf->bufs.num) {
-        size_t  buf_size = zlcf->bufs.size;
+        size_t      buf_size = zlcf->bufs.size;
+        ngx_uint_t  first_buf = ctx->bufs == 0;
+
+        /*
+         * The 40-byte dcz skippable-frame prefix (RFC 9842 §2.2) rides in
+         * the front of THIS buffer instead of its own temp buffer/chain
+         * link: reserve the space here and copy it in below, once, on the
+         * very first output buffer this response ever allocates. A dcz
+         * response's first get_buf() call is always this fresh-allocation
+         * path (ctx->bufs == 0 here always means "never allocated before
+         * for this request" — the free-list reuse branch above cannot fire
+         * before the first allocation exists), so gating on first_buf is
+         * equivalent to, and replaces, the old dcz_header_sent-guarded
+         * call site in the body filter.
+         */
+        ngx_uint_t  want_prefix = first_buf && ctx->dcz_dict != NULL
+                                   && !ctx->dcz_header_sent;
 
         /*
          * Size only the FIRST output buffer from the pledged size, when
@@ -2475,14 +2498,12 @@ ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
          * (chunked/proxied) tail. pledged_size is -1 exactly on that
          * streaming case, so this never fires there.
          */
-        if (ctx->bufs == 0 && ctx->pledged_size >= 0) {
+        if (first_buf && ctx->pledged_size >= 0) {
             size_t  bound = ZSTD_compressBound((size_t) ctx->pledged_size);
 
             /*
              * ZSTD_compressBound() covers only the compressed payload; pad
-             * it for libzstd's own frame/block header overhead (the dcz
-             * 40-byte skippable-frame prefix is queued on its own separate
-             * buffer by emit_dcz_header and never lands here). Never grow
+             * it for libzstd's own frame/block header overhead. Never grow
              * past the configured size, and keep a small floor so
              * tiny/empty bodies still get a buffer the frame overhead fits
              * inside.
@@ -2498,6 +2519,23 @@ ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
             }
         }
 
+        /*
+         * Grow the allocation by the prefix length so reserving it never
+         * steals space ZSTD_compressBound()/the floor above sized for the
+         * compressed payload -- the compressor still gets the full
+         * buf_size to fill; the prefix rides in bytes appended past it.
+         * Never let this push buf_size past zlcf->bufs.size: on the
+         * pledged-size path buf_size is already clamped below it above,
+         * and on the full-size path adding 40 bytes here would otherwise
+         * make the allocation slightly larger than every other buffer in
+         * the pool for no benefit, so clamp back down and only ever
+         * dip into the compressor's own share when the pool buffer is
+         * already at the configured size.
+         */
+        if (want_prefix) {
+            buf_size += NGX_HTTP_ZSTD_DCZ_HEADER_LEN;
+        }
+
         ctx->out_buf = ngx_create_temp_buf(r->pool, buf_size);
         if (ctx->out_buf == NULL) {
             return NGX_ERROR;
@@ -2506,6 +2544,20 @@ ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
         ctx->out_buf->tag = (ngx_buf_tag_t) &ngx_http_zstd_filter_module;
         ctx->out_buf->recycled = 1;
         ctx->bufs++;
+
+        if (want_prefix) {
+            ctx->out_buf->last = ngx_cpymem(ctx->out_buf->last,
+                                             ctx->dcz_dict->frame_header,
+                                             NGX_HTTP_ZSTD_DCZ_HEADER_LEN);
+
+            ctx->bytes_out += NGX_HTTP_ZSTD_DCZ_HEADER_LEN;
+            ctx->dcz_header_sent = 1;
+
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "zstd dcz: 40-byte frame header written into "
+                           "first output buffer (dict \"%V\")",
+                           &ctx->dcz_dict->file);
+        }
 
         ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                        "zstd get_buf: allocated buffer %p (%i in use)",
@@ -2524,7 +2576,15 @@ ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
         return NGX_ERROR;
     }
 
-    ctx->buffer_out.dst = ctx->out_buf->pos;
+    /*
+     * dst/size are keyed off ->last, not ->pos: on a freshly allocated
+     * buffer carrying the dcz prefix, ->last was already advanced past it
+     * above, so the compressor writes immediately after the prefix bytes
+     * instead of overwriting them. On every other buffer (recycled, or a
+     * fresh non-dcz allocation) ->last == ->pos still, so this is exactly
+     * the prior behaviour.
+     */
+    ctx->buffer_out.dst = ctx->out_buf->last;
     ctx->buffer_out.pos = 0;
 
     /* Validate buffer pointers to detect corruption before using in ZSTD */
@@ -2535,53 +2595,14 @@ ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
         return NGX_ERROR;
     }
 
-    ctx->buffer_out.size = ctx->out_buf->end - ctx->out_buf->start;
-
-    return NGX_OK;
-}
-
-
-/*
- * Queue the 40-byte dcz frame header (RFC 9842 §2.2) as the first link
- * on the out chain: the zstd skippable-frame magic 0x184D2A5E with a
- * declared 32-byte content, then the dictionary's SHA-256. Emitted from
- * its own pool buffer rather than through the compressor's recycled
- * buffers so it can never be reordered behind compressed output. A
- * plain zstd decoder skips the frame; a dcz client checks the hash
- * against the dictionary it advertised.
- */
-static ngx_int_t
-ngx_http_zstd_filter_emit_dcz_header(ngx_http_request_t *r,
-    ngx_http_zstd_ctx_t *ctx)
-{
-    ngx_buf_t    *b;
-    ngx_chain_t  *cl;
-
-    b = ngx_create_temp_buf(r->pool, NGX_HTTP_ZSTD_DCZ_HEADER_LEN);
-    if (b == NULL) {
+    if (ctx->out_buf->end < ctx->out_buf->last) {
+        ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+                      "corrupted output buffer: end (%p) < last (%p)",
+                      ctx->out_buf->end, ctx->out_buf->last);
         return NGX_ERROR;
     }
 
-    b->last = ngx_cpymem(b->last, ctx->dcz_dict->frame_header,
-                         NGX_HTTP_ZSTD_DCZ_HEADER_LEN);
-
-    cl = ngx_alloc_chain_link(r->pool);
-    if (cl == NULL) {
-        return NGX_ERROR;
-    }
-
-    cl->buf = b;
-    cl->next = NULL;
-
-    *ctx->last_out = cl;
-    ctx->last_out = &cl->next;
-
-    ctx->bytes_out += NGX_HTTP_ZSTD_DCZ_HEADER_LEN;
-    ctx->dcz_header_sent = 1;
-
-    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                   "zstd dcz: 40-byte frame header queued (dict \"%V\")",
-                   &ctx->dcz_dict->file);
+    ctx->buffer_out.size = ctx->out_buf->end - ctx->out_buf->last;
 
     return NGX_OK;
 }


### PR DESCRIPTION
## TL;DR

An RFC 9842 dcz response carries a fixed 40-byte skippable-frame prefix (magic + dictionary SHA-256) ahead of the compressed body. It used to ride on its own dedicated pool buffer and chain link, separate from the compressor's own output buffers, costing an extra allocation, chain link, and usually one extra downstream writev iovec per dcz response.

`ngx_http_zstd_filter_get_buf()` now reserves `NGX_HTTP_ZSTD_DCZ_HEADER_LEN` extra bytes on the first output buffer it allocates for a dcz response and copies the dictionary's prebuilt `frame_header` in directly; the compressor's `dst`/`size` are pointed at `->last` (past the prefix) instead of `->pos`. `ngx_http_zstd_filter_emit_dcz_header()` and its call site in the body filter are removed; `bytes_out`/`dcz_header_sent` bookkeeping moved into the allocation branch so the prefix is still counted exactly once.

**Severity:** `Low` (`performance — avoidable per-response allocation/chain-link overhead`)

## Mechanism

Making the prefix ride inside the compressor buffer surfaced a bug in the END-transition empty-output check in `ngx_http_zstd_filter_compress()`: it tested `ngx_buf_size(ctx->out_buf)` (the whole buffer), which is never zero on a prefix-bearing buffer even when the compressor itself wrote nothing yet on this call. That forced a premature, non-terminal 40-byte emission and a second buffer allocation — doubling the count instead of reducing it. Fixed by keying that check on this call's own output delta (`buffer_out.pos - pos_out`) instead of the whole-buffer size.

## Testing

- `ci/t/00-filter.t`, `01-static.t`, `02-conf-warn.t`, `03-dcz.t`: 1982/1982 pass against a freshly built `--add-dynamic-module` debug binary.
- `ci/tools/test_dcz.py`: existing end-to-end RFC 9842 suite passes unchanged.
- Added `ci/tools/test_dcz_prefix_alloc.py`: exercises a 1-byte, small, and multi-compressor-iteration dcz body, asserting the RFC magic/dictionary hash, a byte-exact decode round-trip, and (via a debug-log grep) that the old dedicated-buffer path never fires and exactly one compressor buffer is allocated per response.
- Manual allocation/writev counts (debug `error_log` + `strace -e trace=writev`) across empty, 1-byte, small, and multi-iteration bodies: before this change, 2 pool allocations + 2 chain links per dcz response (1 compressor buffer + 1 dedicated prefix buffer); after, 1 pool allocation + 1 chain link. Wire body byte-identical to `master` in every case (verified by direct comparison of the dechunked response body).
- Negative control: reverting the `get_buf`/compress changes reproduces the old allocation count and makes `test_dcz_prefix_alloc.py` fail 3/18 checks (the "old dedicated-prefix-buffer path never fires" assertion, RED); restoring the fix returns it to 18/18 (GREEN).