### PR TITLE
test(probe): wire the PALLOC fault site and cover allocation-failure branches

### DIFF
--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -579,6 +579,17 @@ jobs:
               "$GITHUB_WORKSPACE/ci/t/harness-scenarios/fault-arms" nginx 1.31.4 \
             | tee "$GITHUB_WORKSPACE/vg-fault-arms.log" || rc=1
 
+          # fault-palloc: the pool-allocation failure paths. Worth running
+          # under memcheck specifically -- a request abandoned partway
+          # through its allocations is exactly the shape that strands a
+          # CCtx or leaks a buffer, and no other scenario abandons one.
+          # Same narrow exemption as above: this module's own allocation
+          # diagnostics only, never a valgrind or sanitizer finding.
+          PROBER_ALLOW_LOG='zstd: |ngx_(palloc|pcalloc|pnalloc)' \
+            ./run-scenario.sh \
+              "$GITHUB_WORKSPACE/ci/t/harness-scenarios/fault-palloc" nginx 1.31.4 \
+            | tee "$GITHUB_WORKSPACE/vg-fault-palloc.log" || rc=1
+
           # alloc-neutral: no faults armed, so no log exemption either -- a
           # [crit]/[alert] during it is a real defect and must red the job.
           ./run-scenario.sh \
@@ -586,6 +597,7 @@ jobs:
             | tee "$GITHUB_WORKSPACE/vg-alloc-neutral.log" || rc=1
 
           for log in "$GITHUB_WORKSPACE"/vg-fault-arms.log \
+                     "$GITHUB_WORKSPACE"/vg-fault-palloc.log \
                      "$GITHUB_WORKSPACE"/vg-alloc-neutral.log; do
             if grep -q '^not ok' "$log"; then
               echo "::error::$(basename "$log"): scenario reported a 'not ok' line"
@@ -610,6 +622,7 @@ jobs:
           name: harness-memcheck-tap-logs
           path: |
             vg-fault-arms.log
+            vg-fault-palloc.log
             vg-alloc-neutral.log
           retention-days: 14
           if-no-files-found: ignore

--- a/.github/workflows/harness-fault-arms.yml
+++ b/.github/workflows/harness-fault-arms.yml
@@ -8,6 +8,8 @@ name: Harness Fault Arms
 #                                          CODEC_END), injected via the probe
 #   ci/t/harness-scenarios/alloc-neutral   per-request allocation neutrality
 #                                          (cycle-pool + fd deltas)
+#   ci/t/harness-scenarios/fault-palloc    pool-allocation failure handling
+#                                          (PALLOC fault site, issues.md m8)
 #
 # See plan-testkit-integration.md Phase 4: this is the "real" gate for the
 # codec fault-injection surface Phase 3 wired up -- the testkit-side
@@ -18,7 +20,7 @@ name: Harness Fault Arms
 # its own requires-gate says "a SKIP reads as a pass", and here the .so is
 # our own build product, so the oracle actually runs.
 #
-# The job NAME stays "Harness Fault Arms" even though it now runs two
+# The job NAME stays "Harness Fault Arms" even though it now runs three
 # scenarios: it is a check-name contract (ruleset 16557047 tracking, and the
 # Phase 5 promotion still to come), and renaming a check silently drops
 # whatever was tracking the old name.
@@ -238,6 +240,56 @@ jobs:
             exit 1
           fi
 
+      - name: Run fault-palloc scenario
+        env:
+          PROBER_ROOT: ${{ github.workspace }}
+          PROBER_BUILD: ${{ github.workspace }}/nginx-1.31.4
+          PROBER_MODULE: ngx_http_zstd_filter_module.so
+          PROBER_DIRECTIVE: zstd_probe
+          PROBER_PROBE: "zstd_probe;"
+          # Every oracle in this scenario deliberately fails a pool
+          # allocation, and the module logs those at [crit]/[alert] on its
+          # way to failing the request closed. Without the exemption the
+          # prober's log scrape reds the job for the faults it was asked to
+          # inject -- same reasoning as the fault-arms step above. The
+          # pattern stays narrow: only this module's own allocation
+          # diagnostics, so an unrelated alert still reds the run.
+          PROBER_ALLOW_LOG: 'zstd: |ngx_(palloc|pcalloc|pnalloc)'
+        run: |
+          set -euo pipefail
+          cd ci/t/harness/ci/prober
+          ./run-scenario.sh "$GITHUB_WORKSPACE/ci/t/harness-scenarios/fault-palloc" nginx 1.31.4 \
+            | tee "$GITHUB_WORKSPACE/fault-palloc-tap.log"
+
+          # Same belt-and-braces verdict re-derivation as the steps above.
+          if grep -q '^not ok' "$GITHUB_WORKSPACE/fault-palloc-tap.log"; then
+            echo "::error::fault-palloc scenario reported at least one 'not ok' line"
+            exit 1
+          fi
+
+          # Non-vacuity: if every oracle SKIPped, the run banks a green
+          # having asserted nothing about the allocation-failure surface.
+          TOTAL_OK=$(grep -c '^ok ' "$GITHUB_WORKSPACE/fault-palloc-tap.log" || true)
+          SKIPPED=$(grep -c '^ok .*# SKIP' "$GITHUB_WORKSPACE/fault-palloc-tap.log" || true)
+          if [ "$TOTAL_OK" -gt 0 ] && [ "$TOTAL_OK" -eq "$SKIPPED" ]; then
+            echo "::error::every oracle in fault-palloc SKIPped -- the" \
+              "scenario asserted nothing about pool-allocation failure" \
+              "handling; failing rather than banking a vacuous green"
+            exit 1
+          fi
+
+          # Oracle 2 is the one that proves the PALLOC site is ARMABLE. If it
+          # is missing or skipped, oracles 3 and 4 could both be passing
+          # because the arm was silently declined and the requests failed for
+          # unrelated reasons -- exactly the false green this scenario was
+          # written to close (issues.md m8). Require it to have really run.
+          if ! grep -q '^ok 2 - PALLOC site accepted the arm' "$GITHUB_WORKSPACE/fault-palloc-tap.log"; then
+            echo "::error::oracle 2 (PALLOC site armable, counter advances)" \
+              "did not pass -- without it the fault oracles below cannot be" \
+              "distinguished from a silently-declined arm"
+            exit 1
+          fi
+
       - name: Upload TAP log
         if: always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -246,5 +298,6 @@ jobs:
           path: |
             fault-arms-tap.log
             alloc-neutral-tap.log
