### PR TITLE
n12: profile_pack INVALID never cacheable

### DIFF
--- a/ci/tools/test_cctx_profile_pack.c
+++ b/ci/tools/test_cctx_profile_pack.c
@@ -130,6 +130,7 @@ main(void)
             { 0,            -1,  "window_log negative" },
         };
         size_t i;
+        uint64_t key1, key2;
 
         for (i = 0; i < sizeof(bad) / sizeof(bad[0]); i++) {
             key = ngx_http_zstd_profile_pack(bad[i].lvl, 0, bad[i].wlog);
@@ -145,6 +146,31 @@ main(void)
         if (!rc) {
             printf("  => all %zu out-of-domain inputs refused "
                    "(no silent masking)\n", sizeof(bad) / sizeof(bad[0]));
+        }
+
+        /*
+         * Assert that two distinct out-of-domain profiles collapse to the
+         * SAME sentinel: this is the aliasing the cache guard must detect.
+         * Both should pack to INVALID, proving they compare equal, which is
+         * why acquire_cctx must refuse to borrow or seed on INVALID.
+         */
+        key1 = ngx_http_zstd_profile_pack(LEVEL_MIN - 1, 0, 0);
+        key2 = ngx_http_zstd_profile_pack(0, 0, WLOG_MAX + 1);
+        if (key1 != NGX_HTTP_ZSTD_PROFILE_INVALID
+            || key2 != NGX_HTTP_ZSTD_PROFILE_INVALID
+            || key1 != key2)
+        {
+            fprintf(stderr,
+                    "SENTINEL-ALIASING: two distinct out-of-domain profiles "
+                    "did not both collapse to INVALID: "
+                    "key1=%llu key2=%llu INVALID=%llu\n",
+                    (unsigned long long) key1,
+                    (unsigned long long) key2,
+                    (unsigned long long) NGX_HTTP_ZSTD_PROFILE_INVALID);
+            rc = 1;
+        } else {
+            printf("  => distinct out-of-domain profiles alias to INVALID "
+                   "(cache guard must refuse)\n");
         }
     }
 

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -2840,60 +2840,70 @@ ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
     lender = NULL;
 
     /*
-     * Borrow a slot whose context is free and was built for this location's
-     * complete memory-affecting profile: compression level, long mode and
-     * window log. A mismatch in any of the three never re-parameterises a
-     * slot: the retained workspace is driven by all three and never shrinks,
-     * so honouring a higher-memory location on an existing slot would raise
-     * that slot's floor for every subsequent request of every other location
-     * mapped to it.
-     *
-     * The same walk records the first slot that is empty AND not on loan, so
-     * a miss can seed it below without a second pass. An empty slot is only
-     * ever seeded, never evicted: a live cached context is not thrown away
-     * mid-flight, and one already on loan is left alone.
+     * Defense-in-depth: INVALID is never cacheable. Multiple out-of-domain
+     * inputs collapse to INVALID, so two different invalid profiles would
+     * compare equal on the borrow path and corrupt the cache. This check is
+     * unreachable today (every field is bounded at config load), but if a
+     * future directive widens a domain, it prevents silent aliasing at the
+     * cost of one more cache miss (a fresh context is always safe).
      */
