### PR TITLE
fix: align the directio probe offset so a skippable-prefixed .zst is served

### DIFF
--- a/ci/t/01-static.t
+++ b/ci/t/01-static.t
@@ -1224,3 +1224,51 @@ bypass origin body
 --- error_log
 declares a 134217728-byte decompression window
 above the 8 MB limit browsers enforce for Content-Encoding: zstd
+
+
+
+=== TEST 46: a dcz-style skippable prefix on a directio file IS served
+# M1 regression. Under directio the probe buffer is aligned and the
+# first read at offset 0 succeeds, but the skippable walk then moves
+# `pos` to 40 (the canonical dcz SHA-256 prefix: 8-byte skippable
+# header + 32-byte payload) and the NEXT read used that offset raw. An
+# O_DIRECT descriptor rejects an unaligned file offset with EINVAL, so
+# the read returned -1, the probe took the "aligned probe ... returned
+# -1" branch and DECLINED — every request for a dcz-shaped .zst on a
+# directio location silently lost its precompressed variant (a 404 with
+# "zstd_static always" and no identity file). The fix rounds the read
+# offset down to the alignment and parses the frame at its offset
+# inside the block.
+#
+# Fail-first control (observed): reverting the alignment (reading at
+# `pos` instead of `base`) turns this into "! Content-Encoding" plus
+# the "returned -1" error line, so both the 200-with-zstd assertion and
+# the --- no_error_log [error] assertion go red.
+#
+# The .zst is padded past the "directio 512" threshold so the open
+# really is O_DIRECT; "aligned probe on directio file" is the positive
+# witness that is_directio was set for this request, so the block
+# cannot pass vacuously through the stack-read path on a filesystem
+# where O_DIRECT does not take.
+--- config
+    location /skip/ {
+        zstd_static on;
+        directio 512;
+        root html;
+    }
+--- user_files eval
+">>> skip/dioprefix.js\ndirectio prefix origin\n>>> skip/dioprefix.js.zst\n"
+. pack("C*", 0x50, 0x2A, 0x4D, 0x18, 0x20, 0x00, 0x00, 0x00)
+. ("\0" x 32)
+. pack("C*", 0x28, 0xB5, 0x2F, 0xFD, 0x00, 0x00, 0x19, 0x00, 0x00)
+. "hi\n"
+. ("\0" x 1024)
+--- request
+GET /skip/dioprefix.js
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+Content-Encoding: zstd
+--- error_code: 200
+--- no_error_log
+[error]

--- a/src/ngx_http_zstd_static_module.c
+++ b/src/ngx_http_zstd_static_module.c
@@ -717,12 +717,12 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
          * that frame layout requires.
          */
         u_char       hdrbuf[18];
-        u_char      *hdr;
-        size_t       want;
+        u_char      *hdr, *frame;
+        size_t       want, align, frame_off, avail;
         ssize_t      n;
         uint64_t     window, skip;
         ngx_uint_t   frames;
-        off_t        pos;
+        off_t        pos, base;
 
         if (of.size < 4) {
             ngx_log_error(NGX_LOG_ERR, log, 0,
@@ -732,17 +732,32 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
         }
 
         if (of.is_directio) {
-            want = NGX_HTTP_ZSTD_STATIC_DIO_PROBE;
-            if ((size_t) clcf->directio_alignment > want) {
-                want = (size_t) clcf->directio_alignment;
+            align = NGX_HTTP_ZSTD_STATIC_DIO_PROBE;
+            if ((size_t) clcf->directio_alignment > align) {
+                align = (size_t) clcf->directio_alignment;
             }
 
-            hdr = ngx_pmemalign(r->pool, want, want);
+            /*
+             * TWO blocks, not one. The probe offset is rounded down to
+             * `align` (an O_DIRECT descriptor rejects an unaligned file
+             * offset with EINVAL), so a frame header can start as late
+             * as `align - 1` bytes into the first block and would then
+             * straddle the boundary — parsing only one block would
+             * report that legitimate frame as truncated. A second block
+             * guarantees at least `align` (>= 4096) bytes behind any
+             * in-block start position, far more than the 18 a frame
+             * header can need. Both the length and the buffer stay
+             * `align`-aligned, which is what O_DIRECT requires.
+             */
+            want = align * 2;
+
+            hdr = ngx_pmemalign(r->pool, want, align);
             if (hdr == NULL) {
                 return NGX_HTTP_INTERNAL_SERVER_ERROR;
             }
 
         } else {
+            align = 0;
             hdr = hdrbuf;
             want = sizeof(hdrbuf);
         }
@@ -753,10 +768,20 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
          * Walk a bounded chain of leading skippable frames to reach the
          * first regular frame, so the window guard below cannot be
          * dodged by prepending one (see NGX_HTTP_ZSTD_STATIC_FRAME_SKIP
-         * and NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES). Each iteration
-         * pread()s at the current offset, exactly like the original
-         * single-shot probe did at offset 0; only the offset and the
-         * loop are new.
+         * and NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES).
+         *
+         * Each iteration reads at the current offset. Under directio
+         * the O_DIRECT descriptor rejects an unaligned file offset with
+         * EINVAL, and `pos` after a leading skippable frame is whatever
+         * that frame's length made it (40 for the canonical dcz
+         * SHA-256 prefix) — almost never a multiple of the block size.
+         * So the read offset is rounded DOWN to the alignment and the
+         * frame is parsed at its offset inside the block: `base` is the
+         * aligned read offset, `frame_off` the distance from there to
+         * `pos`, and `avail` the bytes of that block that actually lie
+         * at or after `pos`. Off the directio path `base == pos`,
+         * `frame_off == 0` and this is byte-for-byte the previous
+         * behaviour.
          */
         for (frames = 0; ; frames++) {
 
@@ -772,16 +797,37 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
                 return NGX_DECLINED;
             }
 
