### PR TITLE
fix: never cache a CCtx under the INVALID profile sentinel (n12)

### DIFF
--- a/ci/tools/test_cctx_profile_pack.c
+++ b/ci/tools/test_cctx_profile_pack.c
@@ -130,6 +130,7 @@ main(void)
             { 0,            -1,  "window_log negative" },
         };
         size_t i;
+        uint64_t key1, key2;
 
         for (i = 0; i < sizeof(bad) / sizeof(bad[0]); i++) {
             key = ngx_http_zstd_profile_pack(bad[i].lvl, 0, bad[i].wlog);
@@ -145,6 +146,31 @@ main(void)
         if (!rc) {
             printf("  => all %zu out-of-domain inputs refused "
                    "(no silent masking)\n", sizeof(bad) / sizeof(bad[0]));
+        }
+
+        /*
+         * Assert that two distinct out-of-domain profiles collapse to the
+         * SAME sentinel: this is the aliasing the cache guard must detect.
+         * Both should pack to INVALID, proving they compare equal, which is
+         * why acquire_cctx must refuse to borrow or seed on INVALID.
+         */
+        key1 = ngx_http_zstd_profile_pack(LEVEL_MIN - 1, 0, 0);
+        key2 = ngx_http_zstd_profile_pack(0, 0, WLOG_MAX + 1);
+        if (key1 != NGX_HTTP_ZSTD_PROFILE_INVALID
+            || key2 != NGX_HTTP_ZSTD_PROFILE_INVALID
+            || key1 != key2)
+        {
+            fprintf(stderr,
+                    "SENTINEL-ALIASING: two distinct out-of-domain profiles "
+                    "did not both collapse to INVALID: "
+                    "key1=%llu key2=%llu INVALID=%llu\n",
+                    (unsigned long long) key1,
+                    (unsigned long long) key2,
+                    (unsigned long long) NGX_HTTP_ZSTD_PROFILE_INVALID);
+            rc = 1;
+        } else {
+            printf("  => distinct out-of-domain profiles alias to INVALID "
+                   "(cache guard must refuse)\n");
         }
     }
 

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -2905,7 +2905,23 @@ ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
             return NGX_ERROR;
         }
 
-        if (free_slot != NULL) {
+        /*
+         * Defense-in-depth: INVALID is never cacheable. Every out-of-domain
+         * input collapses to the same INVALID sentinel, so two profiles that
+         * are in fact different would compare equal and a slot seeded under
+         * one could later be borrowed for the other -- a context built with
+         * the wrong parameters, which changes bytes on the wire.
+         *
+         * Guarding the seed is sufficient to close the borrow too: a slot is
+         * only ever seeded here, so an INVALID key is never written into
+         * slot->profile and can therefore never be matched by the walk above.
+         * Unreachable today (every field is bounded at config load); if a
+         * future directive widens a domain, the cost is one uncached context
+         * per request, and a fresh context is always safe.
+         */
+        if (free_slot != NULL
+            && zlcf_profile.key != NGX_HTTP_ZSTD_PROFILE_INVALID)
+        {
             free_slot->cctx = ctx->cctx;
             ngx_http_zstd_cctx_profile_from_conf_wlog(&free_slot->profile,
                 zlcf, eff_window_log);


### PR DESCRIPTION
Closes issues.md row **n12** [Concurrency, NIT].

## The defect

Every out-of-domain input to `ngx_http_zstd_profile_pack()` collapses to the
same `NGX_HTTP_ZSTD_PROFILE_INVALID` sentinel, so two profiles that differ in
fact compare equal. A slot seeded under one such key could later be borrowed
for the other, handing back a CCtx built with the wrong parameters — which
changes bytes on the wire with no diagnostic.

## The fix

Refuse to seed a slot when the packed key is `INVALID`.

Guarding the **seed alone is sufficient to close the borrow too**: a slot's
profile is only ever written at that one site, so an `INVALID` key never
reaches `slot->profile` and the matching walk can therefore never return it.
This keeps the change to a single condition and leaves the borrow loop
untouched, rather than wrapping the whole walk and reindenting it.

An `INVALID` profile falls back to a fresh, uncached context, which is always
safe — the cost is one cache miss per request.

## Reachability and testing

Unreachable today: every field is bounded at config load. This is
defense-in-depth against a future directive widening a domain, exactly as the
existing "refuse rather than mask" comment on the packer intends.

The unit oracle gains an assertion pinning the **premise** — that two distinct
out-of-domain profiles do both collapse to `INVALID`, which is the aliasing
the guard exists to prevent.

The guard itself is not reachable from any config, so it is deliberately left
without a runtime test rather than faking reachability or gaming the coverage
floor. Mutating it would leave any honest test green; that is a property of
the code being unreachable, not a gap in the suite.

Verified: module compiles clean under `-Werror`; `test_cctx_profile_pack.sh`
passes (16,780,160 tuples swept, 0 collisions).