+            fault-palloc-tap.log
           retention-days: 14
           if-no-files-found: ignore

--- a/ci/t/harness-scenarios/fault-palloc/driver.sh
+++ b/ci/t/harness-scenarios/fault-palloc/driver.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+#
+# Scenario: POOL-ALLOCATION FAULT INJECTION for ngx_http_zstd_filter_module.so.
+#
+# Reachable only through the harness's TEST_HARNESS build (see the requires
+# gate): the per-request allocation sites in the filter go through the
+# ngx_http_zstd_{palloc,pnalloc,pcalloc,alloc_chain_link,create_temp_buf,
+# list_push,pool_cleanup_add} wrappers, which consult the PALLOC fault site
+# before delegating to the real allocator. Armed via
+# GET /__probe?fault_palloc=<n>: the n-th WRAPPED allocation since the arm
+# returns NULL. Negative disarms.
+#
+# WHY THIS SCENARIO EXISTS. Pool allocation failure is unprovokable in a
+# normal test -- nginx's pool only fails when the OS refuses memory, and an
+# ulimit big enough to force that kills the worker and every other oracle
+# with it. So the NULL-check branch on each of those sites had no test at
+# all: an unchecked NULL, or a half-mutated header list, would stay green
+# forever. That is issues.md row m8.
+#
+# THE ORDINAL -> SITE MAP. Which wrapped allocation a given nth reaches is
+# a property of this request (200 KB, zstd on, default buffer sizing), not a
+# constant of the module. Measured on nginx 1.31.4 by logging __LINE__ at
+# each wrapper call, the 13 wrapped allocations of one such request are:
+#
+#   nth   site                                           bytes on the wire?
+#    1    ctx pcalloc, header filter                     no
+#    2    Content-Encoding ngx_list_push, header filter  no
+#    3    CCtx cleanup ngx_pool_cleanup_add              no
+#    4    incoming-chain link, body filter               no
+#    5    out_buf ngx_create_temp_buf                    no
+#    6-8  incoming-chain link, body filter               no
+#    9    emit chain link                                no
+#   10-12 incoming-chain link, body filter               YES
+#   13    emit chain link                                YES
+#
+# WHERE "COMMITTED" ACTUALLY IS. Note that the boundary is NOT the header
+# filter / body filter split, which is where one would expect it. nginx
+# buffers the response, so ngx_http_send_header() returning does not put
+# bytes on the wire; the status line only reaches the client once enough
+# output has accumulated to flush. Measured on this request that happens
+# between the 9th and 10th wrapped allocation -- so allocations 3..9 are in
+# the body filter yet still fail with nothing delivered, and only 10+ fail
+# with a response already committed.
+#
+# That is why the two oracles below are split at 9/10 rather than at 2/3:
+# the split has to follow the OBSERVABLE (has the client been promised a
+# zstd stream yet?), because that is what decides which behaviour is
+# correct. Splitting it where the code structure suggests would have made
+# oracle 4 assert "200 was on the wire" for four allocations where it never
+# is, and the oracle would have been red for a reason that is not a defect.
+#
+# The oracles aim at 1, 2, 3, 4, 5, 9 (uncommitted; every distinct site) and
+# 10, 13 (committed; the chain-link and emit sites, the only two reachable
+# after the flush). If the ordering ever changes, the counter assertions
+# still hold but an oracle could silently start testing a different site --
+# so each oracle names the site it believes it is hitting, and the mutation
+# testing recorded in the PR is what ties an oracle to its guard.
+#
+# NON-VACUITY DISCIPLINE. Every oracle below asserts the fault ACTUALLY
+# FIRED, not merely that the request misbehaved. A request can fail for
+# reasons unrelated to the arm, and an arm the module silently DECLINEs
+# (which is exactly what this site did before this change) leaves the
+# request succeeding normally. Both would be indistinguishable from a real
+# pass if the oracle only looked at the response. So each oracle checks the
+# probe's palloc_calls counter advanced to the armed ordinal -- the
+# observable that exists only when the wrapper ran and the site was armed.
+set -euo pipefail
+
+# shellcheck source=../../harness/ci/prober/lib.sh
+. "$PROBER_LIB"
+
+HOST=127.0.0.1
+PORT="$PROBER_RESOLVED_PORT"
+ELOG="$PROBER_PREFIX/logs/error.log"
+
+FAILED=0
+
+mkdir -p "$PROBER_PREFIX/www"
+# 200 KB: large enough to need several output buffers and several chain
+# links, which is what puts allocation sites AFTER the header commit on the
+# call sequence at all. A small body commits headers and finishes in one
+# body-filter pass, and oracle 3 would have nothing to aim at.
+head -c 204800 /dev/zero | tr '\0' 'a' >"$PROBER_PREFIX/www/body.bin"
+
+# arm NTH / disarm: GET /__probe?fault_palloc=<nth>. Arming and reading are
+# the same request (see ngx_http_zstd_probe_handler's arm-then-render
+# comment), and arming RESETS the counter, so the counter read must come
+# from a LATER, key-less /__probe request -- never from the arming one.
+arm() {
+    curl -fsS --max-time 5 \
+        "http://$HOST:$PORT/__probe?fault_palloc=${1}" -o /dev/null
+}
+
+disarm() { arm -1; }
+
+# palloc_calls: the module's wrapped-allocation counter, since the arm.
+# A key-less /__probe neither arms nor resets.
+palloc_calls() {
+    curl -fsS --max-time 5 "http://$HOST:$PORT/__probe" \
+        | sed 's/.*"palloc_calls":\([0-9]*\).*/\1/'
+}
+
+# fetch: bounded GET of the compressible body. Headers to $2.hdrs, body to
+# $2, curl's own diagnostic to $2.stderr. Returns curl's exit status --
+# which matters here: the two failure classes this scenario separates are
+# distinguished precisely by whether any response line was written before
+# the connection went away.
+fetch() {
+    curl -sS --max-time 10 -D "$2.hdrs" -o "$2" \
+        -H 'Accept-Encoding: zstd' \
+        "http://$HOST:$PORT$1" 2>"$2.stderr"
+}
+
+# --- oracle plan --------------------------------------------------------
+# 1  warm-up: a plain compressing request serves 200 (readiness), and
+#    establishes how many wrapped allocations one such request makes
+# 2  the PALLOC site is ARMABLE at all -- the counter advances. Before this
+#    change fault_set_global returned NGX_DECLINED for PALLOC, so this
+#    oracle is the one that fails outright on the old module
+# 3  BEFORE anything is committed to the wire (nth=1 ctx pcalloc, 2
+#    Content-Encoding list_push, 3 cleanup_add, 4 chain link, 5 out_buf,
+#    9 emit chain link -- every distinct site on the uncommitted side): the
+#    request fails closed with NO response line at all
+# 4  AFTER the response is committed (nth=10 chain link, 13 emit chain
+#    link): the 200 and Content-Encoding: zstd ARE on the wire, and then the
+#    connection is torn down mid-body rather than completing a truncated or
+#    corrupt zstd stream. Completing the response is the defect this oracle
+#    exists to catch
+# 5  the fault is one-shot and per-arm: after disarming, a compressing
+#    request serves a clean 200 again
+# 6  an out-of-range nth is REFUSED rather than stored as an arm that can
+#    never fire (the codec ZERO_BASE encoding does not apply to this site).
+#    Observed via the counter, not the HTTP status -- see the oracle
+# 7  no worker died by signal across the whole run
+echo "1..7"
+
+# --- 1: warm-up + establish the wrapped-allocation count ------------------
+disarm || true
+WARM="$PROBER_PREFIX/warm.out"
+BASE_CALLS=0
+if fetch /body.bin "$WARM" && grep -q '^HTTP/1.1 200' "$WARM.hdrs"; then
+    BASE_CALLS=$(palloc_calls)
+    if [ "${BASE_CALLS:-0}" -gt 0 ]; then
+        echo "ok 1 - warm-up served a clean 200 and made $BASE_CALLS wrapped pool allocations"
+    else
+        echo "not ok 1 - warm-up served 200 but the module reported ZERO wrapped allocations (palloc_calls=$BASE_CALLS) -- the wrappers are not on the request path, so every oracle below would assert nothing"
+        FAILED=$((FAILED + 1))
+    fi
+else
+    echo "not ok 1 - warm-up request did not serve a clean 200"
+    FAILED=$((FAILED + 1))
+fi
+
+# --- 2: the PALLOC site is armable ----------------------------------------
+#
+# THE load-bearing non-vacuity oracle. fault_set_global used to answer
+# NGX_DECLINED for NGX_TEST_PROBE_FAULT_PALLOC, which the testkit reports as
+# "no hook at all": the arm silently did nothing and every request stayed
+# normal. Asserting the counter advances to exactly the armed ordinal proves
+# the arm was accepted AND that the wrapper consulted the site.
+if arm 3; then
+    fetch /body.bin "$PROBER_PREFIX/arm.out" || true
+    SEEN=$(palloc_calls)
+    if [ "${SEEN:-0}" -ge 3 ]; then
+        echo "ok 2 - PALLOC site accepted the arm and the wrapped-allocation counter advanced (palloc_calls=$SEEN)"
+    else
+        echo "not ok 2 - PALLOC arm did not take effect (palloc_calls=$SEEN after arming nth=3) -- the site is refusing the arm, so no fault below can fire"
+        FAILED=$((FAILED + 1))
+    fi
+else
+    echo "not ok 2 - /__probe refused the fault_palloc arm outright"
+    FAILED=$((FAILED + 1))
+fi
+disarm || true
+
+# --- 3: allocation failure BEFORE anything is committed -------------------
+#
+# Every distinct site on the uncommitted side of the flush boundary: nth=1
+# ctx pcalloc and nth=2 Content-Encoding ngx_list_push (header filter),
+# nth=3 CCtx cleanup_add, nth=4 incoming-chain link, nth=5 out_buf temp
+# buffer, nth=9 emit chain link (body filter, but still before the response
+# flushes -- see the map above). In all of these the client has been
+# promised nothing yet, so the correct outcome is fail-closed with nothing
+# on the wire: NGX_ERROR finalizes the request and no status line is ever
+# produced.
+#
+# nth=2 matters on its own. A half-mutated header list -- the push
+# succeeding but its fields left unset, or the failure ignored -- is one of
+# the concrete regressions this row was filed about, and it is invisible
+# unless the allocation can actually be failed there.
+#
+# The counter check is what makes this non-vacuous: "no response line" is
+# also what a dead worker or a wedged port produces, and neither has
+# anything to do with the arm.
+PRE_FAILED=0
+PRE_DETAIL=""
+for n in 1 2 3 4 5 9; do
+    OUT="$PROBER_PREFIX/precommit.$n"
+    rm -f "$OUT" "$OUT.hdrs"
+    armed=0
+    st=1
+    if arm "$n"; then
+        armed=1
+        fetch /body.bin "$OUT" && st=0 || st=$?
+    fi
+    calls=$(palloc_calls)
+    line=$(head -1 "$OUT.hdrs" 2>/dev/null | tr -d '\r' || true)
+    if [ "$armed" -eq 1 ] && [ "${calls:-0}" -ge "$n" ] \
+       && [ "$st" -ne 0 ] && [ -z "$line" ]
+    then
+        PRE_DETAIL="$PRE_DETAIL nth=$n(rc=$st,calls=$calls,ok)"
+    else
+        PRE_DETAIL="$PRE_DETAIL nth=$n(armed=$armed,calls=$calls,rc=$st,line='$line',BAD)"
+        PRE_FAILED=1
+    fi
+    disarm || true
+done
+if [ "$PRE_FAILED" -eq 0 ]; then
+    echo "ok 3 - allocation failure before the response is committed failed closed with no response line at all:$PRE_DETAIL"
+else
+    echo "not ok 3 - an uncommitted-side allocation failure did not fail closed as expected:$PRE_DETAIL"
+    FAILED=$((FAILED + 1))
+fi
+
+# --- 4: allocation failure AFTER the response is committed ----------------
+#
+# The two distinct sites reachable past the flush boundary: nth=10 an
+# incoming-chain link and nth=13 an emit chain link. By this point "200 OK"
+# and "Content-Encoding: zstd" really are on the wire, so it CANNOT be
+# retracted
+# -- the client has been promised a zstd stream. The only correct behaviour
+# left is to abort the connection, so the client sees a truncated transfer
+# (a hard, detectable error) instead of a complete-looking body that is not
+# a valid zstd frame.
+#
+# So this oracle asserts BOTH halves: the 200 really was committed, AND the
+# transfer did not complete. Asserting only the second half would also pass
+# for a request that failed before ever sending headers -- that is oracle
+# 3's case, a different branch, and conflating the two would let a
+# regression in either one hide behind the other.
+POST_FAILED=0
+POST_DETAIL=""
+for n in 10 13; do
+    OUT="$PROBER_PREFIX/postcommit.$n"
+    rm -f "$OUT" "$OUT.hdrs"
+    armed=0
+    st=1
+    if arm "$n"; then
+        armed=1
+        fetch /body.bin "$OUT" && st=0 || st=$?
+    fi
+    calls=$(palloc_calls)
+    got200=0
+    gotce=0
+    grep -q '^HTTP/1.1 200' "$OUT.hdrs" 2>/dev/null && got200=1
+    grep -qi '^Content-Encoding: *zstd' "$OUT.hdrs" 2>/dev/null && gotce=1
+    if [ "$armed" -eq 1 ] && [ "${calls:-0}" -ge "$n" ] \
+       && [ "$got200" -eq 1 ] && [ "$gotce" -eq 1 ] && [ "$st" -ne 0 ]
+    then
+        POST_DETAIL="$POST_DETAIL nth=$n(rc=$st,calls=$calls,ok)"
+    else
+        POST_DETAIL="$POST_DETAIL nth=$n(armed=$armed,calls=$calls,200=$got200,ce=$gotce,rc=$st,BAD)"
+        POST_FAILED=1
+    fi
+    disarm || true
+done
+if [ "$POST_FAILED" -eq 0 ]; then
+    echo "ok 4 - allocation failure after the response is committed aborted the connection mid-body instead of completing a corrupt zstd stream:$POST_DETAIL"
+else
+    echo "not ok 4 - a post-commit allocation failure did not abort as expected (a completed transfer here means a truncated body was served as if valid):$POST_DETAIL"
+    FAILED=$((FAILED + 1))
+fi
+
+# --- 5: disarming restores normal service ---------------------------------
+CLEAN="$PROBER_PREFIX/clean.out"
+if fetch /body.bin "$CLEAN" && grep -q '^HTTP/1.1 200' "$CLEAN.hdrs"; then
+    echo "ok 5 - after disarming, a compressing request serves a clean 200 again (fault state is per-arm, not sticky)"
+else
+    echo "not ok 5 - a disarmed request did not serve a clean 200 -- fault state leaked past the arm"
+    FAILED=$((FAILED + 1))
+fi
+
+# --- 6: an out-of-range nth is refused, not stored -------------------------
+#
+# 1000+ is the codec site's ZERO-outcome encoding and means nothing here.
+# Storing it would arm allocation call 1000+, which no request ever reaches:
+# the arm would look accepted and never fire, which is exactly the
+# false-green class this surface exists to prevent.
+#
+# HOW REFUSAL IS OBSERVED. Not by HTTP status -- ngx_http_zstd_probe_handler
+# discards ngx_test_probe_arm()'s return value on purpose (it renders the
+# post-arm state either way), so a declined arm still answers 200 and
+# `curl -f` cannot see it. The observable that DOES differ is the counter:
+# accepting an arm resets palloc_calls to 0, refusing it leaves the counter
+# untouched. So drive the counter to a known non-zero value first, then
+# offer the bad arm and require the counter to have survived.
+disarm || true
+fetch /body.bin "$PROBER_PREFIX/pre-range.out" || true
+BEFORE_BAD=$(palloc_calls)
+arm 1001 || true
+AFTER_BAD=$(palloc_calls)
+if [ "${BEFORE_BAD:-0}" -gt 0 ] && [ "${AFTER_BAD:-0}" -eq "${BEFORE_BAD:-0}" ]; then
+    echo "ok 6 - fault_palloc=1001 (out of this site's range) was refused, not stored: the counter was left untouched at $AFTER_BAD"
+elif [ "${BEFORE_BAD:-0}" -le 0 ]; then
+    echo "not ok 6 - could not establish a non-zero counter before offering the out-of-range arm (palloc_calls=$BEFORE_BAD), so refusal is unobservable and this oracle would assert nothing"
+    FAILED=$((FAILED + 1))
+else
+    echo "not ok 6 - fault_palloc=1001 was ACCEPTED (counter reset $BEFORE_BAD -> $AFTER_BAD); the codec ZERO_BASE encoding does not apply to this site and storing it arms a call no request ever reaches"
+    FAILED=$((FAILED + 1))
+fi
+disarm || true
+
+# --- 7: no worker died by signal -------------------------------------------
+#
+# Every oracle above deliberately makes an allocation fail. If any of those
+# branches dereferenced the NULL instead of handling it, the worker would
+# have taken a SIGSEGV -- and oracles 3 and 4 would still have "passed",
+# because a crashed worker also produces a torn-down connection. This is the
+# oracle that separates "handled the failure" from "crashed on it".
+if grep -qE 'worker process .* exited on signal|SIGSEGV|SIGABRT|SIGBUS' "$ELOG"; then
+    echo "not ok 7 - a worker died by signal -- an allocation-failure branch dereferenced NULL rather than handling it"
+    grep -nE 'exited on signal|SIGSEGV|SIGABRT|SIGBUS' "$ELOG" | sed 's/^/# /'
+    FAILED=$((FAILED + 1))
+else
+    echo "ok 7 - no worker died by signal across the whole allocation-fault run"
+fi
+
+if [ "$FAILED" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/ci/t/harness-scenarios/fault-palloc/nginx.conf
+++ b/ci/t/harness-scenarios/fault-palloc/nginx.conf
@@ -1,0 +1,25 @@
+@LOAD@
+# Local scenario (NOT vendored, NOT gitignored): unlike testkit's
+# consumer-zstd, this repo IS the module under test, so PROBER_MODULE is
+# ngx_http_zstd_filter_module.so itself -- @LOAD@ already load_modules it,
+# there is no separate probe .so to add. No requires-gate skip-forever
+# hazard either. See plan-testkit-integration.md Phase 4.
+daemon off;
+pid @PREFIX@/nginx.pid;
+error_log @PREFIX@/logs/error.log info;
+worker_processes 1;
+events { worker_connections 16; }
+http {
+    server {
+        listen 127.0.0.1:@PORT@;
+
+        root @PREFIX@/www;
+
+        location / {
+            zstd on;
+            zstd_min_length 0;
+        }
+
+        location /__probe { @PROBE@ }
+    }
+}

--- a/ci/t/harness-scenarios/fault-palloc/requires
+++ b/ci/t/harness-scenarios/fault-palloc/requires
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Gate: the tree run-scenario.sh is about to boot must be a TEST_HARNESS
+# build -- the probe endpoint and the pool-allocation fault site compile
+# out entirely otherwise (plan-testkit-integration.md Ground truth: without
+# both TEST_HARNESS=1 and -DNGX_TEST_HARNESS, the module builds and answers,
+# but every fault-injection oracle here would pass by testing nothing).
+#
+# Checked the same way run-scenario.sh/lib.sh resolve the build tree, so this
+# gate can never SKIP a tree the engine would boot fine or pass one it would
+# reject -- see consumer-zstd/requires's identical reasoning for why the
+# derivation must match lib.sh exactly.
+set -euo pipefail
+
+FLAVOR="${2:-nginx}"
+VERSION="${3:-1.31.3}"
+BUILD="${PROBER_BUILD:-${PROBER_ROOT:-$(cd ../.. && pwd)}/.build/${FLAVOR}-${VERSION}}"
+SO="$BUILD/objs/ngx_http_zstd_filter_module.so"
+
+if [ ! -f "$SO" ]; then
+    echo "ngx_http_zstd_filter_module.so not found at $SO -- build it first"
+    exit 1
+fi
+
+if ! nm "$SO" 2>/dev/null | grep -q ' ngx_test_probe_'; then
+    echo "$SO carries no ngx_test_probe_* symbols -- this is a packaged (non-harness) build; configure with TEST_HARNESS=1 CFLAGS=\"\$CFLAGS -DNGX_TEST_HARNESS\" first (see plan-testkit-integration.md Ground truth)"
+    exit 1
+fi
+
+exit 0

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -23,6 +23,70 @@
 
 
 /*
+ * Pool-allocation wrappers for the per-REQUEST allocation sites in this
+ * file (the ones reached while serving a compressed response). They exist
+ * solely so a test can fail one chosen allocation and assert that the
+ * branch handling it is correct; see ngx_http_zstd_probe_hooks.h's
+ * fault_palloc block for the arming contract and the counting rules.
+ *
+ * COST IN A PACKAGED BUILD IS EXACTLY ZERO -- not "one predictable
+ * branch", zero. Without NGX_TEST_HARNESS each macro expands to the bare
+ * allocator call it wraps, so the preprocessor leaves the identical token
+ * sequence the code had before the wrappers existed and the compiler sees
+ * no fault site at all. That is why these are macros and not functions
+ * with an internal guard: a function would still be a call the optimizer
+ * has to reason about, and the hot path must not pay for a test feature.
+ *
+ * There is no ngx_http_zstd_palloc(): every raw ngx_palloc() in this file
+ * is a cf->pool call, and those are deliberately not wrapped (below). A
+ * wrapper nothing calls would be dead code that looks like coverage.
+ *
+ * CONFIG-TIME sites (cf->pool) are deliberately NOT wrapped. They run once
+ * at startup, their failure mode is "nginx refuses to start" rather than a
+ * mid-request branch, and arming a fault that fires during configuration
+ * would break the probe endpoint itself before any test could use it.
+ */
+#ifdef NGX_TEST_HARNESS
+
+#define ngx_http_zstd_pnalloc(pool, size)                                    \
+    (ngx_http_zstd_probe_palloc_should_fail()                                \
+        ? NULL : ngx_pnalloc(pool, size))
+
+#define ngx_http_zstd_pcalloc(pool, size)                                    \
+    (ngx_http_zstd_probe_palloc_should_fail()                                \
+        ? NULL : ngx_pcalloc(pool, size))
+
+#define ngx_http_zstd_alloc_chain_link(pool)                                 \
+    (ngx_http_zstd_probe_palloc_should_fail()                                \
+        ? NULL : ngx_alloc_chain_link(pool))
+
+#define ngx_http_zstd_create_temp_buf(pool, size)                            \
+    (ngx_http_zstd_probe_palloc_should_fail()                                \
+        ? NULL : ngx_create_temp_buf(pool, size))
+
+#define ngx_http_zstd_list_push(list)                                        \
+    (ngx_http_zstd_probe_palloc_should_fail()                                \
+        ? NULL : ngx_list_push(list))
+
+#define ngx_http_zstd_pool_cleanup_add(pool, size)                           \
+    (ngx_http_zstd_probe_palloc_should_fail()                                \
+        ? NULL : ngx_pool_cleanup_add(pool, size))
+
+#else
+
+#define ngx_http_zstd_pnalloc(pool, size)         ngx_pnalloc(pool, size)
+#define ngx_http_zstd_pcalloc(pool, size)         ngx_pcalloc(pool, size)
+#define ngx_http_zstd_alloc_chain_link(pool)      ngx_alloc_chain_link(pool)
+#define ngx_http_zstd_create_temp_buf(pool, size)                            \
+    ngx_create_temp_buf(pool, size)
+#define ngx_http_zstd_list_push(list)             ngx_list_push(list)
+#define ngx_http_zstd_pool_cleanup_add(pool, size)                            \
+    ngx_pool_cleanup_add(pool, size)
+
+#endif
+
+
+/*
  * Compute the ceiling of log₂(x) for a size_t value: the minimum k such that
  * 2^k >= x. Used for window-log sizing in dcz frame setup, where we must fit
  * a dictionary and expected content within a power-of-two decompression window.
@@ -1323,7 +1387,7 @@ ngx_http_zstd_header_filter(ngx_http_request_t *r)
     if (zlcf->bypass_vary.len) {
         ngx_table_elt_t  *v;
 
-        v = ngx_list_push(&r->headers_out.headers);
+        v = ngx_http_zstd_list_push(&r->headers_out.headers);
         if (v == NULL) {
             return NGX_ERROR;
         }
@@ -1442,7 +1506,7 @@ ngx_http_zstd_header_filter(ngx_http_request_t *r)
         return ngx_http_next_header_filter(r);
     }
 
-    ctx = ngx_pcalloc(r->pool, sizeof(ngx_http_zstd_ctx_t));
+    ctx = ngx_http_zstd_pcalloc(r->pool, sizeof(ngx_http_zstd_ctx_t));
     if (ctx == NULL) {
         return NGX_ERROR;
     }
@@ -1453,7 +1517,7 @@ ngx_http_zstd_header_filter(ngx_http_request_t *r)
     ctx->last_in  = &ctx->in;
     ctx->dcz_dict = dcz;
 
-    h = ngx_list_push(&r->headers_out.headers);
+    h = ngx_http_zstd_list_push(&r->headers_out.headers);
     if (h == NULL) {
         return NGX_ERROR;
     }
@@ -1943,7 +2007,7 @@ ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
          * tail cannot go stale between calls.
          */
         for (cl = in; cl; cl = cl->next) {
-            link = ngx_alloc_chain_link(r->pool);
+            link = ngx_http_zstd_alloc_chain_link(r->pool);
             if (link == NULL) {
                 goto failed;
             }
@@ -2401,7 +2465,7 @@ ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
         return NGX_AGAIN;
     }
 
-    cl = ngx_alloc_chain_link(r->pool);
+    cl = ngx_http_zstd_alloc_chain_link(r->pool);
     if (cl == NULL) {
         return NGX_ERROR;
     }
@@ -2683,7 +2747,7 @@ ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
             buf_size += NGX_HTTP_ZSTD_DCZ_HEADER_LEN;
         }
 
