### PR TITLE
fix: emit a writer-legal zero-size last_buf on a terminal empty frame

### DIFF
--- a/ci/t/harness-scenarios/fault-arms/driver.sh
+++ b/ci/t/harness-scenarios/fault-arms/driver.sh
@@ -83,7 +83,7 @@ fetch() {
 # 6  disarming restores normal (uncorrupted) compression -- proves the
 #    fault state is per-arm, not sticky
 # 7  no worker died by signal across the whole run
-echo "1..7"
+echo "1..8"
 
 # --- 1: warm-up -----------------------------------------------------------
 WARMUP="$PROBER_PREFIX/warmup.out"
@@ -220,13 +220,56 @@ else
     FAILED=$((FAILED + 1))
 fi
 
-# --- 7: no signal-death across the run --------------------------------------
+# --- 7: terminal zero-output END emits a WRITER-LEGAL zero-size last_buf ----
+#
+# fault_codec_end=1001 is the FIRST end-of-frame call producing no output --
+# the arm oracle 4 deliberately avoids. The module must still emit the
+# zero-length last_buf (the suppression arm lets it through on purpose), and
+# nginx's writer only tolerates a zero-size buffer that ngx_buf_special()
+# accepts: `(flush||last_buf||sync) && !ngx_buf_in_memory(b) && !b->in_file`.
+# out_buf comes from ngx_create_temp_buf(), so `temporary` stays set and
+# ngx_buf_in_memory() stays true even when the buffer is fully drained. That
+# made ngx_http_write_filter log "zero size buf in writer" and abort the
+# response mid-stream.
+#
+# The assertion is on the ALERT and the transfer, NOT on frame validity: this
+# arm suppresses the real terminal call, so the body legitimately is not a
+# complete zstd frame. Asserting `zstd -d` here would be asserting that an
+# injected fault did not happen. What must hold is that the fault degrades the
+# BODY without provoking a writer-level abort or a worker alert.
+#
+# Non-vacuity: the alert grep is scoped to lines logged after this point in
+# the run, and the fetch must genuinely reach the module -- an arm that never
+# fired would leave a full decodable frame, which the size check below rejects.
+END_ZERO1_OUT="$PROBER_PREFIX/codec-end-zero1.out"
+ELOG_MARK_7="$(wc -l < "$ELOG")"
+ARM7_OK=0
+if arm codec_end 1001 && fetch /body.bin "$END_ZERO1_OUT"; then
+    ARM7_OK=1
+fi
+ZEROBUF_7=0
+if [ "$(tail -n +$((ELOG_MARK_7 + 1)) "$ELOG" | grep -c 'zero size buf in writer' || true)" -gt 0 ]; then
+    ZEROBUF_7=1
+fi
+if [ "$ARM7_OK" -eq 1 ] \
+    && [ "$ZEROBUF_7" -eq 0 ] \
+    && grep -q '^HTTP/1.1 200' "$END_ZERO1_OUT.hdrs" 2>/dev/null
+then
+    echo "ok 7 - CODEC_END ZERO on the FIRST end call emitted a writer-legal zero-size last_buf (no \"zero size buf in writer\", no aborted transfer)"
+else
+    echo "not ok 7 - first-call CODEC_END ZERO tripped the writer or aborted the response"
+    tail -n +$((ELOG_MARK_7 + 1)) "$ELOG" | grep -n 'zero size buf in writer' | sed 's/^/# /'
+    FAILED=$((FAILED + 1))
+fi
+disarm codec_end || true
+
+# --- 8: no signal-death across the run --------------------------------------
 if grep -qE 'worker process .* exited on signal|SIGSEGV|SIGABRT|SIGBUS' "$ELOG"; then
-    echo "not ok 7 - a worker died by signal during fault injection"
+    echo "not ok 8 - a worker died by signal during fault injection"
     grep -nE 'exited on signal|SIGSEGV|SIGABRT|SIGBUS' "$ELOG" | sed 's/^/# /'
     FAILED=$((FAILED + 1))
 else
-    echo "ok 7 - no worker died by signal across the whole fault-injection run"
+    echo "ok 8 - no worker died by signal across the whole fault-injection run"
 fi
 
 if [ "$FAILED" -gt 0 ]; then

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -2429,6 +2429,32 @@ ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
         ctx->flush = 0;
     }
 