-    for (i = 0; i < NGX_HTTP_ZSTD_CCTX_SLOTS; i++) {
-        slot = &ngx_http_zstd_worker_cctx_slots[i];
+    if (zlcf_profile.key != NGX_HTTP_ZSTD_PROFILE_INVALID) {
+        /*
+         * Borrow a slot whose context is free and was built for this
+         * location's complete memory-affecting profile: compression level,
+         * long mode and window log. A mismatch in any of the three never
+         * re-parameterises a slot: the retained workspace is driven by all
+         * three and never shrinks, so honouring a higher-memory location on
+         * an existing slot would raise that slot's floor for every
+         * subsequent request of every other location mapped to it.
+         *
+         * The same walk records the first slot that is empty AND not on
+         * loan, so a miss can seed it below without a second pass. An empty
+         * slot is only ever seeded, never evicted: a live cached context is
+         * not thrown away mid-flight, and one already on loan is left alone.
+         */
+        for (i = 0; i < NGX_HTTP_ZSTD_CCTX_SLOTS; i++) {
+            slot = &ngx_http_zstd_worker_cctx_slots[i];
 
-        if (slot->busy) {
-            continue;
-        }
-
-        if (slot->cctx == NULL) {
-            if (free_slot == NULL) {
-                free_slot = slot;
+            if (slot->busy) {
+                continue;
             }
-            continue;
-        }
 
-        if (ngx_http_zstd_cctx_profiles_match(&slot->profile,
-                                              &zlcf_profile))
-        {
-            ctx->cctx = slot->cctx;
-            slot->busy = 1;
-            lender = slot;
-            borrowed = 1;
+            if (slot->cctx == NULL) {
+                if (free_slot == NULL) {
+                    free_slot = slot;
+                }
+                continue;
+            }
 
+            if (ngx_http_zstd_cctx_profiles_match(&slot->profile,
+                                                  &zlcf_profile))
             {
-            ngx_int_t   dbg_level, dbg_wlog;
-            ngx_flag_t  dbg_long;
+                ctx->cctx = slot->cctx;
+                slot->busy = 1;
+                lender = slot;
+                borrowed = 1;
 
-            /*
-             * Unpack rather than read zlcf: this prints what the SLOT was
-             * built for, which is the thing a reuse decision turns on, and
-             * it exercises the key's reversibility on the hot debug path.
-             */
-            ngx_http_zstd_profile_unpack(slot->profile.key, &dbg_level,
-                                         &dbg_long, &dbg_wlog);
+                {
+                ngx_int_t   dbg_level, dbg_wlog;
+                ngx_flag_t  dbg_long;
 
-            ngx_log_debug5(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                           "zstd: reusing worker cctx %p (slot:%ui) "
-                           "level:%i long:%i window_log:%i",
-                           ctx->cctx, i, dbg_level, (ngx_int_t) dbg_long,
-                           dbg_wlog);
+                /*
+                 * Unpack rather than read zlcf: this prints what the SLOT was
+                 * built for, which is the thing a reuse decision turns on, and
+                 * it exercises the key's reversibility on the hot debug path.
+                 */
+                ngx_http_zstd_profile_unpack(slot->profile.key, &dbg_level,
+                                             &dbg_long, &dbg_wlog);
+
+                ngx_log_debug5(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                               "zstd: reusing worker cctx %p (slot:%ui) "
+                               "level:%i long:%i window_log:%i",
+                               ctx->cctx, i, dbg_level, (ngx_int_t) dbg_long,
+                               dbg_wlog);
+                }
+                break;
             }
-            break;
         }
     }
 
@@ -2905,7 +2915,9 @@ ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
             return NGX_ERROR;
         }
 
-        if (free_slot != NULL) {
+        if (free_slot != NULL
+            && zlcf_profile.key != NGX_HTTP_ZSTD_PROFILE_INVALID)
+        {
             free_slot->cctx = ctx->cctx;
             ngx_http_zstd_cctx_profile_from_conf_wlog(&free_slot->profile,
                 zlcf, eff_window_log);


### PR DESCRIPTION
## Summary

Defense-in-depth fix for issue n12: refuse to cache or borrow with an INVALID profile key.

The `ngx_http_zstd_profile_pack()` function returns the same `NGX_HTTP_ZSTD_PROFILE_INVALID` sentinel for multiple distinct out-of-domain inputs (e.g. level below bias, window_log above field, etc.). This aliasing would cause two different invalid profiles to compare equal in the cache lookup, allowing a request expecting one set of parameters to borrow a context built with completely different parameters — changing bytes on the wire.

## Fix

Added guards in `ngx_http_zstd_acquire_cctx()` to:
1. Skip the borrow walk entirely if the target profile key is INVALID
2. Skip seeding a free cache slot if the target profile key is INVALID

When INVALID is encountered, a fresh uncached context is always created. This is fail-safe: the request still completes successfully (no error), but bypasses the cache entirely. 

**Unreachable today** — every profile field is already bounded at config load, so INVALID can never be returned. This is a defense-in-depth measure that protects against future directive domain widening.

## Testing

- Extended `ci/tools/test_cctx_profile_pack.c` to verify that two distinct out-of-domain inputs both collapse to INVALID, documenting the aliasing hazard
- All existing unit tests and integration tests pass
- Build succeeds with no new lint findings
- Coverage remains at 77.6% (unchanged, as expected — the guard is unreachable in practice)

## Behavior

- **Before**: Two distinct out-of-domain profiles could alias to INVALID and incorrectly share a cached context
- **After**: INVALID keys are never used for caching; each request with an INVALID profile gets a fresh context