-            n = ngx_http_zstd_static_pread(of.fd, hdr, want, pos, log,
+            if (of.is_directio) {
+                frame_off = (size_t) ((uint64_t) pos % (uint64_t) align);
+                base = pos - (off_t) frame_off;
+
+            } else {
+                frame_off = 0;
+                base = pos;
+            }
+
+            n = ngx_http_zstd_static_pread(of.fd, hdr, want, base, log,
                                            &path);
-            if (n < 4) {
+
+            /*
+             * Bytes of the block that lie at or after `pos`. A short
+             * read that stopped inside the prefix leaves nothing for
+             * the frame, which is the same "too few bytes" condition as
+             * a short read at offset 0 and takes the same branch.
+             */
+            avail = ((size_t) (n > 0 ? n : 0) > frame_off)
+                        ? (size_t) n - frame_off : 0;
+
+            frame = hdr + frame_off;
+
+            if (n < 0 || avail < 4) {
                 if (of.is_directio) {
                     ngx_log_error(NGX_LOG_ERR, log, ngx_errno,
                                   "zstd static: %uz-byte aligned probe on "
                                   "directio file \"%s\" returned %z — "
                                   "declining; check directio_alignment "
                                   "against the device geometry",
-                                  want, path.data, n);
+                                  align, path.data, n);
                     return NGX_DECLINED;
                 }
 
@@ -803,11 +849,10 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
             if (of.is_directio) {
                 ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
                                "zstd static: %uz-byte aligned probe on "
-                               "directio file \"%s\"", want, path.data);
+                               "directio file \"%s\"", align, path.data);
             }
 
-            switch (ngx_http_zstd_static_probe_frame(hdr, (size_t) n,
-                                                      &window))
+            switch (ngx_http_zstd_static_probe_frame(frame, avail, &window))
             {
 
             case NGX_HTTP_ZSTD_STATIC_FRAME_NOT_ZSTD:
@@ -815,8 +860,8 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
                               "zstd static: \"%s\" is not a zstd frame "
                               "(leading bytes 0x%02xd%02xd%02xd%02xd)",
                               path.data,
-                              (ngx_uint_t) hdr[0], (ngx_uint_t) hdr[1],
-                              (ngx_uint_t) hdr[2], (ngx_uint_t) hdr[3]);
+                              (ngx_uint_t) frame[0], (ngx_uint_t) frame[1],
+                              (ngx_uint_t) frame[2], (ngx_uint_t) frame[3]);
                 return NGX_DECLINED;
 
             case NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED:

--- a/src/ngx_http_zstd_static_module.c
+++ b/src/ngx_http_zstd_static_module.c
@@ -657,7 +657,7 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
      * undecodable body — a confusing outage class that nginx's built-in
      * gzip_static also doesn't defend against. The probe is cheap (one
      * offset-explicit read of the frame-header prefix at offset 0 — 18
-     * bytes, or one aligned block under directio — via
+     * bytes, or a pair of aligned blocks under directio — via
      * ngx_http_zstd_static_pread(): pread(2) on POSIX, ngx_read_file()
      * on Win32, both of which take the offset as an argument and so
      * never move the open_file_cache's shared fd position. Using plain
@@ -688,12 +688,19 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
      *
      * When the file was opened with O_DIRECT (of.is_directio, set by
      * ngx_open_cached_file when "directio <size>" is configured and the
-     * file meets the threshold), the read must be block-aligned, so the
-     * probe reads one block of max(NGX_HTTP_ZSTD_STATIC_DIO_PROBE,
-     * directio_alignment) bytes into an equally-aligned pool buffer —
-     * honoring the operator's declared geometry the same way the core
-     * copy filter does. The window check in particular must not be
-     * skipped under directio: oversized declared windows are a
+     * file meets the threshold), BOTH the read offset and the length
+     * must be block-aligned, so the probe rounds each frame offset down
+     * to max(NGX_HTTP_ZSTD_STATIC_DIO_PROBE, directio_alignment) and
+     * reads two such blocks into an equally-aligned pool buffer,
+     * parsing the frame at its offset inside them — honoring the
+     * operator's declared geometry the same way the core copy filter
+     * does. Rounding the OFFSET is what the skippable-frame walk needs:
+     * the second and later probes are at whatever offset the previous
+     * frame's declared length produced (40 for a canonical dcz prefix),
+     * which an O_DIRECT descriptor rejects with EINVAL if passed raw.
+     *
+     * The window check in particular must not be skipped under
+     * directio: oversized declared windows are a
      * systematic build-pipeline product, not rare corruption, and every
      * browser rejects them. If the aligned read STILL fails, the file
      * is DECLINED, not served: for a validation read, falling back to


