### PR TITLE
fix(dict): load dictionaries reliably — read to completion, clear O_NONBLOCK

### DIFF
--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -3439,6 +3439,28 @@ ngx_http_zstd_open_dict_file(ngx_conf_t *cf, ngx_str_t *path,
         }
     }
 
+    /*
+     * Clear O_NONBLOCK now that the target is confirmed regular. The flag
+     * exists only so the open() above cannot block the config-parsing
+     * master on a FIFO with no writer; that job is done. Leaving it set
+     * lets the caller's read hit the non-blocking-regular-file behaviour
+     * that some filesystems have but ext4/xfs do not: on a 9p/drvfs mount
+     * (a WSL /mnt/c dictionary, a Plan 9 export) read() returns a SHORT
+     * count on a regular file, and both callers treat a short read as a
+     * fatal "incomplete read" — so a valid dictionary larger than one such
+     * chunk fails config load there. A blocking read loops in the kernel
+     * and returns the whole file on every filesystem. fcntl() is a no-op
+     * that cannot fail meaningfully here (valid fd, defined flags); ignore
+     * its result rather than fail a load over a hardening detail.
+     */
+    {
+        int  fl = fcntl(fd, F_GETFL);
+
+        if (fl != -1) {
+            (void) fcntl(fd, F_SETFL, fl & ~O_NONBLOCK);
+        }
+    }
+
 #endif
 
     return fd;


### PR DESCRIPTION
Follow-up to #165 (the dictionary path-hardening change that added `ngx_http_zstd_open_dict_file()`).

## What

Both dictionary loaders (`zstd_dict_file` and `zstd_dcz_dict_file`) called `ngx_read_fd()` **once** and rejected anything short as a fatal `"incomplete read"`. That rejects a perfectly valid dictionary on any short read, and there are two ways to get one:

**1. `O_NONBLOCK`.** `ngx_http_zstd_open_dict_file()` opens with `O_NONBLOCK` so the `open()` can't block the config-parsing master on a FIFO with no writer, and left the flag set through the read. On ext4/xfs that's a no-op, but some filesystems return a **short** read on a non-blocking regular-file read — a 9p/drvfs mount (a dictionary under WSL's `/mnt/c`, a Plan 9 export) returns ~64 KB and stops, so a dictionary larger than one chunk fails config load.

**2. Short reads generally.** Even a *blocking* `read()` may return a partial count on a regular file — interrupted by a signal after a partial transfer (EINTR-after-partial), or on an interruptible filesystem (POSIX `read(2)`). A single read isn't enough. (Thanks to CodeRabbit for flagging this second half.)

## Fix

- Clear `O_NONBLOCK` once the target is confirmed regular (the FIFO risk lives only in `open()`), before the read.
- Read to completion in a shared `ngx_http_zstd_read_dict_full()` used by both loaders: retry `EINTR`, accumulate until `size`, and stop early only on a hard error (returns `-1`, `ngx_errno` preserved) or an unexpected EOF (returns the partial total, so the caller still reports the incomplete read). The callers' existing `n < 0` / `n != size` handling is unchanged — this only replaces the single `ngx_read_fd()` that fed it.

The two are complementary: clearing `O_NONBLOCK` keeps a regular-file read from ever returning `EAGAIN` (which the loop deliberately doesn't retry, to avoid a busy-spin), and the loop covers every remaining short-read cause.

## Why the suite doesn't catch it

The path-hardening fixtures are 8 KB (under a single read on any filesystem) and CI runs on ext4, where `O_NONBLOCK` is a no-op.

## Verification

An 8 MB `zstd_dict_file` **and** an 8 MB `zstd_dcz_dict_file` both load cleanly via `nginx -t` on a `/mnt/c` (drvfs) mount — where the pre-fix single-read rejected them with `read() dictionary "...": 65512 of 8388609 bytes`, reproduced deterministically in a downstream module carrying the identical loader shape. Both loaders route through the new helper.
