### PR TITLE
test: bump vendored testkit harness to 5f7986c

### DIFF
--- a/filter/config
+++ b/filter/config
@@ -32,6 +32,8 @@ if [ "${TEST_HARNESS:-0}" = "1" ]; then
     ngx_module_srcs="$ngx_module_srcs \
                  $_ngx_zstd_root/ci/t/harness/src/ngx_test_probe.c \
                  $_ngx_zstd_root/ci/t/harness/src/ngx_test_probe_arm.c \
+                 $_ngx_zstd_root/ci/t/harness/src/ngx_test_probe_redzone.c \
+                 $_ngx_zstd_root/ci/t/harness/src/ngx_test_probe_canary.c \
                  $_ngx_zstd_root/src/ngx_http_zstd_probe_hooks.c"
     ngx_module_deps="$ngx_module_deps \
                  $_ngx_zstd_root/ci/t/harness/src/ngx_test_probe.h \


### PR DESCRIPTION
## TL;DR

Bumps the vendored testkit harness (`ci/t/harness`) from `f8e0999` to
`5f7986c`, mainly to pull in the fix that makes `--track-fds=all` usable in
the monthly `harness-memcheck` job.

`ci/t/harness` bumped `f8e0999` -> `5f7986c` (7 commits); `filter/config` gains two new probe TUs under the existing `TEST_HARNESS=1` gate.

**Severity:** `Low` (`test infrastructure — no runtime/packaged-build impact`)

## Why this bump

Testkit PR #213 fixes `prober_scrape_valgrind`: `valgrind-scenarios.sh` set
`--track-fds=all`, but the scrape grepped `ERROR SUMMARY: [1-9]`, which nginx
can never satisfy — it always exits holding ~9 open-fd contexts. Without this
bump, `--track-fds=all` cannot be kept in `harness-memcheck`. Six other
commits ride along: #208 (slab counters), #212 (import-prompt docs), #215
(slab canaries), #217 (assertion-5 fix), #218 (pool redzones), #219
(cache-key/stale-binary fix).

## Consumer wiring

- `ci/t/harness/t/module/config` now also compiles
  `src/ngx_test_probe_redzone.c` and `src/ngx_test_probe_canary.c`.
  `filter/config` (inside the `TEST_HARNESS=1` block) only listed
  `ngx_test_probe.c` and `ngx_test_probe_arm.c`, so it now lists all four.
  No new header dependency: both new TUs only include `ngx_test_probe.h`,
  already in `ngx_module_deps` (their `ngx_pool_shim.h` include is guarded by
  `NGX_TEST_PROBE_POOL_SHIM`, defined only in the harness's own direct-call
  unit tests, not this build path).
- `ci/t/harness/probe-schema.json` now marks `redzone`, `redzone.violations`,
  `redzone.checked`, `canary`, `canary.violations`, `canary.checked`,
  `canary.live`, and `zone.slab_reqs`/`slab_fails`/`slab_used` (when
  `zone.present`) as required. All of these fields are emitted by
  `ci/t/harness/src/ngx_test_probe.c` itself, not by this module's
  `src/ngx_http_zstd_probe_hooks.c` or any scenario under
  `ci/t/harness-scenarios/`. Nothing to change there.

## Testing

Built `nginx-1.31.4` locally with `TEST_HARNESS=1
CFLAGS="-DNGX_TEST_HARNESS -Wextra -Werror"` and `--add-dynamic-module`: exit
0, `ngx_http_zstd_filter_module.so` links all four probe TUs
(`ngx_test_probe`, `ngx_test_probe_arm`, `ngx_test_probe_redzone`,
`ngx_test_probe_canary`), 40 `ngx_test_probe_*` symbols present via `nm`.

Ran both harness scenarios against that build via
`ci/t/harness/ci/prober/run-scenario.sh`:

- `fault-arms`: `1..7`, 7 `ok`, 0 `not ok`, 0 SKIP.
- `alloc-neutral`: `1..7`, 7 `ok`, 0 `not ok`, 0 SKIP (`cycle_used` flat at
  79134, `cycle_blocks`/`cycle_large` flat at 5/7, worker/master fd counts
  flat at 10/8).

Did not run `valgrind-scenarios.sh` (long-runner, out of scope for local
verification). `.claude/skills/_shared/review-lint.sh --branch master`:
`no reviewable files in selection` (gitlink bump + shell config aren't
lint targets); all-linters-clean on the rest of the roster.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI test harness to a newer revision.
  * Enhanced test builds with additional memory-safety checks for detecting buffer overflows and memory corruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->