-        ctx->out_buf = ngx_create_temp_buf(r->pool, buf_size);
+        ctx->out_buf = ngx_http_zstd_create_temp_buf(r->pool, buf_size);
         if (ctx->out_buf == NULL) {
             return NGX_ERROR;
         }
@@ -2812,7 +2876,7 @@ ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
      * borrowed context can never be stranded with busy set: an allocation
      * failure here happens while the cache is still untouched.
      */
-    cln = ngx_pool_cleanup_add(r->pool, 0);
+    cln = ngx_http_zstd_pool_cleanup_add(r->pool, 0);
     if (cln == NULL) {
         return NGX_ERROR;
     }
@@ -4961,7 +5025,7 @@ ngx_http_zstd_ratio_variable(ngx_http_request_t *r,
     }
 
     /* Two ngx_uint_t values (up to NGX_INT_T_LEN digits each) + '.' + '\0' */
-    vv->data = ngx_pnalloc(r->pool, NGX_INT_T_LEN * 2 + 2);
+    vv->data = ngx_http_zstd_pnalloc(r->pool, NGX_INT_T_LEN * 2 + 2);
     if (vv->data == NULL) {
         return NGX_ERROR;
     }
@@ -5016,7 +5080,7 @@ ngx_http_zstd_bytes_variable(ngx_http_request_t *r,
 
     value = *(uint64_t *) ((char *) ctx + data);
 
-    vv->data = ngx_pnalloc(r->pool, NGX_INT64_LEN);
+    vv->data = ngx_http_zstd_pnalloc(r->pool, NGX_INT64_LEN);
     if (vv->data == NULL) {
         return NGX_ERROR;
     }

--- a/src/ngx_http_zstd_probe_hooks.c
+++ b/src/ngx_http_zstd_probe_hooks.c
@@ -93,6 +93,15 @@ static ngx_int_t  ngx_http_zstd_probe_fault_codec_end_nth = -1;
 static ngx_uint_t  ngx_http_zstd_probe_codec_calls;
 static ngx_uint_t  ngx_http_zstd_probe_codec_end_calls;
 
+/*
+ * Pool-allocation fault site. Same shape and same arm-relative counting as
+ * the codec sites above; see the header for why the nth is a bare ordinal
+ * here (an allocation has no outcome to encode -- it succeeds or it does
+ * not) and for the "only wrapped sites count" caveat.
+ */
+static ngx_int_t   ngx_http_zstd_probe_fault_palloc_nth = -1;
+static ngx_uint_t  ngx_http_zstd_probe_palloc_calls;
+
 static ngx_int_t ngx_http_zstd_probe_handler(ngx_http_request_t *r);
 
 
@@ -180,6 +189,50 @@ ngx_http_zstd_probe_codec_fault(ngx_uint_t is_end)
 
 
 /*
+ * Pool-allocation fault decision, called once per WRAPPED allocation,
+ * immediately before the real allocator runs. Advances this site's
+ * arm-relative counter and reports whether THIS call is the armed nth.
+ *
+ * One-shot by construction (`==`, not `>=`), so a test arming nth=1 fails
+ * exactly one allocation and every later allocation in the same request --
+ * including the ones nginx core makes to build the error response -- is
+ * unarmed again. That matters: failing *every* allocation after the first
+ * would take down the error path too and the test could not tell a handled
+ * failure from a dead worker.
+ *
+ * Unarmed cost is one increment and one perfectly-predicted compare, and
+ * the whole function does not exist in a build without NGX_TEST_HARNESS.
+ */
+ngx_uint_t
+ngx_http_zstd_probe_palloc_should_fail(void)
+{
+    ngx_uint_t  seq;
+
+    seq = ++ngx_http_zstd_probe_palloc_calls;
+
+    if (ngx_http_zstd_probe_fault_palloc_nth < 0) {
+        return 0;
+    }
+
+    return (ngx_uint_t) ngx_http_zstd_probe_fault_palloc_nth == seq;
+}
+
+
+/*
+ * Wrapped-allocation count since the site was last armed or disarmed.
+ * Rendered at /__probe so a test can assert the counter ADVANCED, rather
+ * than inferring from a failed request that the fault must have fired --
+ * a request can fail for reasons that have nothing to do with the arm, and
+ * an oracle that cannot tell those apart asserts nothing.
+ */
+ngx_uint_t
+ngx_http_zstd_probe_palloc_count(void)
+{
+    return ngx_http_zstd_probe_palloc_calls;
+}
+
+
+/*
  * module_render hook: append this module's zone-independent counters to
  * the top-level "module" object. ngx_test_probe_render_module() has
  * already written the opening `,"module":{` before calling this hook, so
@@ -191,9 +244,11 @@ ngx_http_zstd_probe_module_render(u_char *buf, u_char *last)
 {
     buf = ngx_slprintf(buf, last,
                         "\"chain_links_allocated\":%ui"
-                        ",\"buffers_allocated\":%ui",
+                        ",\"buffers_allocated\":%ui"
+                        ",\"palloc_calls\":%ui",
                         ngx_http_zstd_probe_chain_links,
-                        ngx_http_zstd_probe_bufs_allocated);
+                        ngx_http_zstd_probe_bufs_allocated,
+                        ngx_http_zstd_probe_palloc_calls);
 
     if (ngx_http_zstd_probe_have_ctx) {
         buf = ngx_slprintf(buf, last,
@@ -225,10 +280,12 @@ ngx_http_zstd_probe_module_render(u_char *buf, u_char *last)
  * something that can never fire and pass by testing nothing -- the same
  * false-green class the arm-relative counter exists to prevent.
  *
- * Applied per codec site rather than up front: SLAB/PALLOC/TEMPFILE/ACCEPT
- * decline because the SITE is unimplemented here, which is true whatever
- * nth says, and conflating the two would answer the wrong question for
- * them even though both answers happen to be NGX_DECLINED.
+ * Applied per site rather than up front: SLAB/TEMPFILE/ACCEPT decline
+ * because the SITE is unimplemented here, which is true whatever nth says,
+ * and conflating the two would answer the wrong question for them even
+ * though both answers happen to be NGX_DECLINED. The PALLOC site uses this
+ * helper too, but narrows it further -- see its arm, which rejects the
+ * codec-only ZERO_BASE range.
  */
 static ngx_int_t
 ngx_http_zstd_probe_nth_is_valid(ngx_int_t nth)
@@ -252,8 +309,8 @@ ngx_http_zstd_probe_nth_is_valid(ngx_int_t nth)
 
 
 /*
- * fault_set_global hook: zstd wires no SLAB/PALLOC/TEMPFILE/ACCEPT
- * injection points -- decline those. CODEC/CODEC_END are stored raw,
+ * fault_set_global hook: zstd wires no SLAB/TEMPFILE/ACCEPT injection
+ * points -- decline those. CODEC/CODEC_END are stored raw,
  * outcome encoding and all; ngx_http_zstd_probe_codec_fault() decodes
  * them at the single ZSTD_compressStream2 call site in the filter.
  *
@@ -294,8 +351,24 @@ ngx_http_zstd_probe_fault_set_global(ngx_test_probe_fault_e fault,
         ngx_http_zstd_probe_codec_end_calls = 0;
         return NGX_OK;
 
-    case NGX_TEST_PROBE_FAULT_SLAB:
     case NGX_TEST_PROBE_FAULT_PALLOC:
+        /*
+         * Bare ordinal, so only the plain 1..999 form (and negatives) is
+         * accepted -- the ZERO_BASE encoding is codec-specific and an nth
+         * in that range here would arm call 1000+, which no request ever
+         * reaches. Refusing beats storing an arm that can never fire.
+         */
+        if (nth >= NGX_HTTP_ZSTD_PROBE_FAULT_ZERO_BASE
+            || !ngx_http_zstd_probe_nth_is_valid(nth))
+        {
+            return NGX_DECLINED;
+        }
+
+        ngx_http_zstd_probe_fault_palloc_nth = nth;
+        ngx_http_zstd_probe_palloc_calls = 0;
+        return NGX_OK;
+
+    case NGX_TEST_PROBE_FAULT_SLAB:
     case NGX_TEST_PROBE_FAULT_TEMPFILE:
     case NGX_TEST_PROBE_FAULT_ACCEPT:
     default:

--- a/src/ngx_http_zstd_probe_hooks.h
+++ b/src/ngx_http_zstd_probe_hooks.h
@@ -147,6 +147,47 @@ typedef enum {
 ngx_http_zstd_probe_codec_outcome_e
     ngx_http_zstd_probe_codec_fault(ngx_uint_t is_end);
 
+
+/*
+ * Pool-allocation fault injection.
+ *
+ * Armed with GET /__probe?fault_palloc=<nth>: the nth pool allocation the
+ * filter makes THROUGH THE WRAPPERS in the filter TU, counted from the arm,
+ * returns NULL instead of memory. Negative disarms. Unlike the codec site
+ * there is no outcome encoding -- an allocation either succeeds or returns
+ * NULL -- so `nth` carries only the ordinal and the valid set is 1..999
+ * plus negatives.
+ *
+ * WHY A MODULE-LOCAL WRAPPER AND NOT A REAL POOL FAILURE. nginx's pool
+ * allocator only fails when the OS refuses memory, which a test cannot
+ * provoke without an ulimit/cgroup that would take the whole worker down
+ * (and with it every oracle in the run). The wrapper narrows the failure to
+ * exactly one call, at exactly one site, leaving the rest of the request
+ * intact -- which is the only way an "allocation failed HERE" branch can be
+ * asserted individually.
+ *
+ * COUNTING IS FROM THE ARM, for the same reason the codec counter is: an
+ * absolute counter makes a low nth unreachable after any earlier traffic,
+ * and an arm that can never fire is a false green (see the codec counter's
+ * comment for the full argument).
+ *
+ * IMPORTANT -- only wrapped call sites are counted. A pool allocation the
+ * filter makes by calling ngx_palloc() directly is invisible to both the
+ * counter and the fault, so `nth` means "the nth WRAPPED allocation", not
+ * "the nth allocation". Which ordinal reaches which site is therefore a
+ * property of the request, not a constant; ci/t/harness-scenarios/
+ * fault-palloc/driver.sh documents the map it relies on and asserts the
+ * counter advanced, so a change in that order fails the oracle loudly
+ * instead of silently aiming it at a different site.
+ *
+ * ngx_http_zstd_probe_palloc_count() exposes the counter so a test can
+ * assert it actually advanced, which is what distinguishes "the fault fired
+ * and the branch handled it" from "the arm was silently refused and the
+ * request failed for some unrelated reason".
+ */
+ngx_uint_t ngx_http_zstd_probe_palloc_should_fail(void);
+ngx_uint_t ngx_http_zstd_probe_palloc_count(void);
+
 #endif /* NGX_TEST_HARNESS */
 
 #endif /* NGX_HTTP_ZSTD_PROBE_HOOKS_H_INCLUDED_ */


### PR DESCRIPTION
> Closes issues.md row m8 [Tests]. Implements the PALLOC fault site only — SLAB, TEMPFILE and ACCEPT keep declining exactly as they do today.

## TL;DR

When a web server runs out of memory mid-request, the code has to notice and back out cleanly. Every one of those "did that fail?" checks in this module was untested, because the only way to make memory run out was to starve the whole process — which kills the test along with everything else, so the checks could have rotted at any point and every test would still have passed. This adds a switch that fails one chosen allocation on one chosen request and leaves everything else alone, plus a scenario that uses it to prove each check works.

Concretely: `ngx_http_zstd_probe_palloc_should_fail()` backs seven `ngx_http_zstd_*` allocation macros wrapping the nine per-request allocation sites in the filter, armed with `GET /__probe?fault_palloc=<nth>`.

**Severity:** `Low` (`test coverage — no production behaviour changes`)

## Why this was untestable

`ngx_palloc()` and friends only return NULL when the OS refuses memory. Provoking that needs an ulimit or cgroup tight enough to starve the worker, which takes down the probe endpoint and every other oracle in the run — so the failure can be caused but not *observed*. The wrapper narrows it to exactly one call at exactly one site, so the rest of the request stays intact and the branch can be asserted on its own.

## What changed

**Probe hooks.** `ngx_http_zstd_probe_palloc_should_fail()` / `_count()`, following the `FAULT_CODEC` idiom directly above them: `nth` validated before it is stored, a dedicated `_nth` global, and a `_calls` counter zeroed on every arm so `nth` counts from the arm rather than from process start. `fault_set_global` now accepts `NGX_TEST_PROBE_FAULT_PALLOC`, and the probe document renders `palloc_calls`.

The site narrows the shared `nth` validator further: it rejects the codec-only `ZERO_BASE` range (1000+), which would otherwise be stored as an arm on allocation call 1000 — a call no request ever reaches, so the arm would look accepted and silently never fire.

**Filter.** Seven wrapper macros over the nine per-request sites:

| wrapped | site |
|---|---|
| `_pcalloc` | request ctx, header filter |
| `_list_push` | `Content-Encoding` and `zstd_bypass_vary` header pushes |
| `_pool_cleanup_add` | CCtx cleanup registration |
| `_alloc_chain_link` | incoming-chain append, and the emit link |
| `_create_temp_buf` | `ctx->out_buf` |
| `_pnalloc` | the two variable handlers (`$zstd_ratio`, the uint64 pair) |

Config-time (`cf->pool`) sites are deliberately **not** wrapped: they fail at startup rather than mid-request, and a fault firing during configuration would break the probe endpoint before a test could use it. There is deliberately no `ngx_http_zstd_palloc()` — every raw `ngx_palloc()` left in the file is a `cf->pool` call.

**All nine request-path sites already checked their result for NULL.** No unchecked allocation was found.

## Zero cost in a packaged build — verified, not asserted

Without `NGX_TEST_HARNESS` each wrapper is a macro expanding to the bare allocator call, so the preprocessor emits the same token sequence the code had before. They are macros rather than functions for exactly this reason: a function would still be a call the optimizer has to reason about.

Checked by building the same object from this branch and from `master`:

```
cmp .build/nginx-1.31.4/objs/addon/src/ngx_http_zstd_filter_module.o  /tmp/before.o
# byte-identical, 258416 bytes
```

## The two failure classes, split at the observable

The row asks for coverage before and after the headers commit. The boundary is **not** the header-filter/body-filter split, which is where I expected it: nginx buffers the response, so `ngx_http_send_header()` returning does not put bytes on the wire. Measured on this scenario's request, the status line reaches the client between the 9th and 10th wrapped allocation — so allocations 3 through 9 are already in the body filter and still fail with nothing delivered.

That is why the oracles split at 9/10. The split has to follow what the client can observe, because that is what decides which behaviour is correct:

* **before** — nothing has been promised, so the request must fail closed with no response line at all (`curl` rc 52)
* **after** — the client has been promised a zstd stream, so the connection must be torn down mid-body rather than complete a truncated frame that looks valid (`curl` rc 18, after a real `200` and `Content-Encoding: zstd`)

`driver.sh` documents the full ordinal-to-site map it relies on.

## Non-vacuity

Every oracle asserts `palloc_calls` advanced, not merely that the request misbehaved. Before this change the site answered `NGX_DECLINED`, so an arm did nothing and the request stayed perfectly normal — and "the request failed" is also what a dead worker or a wedged port produces. A response-only oracle cannot tell any of those from a real pass. The CI step additionally requires oracle 2 (`PALLOC site accepted the arm`) to be present and passing, so the fault oracles can never be read as green off a silently-declined arm.

## Testing

New scenario `ci/t/harness-scenarios/fault-palloc`, run by the existing **Harness Fault Arms** job and added to the `ci-deep` Valgrind memcheck sweep — a request abandoned partway through its allocations is exactly the shape that strands a CCtx, and no other scenario abandons one.

Locally against a `TEST_HARNESS=1 -DNGX_TEST_HARNESS` nginx 1.31.4 tree: **7/7 green**, and the existing `fault-arms` scenario still **8/8** (no regression).

Mutation-tested — compiling out the NULL check at each guarded site, rebuilding, and rerunning:

| mutation | result |
|---|---|
| `if (0 && ctx == NULL)` | RED — oracle 3 `nth=1`, + worker SIGSEGV on oracle 7 |
| `if (0 && h == NULL)` | RED — oracle 3 `nth=2`, + SIGSEGV |
| `if (0 && cln == NULL)` | RED — oracles 2 and 3 `nth=3`, + SIGSEGV |
| `if (0 && link == NULL)` | RED — oracles 3 and 4, + SIGSEGV |
| `if (0 && ctx->out_buf == NULL)` | RED — oracle 3 `nth=5`, + SIGSEGV |
| `if (0 && cl == NULL)` | RED — oracles 3 and 4, + SIGSEGV |

No mutation survived. Each removal both fails the oracle aimed at that ordinal and crashes the worker, which oracle 7 catches — that pairing is what separates "handled the failure" from "crashed on it", since a crashed worker also produces a torn-down connection.

An earlier draft aimed oracle 4 at `nth=10` only, and mutating the emit-link check at what is now `nth=13` **survived** — the ordinal was hitting a different chain-link site. That is why the driver carries the site map and why the oracles name the site they believe they are hitting.

## Coverage floor

No effect. The coverage job builds without `NGX_TEST_HARNESS`, so every line added here is preprocessed out of the gcov build — nothing added, nothing to cover, floor untouched at 82%.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pool-allocation failure injection for test and diagnostic scenarios.
  * Added reporting of wrapped allocation call counts.
  * Added validation for supported fault-injection values and disarm behavior.

* **Tests**
  * Added comprehensive coverage for allocation failures, response handling, restoration, invalid inputs, and worker safety.
  * Added CI execution and artifact collection for the new scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->