### PR DESCRIPTION
> Found auditing the static handler's frame probe. Independent of #117 and #129.

## TL;DR

When a site is set up to bypass the operating system's file cache, the disk will
only hand over whole blocks starting at block boundaries. The check that decides
whether a pre-compressed file is safe to serve skips over a small header at the
front of the file and then read from wherever that header ended — almost never a
boundary — so the read was refused and the pre-compressed copy was quietly passed
over on every request for it. Sites configured to serve only the compressed copy
returned a "not found" instead.

In code terms: under `directio`, the leading-skippable-frame walk in
`ngx_http_zstd_static_handler()` passed the raw frame offset to
`ngx_http_zstd_static_pread()`. On the second and later iterations that offset is
unaligned, `pread(2)` fails `EINVAL`, and the handler takes its directio
short-read branch and returns `NGX_DECLINED`.

**Severity:** `Medium` (`correctness — silent loss of the precompressed variant, or a 404 under zstd_static always`)

## Why it happens

The probe reads a frame header, and a `.zst` file may begin with one or more
skippable frames before the real payload frame. The canonical dcz prefix is
exactly one: an 8-byte skippable header plus a 32-byte SHA-256, so the walk's
second read is at offset 40.

Offset 0 is aligned, so the first read always succeeds and the bug is invisible
for a file with no skippable prefix. Offset 40 is not, and an `O_DIRECT`
descriptor rejects an unaligned file offset outright. The handler cannot
distinguish that from a device-geometry mismatch, so it logs
`aligned probe on directio file ... returned -1` at `NGX_LOG_ERR` and declines —
fail-closed, but per request and for the lifetime of the file.

This is the same class as the archived first-read-only alignment fix,
reintroduced when the skippable walk was added: that fix aligned the buffer and
the length, which is sufficient while the only offset is 0.

## The fix

Round each probe offset down to `max(4096, directio_alignment)`, read from
there, and parse the frame at its offset inside the block.

The buffer is two blocks rather than one because `O_DIRECT` requires the read
*length* to be aligned too, and a frame starting late in the first block would
otherwise straddle the boundary and be misreported as truncated. Two blocks
guarantee at least 4096 bytes behind any in-block start position, against the 18
a frame header can need.

Off the directio path the rounding is a no-op — `base == pos`, `frame_off == 0`,
`avail == n` — so the non-directio behaviour is byte-for-byte unchanged.

The two directio log lines now report the alignment rather than the read length.
Their text is unchanged, which keeps the existing assertions in TESTs 33 and 34
exact and means the number an operator sees is still the `directio_alignment`
the message tells them to check.

## Testing

`ci/t/01-static.t` TEST 46: a dcz-style skippable prefix ahead of a small-window
regular frame, padded past a `directio 512` threshold, must be served
`200` + `Content-Encoding: zstd` with no error log.

Fail-first control, observed rather than reasoned: compiling the offset rounding
out (`if (0)` on the alignment branch), rebuilding, and re-running turns TEST 46
red on both its `Content-Encoding` and its `no_error_log` assertions, with

```
zstd static: 4096-byte aligned probe on directio file "...dioprefix.js.zst"
returned -1 — declining; check directio_alignment against the device geometry
(22: Invalid argument)
```

which is the defect verbatim. Restoring the fix returns it to green. Only TEST
46's assertions moved, so the control is discriminating rather than a
harness-wide failure.

Local suite against nginx 1.31.4, all green:
`01-static.t` 588, `00-filter.t` 1206, `02-conf-warn.t` 82, `03-dcz.t` 115
assertions, zero failures. `ci/tests/unit/run.sh` 45/45.

`review-lint.sh --branch master` reports no finding on the changed lines and no
`coverage gap` block; the four `ast-grep` candidates, the `codespell` hit on
`r->exten` and the pre-existing `lizard` complexity warning on
`ngx_http_zstd_static_handler` all fall outside this diff.

## Not in this PR

Under a large operator-configured `directio_alignment` the probe allocation is
now `2 x` what it was. The value is unbounded in both cases (`ngx_conf_set_off_slot`
does not clamp it) and operator-controlled rather than attacker-controlled, so
this doubles an existing exposure rather than creating one. Worth a bound, as its
own change.