+    /*
+     * A terminal frame that produced no output bytes (everything drained on a
+     * prior iteration) still has to emit the zero-length last_buf -- that is
+     * what the suppression arm above deliberately lets through. But the writer
+     * only tolerates a zero-size buffer when ngx_buf_special() accepts it, and
+     * that macro requires !ngx_buf_in_memory(b) && !b->in_file. out_buf comes
+     * from ngx_create_temp_buf(), so `temporary` is set and start/end point at
+     * a real allocation: ngx_buf_in_memory() stays true even once the buffer is
+     * fully drained, the special test fails, and ngx_http_write_filter logs
+     * "zero size buf in writer" and aborts the response mid-stream.
+     *
+     * Clearing `temporary` on an empty buffer is exactly what nginx's own gzip
+     * filter does for this case (ngx_http_gzip_filter_module.c, in its
+     * deflateEnd path). `recycled` goes with it: a zero-size buffer has nothing
+     * to reclaim, and leaving the flag set on a buffer the writer treats as
+     * special only invites ngx_chain_update_chains() to reason about a buffer
+     * that no longer describes memory.
+     *
+     * Only the size-0 case is touched, so a normal terminal buffer carrying
+     * bytes keeps both flags and its ordinary in-memory identity.
+     */
+    if (ngx_buf_size(b) == 0) {
+        b->temporary = 0;
+        b->recycled = 0;
+    }
+
     ctx->bytes_out += ngx_buf_size(b);
 
     cl->next = NULL;


### PR DESCRIPTION
> Found by finishing the oracle-4 diagnosis that cycles 1 and 2 left open. Fixes the defect ledgered in `issues.md` as "Terminal zero-output `ZSTD_e_end` emits a zero-size `last_buf`, which nginx's writer rejects" — pre-existing, reproduced independently three times, and until now deliberately routed around by the test suite rather than fixed.

## TL;DR

When a compressed response happened to finish with nothing left to send, the module still had to send an end-of-response marker — an empty one. nginx's output stage refused that empty marker, logged an alarm, and cut the response off partway. The fix marks the empty marker the way nginx expects, so it is accepted instead of rejected.

`ngx_http_zstd_filter_emit()` now clears `temporary` and `recycled` on a zero-size `out_buf` before queueing it, so a terminal empty buffer satisfies `ngx_buf_special()`.

**Severity:** `Medium` (`availability — a truncated response and an [alert] on a reachable path; no memory-safety or trust-boundary impact`)

## Why the writer rejected it

A terminal `ZSTD_e_end` producing no output bytes — everything drained on a prior iteration — must still emit the zero-length `last_buf`. The suppression arm at `ngx_buf_size(ctx->out_buf) == 0 && !last` lets it through deliberately, and the comment above the `last` computation documents that intent.

`ngx_http_write_filter` tolerates a zero-size buffer only when `ngx_buf_special()` accepts it:

```c
(flush || last_buf || sync) && !ngx_buf_in_memory(b) && !b->in_file
```

`ctx->out_buf` comes from `ngx_create_temp_buf()`, so `temporary` is set and `start`/`end` point at a real allocation. `ngx_buf_in_memory()` therefore stays true even once the buffer is fully drained, the special test fails, and the writer logs `zero size buf in writer` and aborts the response mid-stream.

## The fix

Clearing `temporary` on an empty buffer is exactly what nginx's own gzip filter does for this case, in its `deflateEnd` path (`ngx_http_gzip_filter_module.c`). `recycled` is cleared alongside it: a zero-size buffer has nothing to reclaim, and leaving the flag set on a buffer the writer now treats as special only invites `ngx_chain_update_chains()` to reason about a buffer that no longer describes memory.

Only the size-0 case is touched, so a terminal buffer carrying bytes keeps both flags and its ordinary in-memory identity.

## Testing

Reachable deterministically through the codec fault site with `fault_codec_end=1001` — zero output on the **first** end-of-frame call. That is the arm the `fault-arms` scenario previously had to avoid, precisely because arming it would have shipped a permanently-red gate for this open defect.

Adds **oracle 7** to that scenario for this arm, renumbering the signal-death check to 8. The assertion is on the writer alert and the transfer, **not** on frame validity: this arm suppresses the real terminal call, so the body legitimately is not a complete zstd frame. Asserting `zstd -d` there would amount to asserting that an injected fault did not happen.

**Mutation-proven.** Reverting the two assignments (binaries confirmed distinct by `sha256sum`) makes oracle 7 the **only** oracle that flips — `not ok 7`, with the `zero size buf in writer` alert quoted in the failure output — while 1-6 and 8 stay green:

| build | fault-arms result |
|---|---|
| with fix | `1..8`, 8/8 green |
| fix reverted | `not ok 7` only; 1-6 and 8 still green |

Also verified: `fault_codec_end=1` (a genuine injected error) still fails closed at `curl` exit 18, so the change does not blunt real error detection; and the unfaulted arms still decode to the byte-exact 204800-byte origin.

`Test::Nginx` `00-filter.t`: **573 subtests, 0 failed** (run against a local build; the run bails afterwards on `auth_request`, absent from that scratch tree and unrelated to this change).
