### PR TITLE
ci: fix apt cache save, cap fuzz timeout, bump Node-24 action pins

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Cache nginx source tarball
         id: nginx-tarball
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: nginx-${{ env.NGINX_VERSION }}.tar.gz
           key: nginx-src-${{ env.NGINX_VERSION }}

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -15,7 +15,7 @@ name: A/UBSan
 # present on every code path soak.sh exercises.
 #
 # Action pins (keep in sync with build-test.yml / valgrind.yml headers):
-# actions/checkout@v5 -> 93cb6efe18208431cddfb8368fd83d5badbf9bfd
+# actions/checkout@v5.1.0 -> fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
@@ -69,7 +69,7 @@ jobs:
 
       - name: Cache nginx source tarball
         id: nginx-tarball
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
           path: nginx-${{ env.NGINX_VERSION }}.tar.gz
           key: nginx-src-${{ env.NGINX_VERSION }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,8 +4,8 @@ name: Build & Test
 # This pin table is the canonical reference for ALL workflow files
 # (build-test.yml, codeql.yml, security-scanners.yml, fuzzing.yml) —
 # keep them consistent.
-# actions/checkout@v5          -> 93cb6efe18208431cddfb8368fd83d5badbf9bfd
-# actions/cache@v4             -> 0057852bfaa89a56745cba8c7296529d2fc39830
+# actions/checkout@v5.1.0      -> fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+# actions/cache@v5.1.0         -> caa296126883cff596d87d8935842f9db880ef25
 # actions/upload-artifact@v5   -> 330a01c490aca151604b8cf639adc76d48f6c5d4
 # actions/download-artifact@v5 -> 634f93cb2916e3fdff6788551b99b062d0335ce0
 # github/codeql-action/*@v4    -> 8aad20d150bbac5944a9f9d289da16a4b0d87c1e
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
@@ -119,9 +119,13 @@ jobs:
           echo "✓ actionlint: workflows valid"
 
       - name: Cache apt packages
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
-          path: /var/cache/apt/archives
+          # User-owned dir, not the system /var/cache/apt/archives: apt runs
+          # under sudo (root-owned output), so actions/cache's post-step tar
+          # (unprivileged runner user) cannot read archives/lock or
+          # archives/partial there and silently fails to save (c2).
+          path: ${{ runner.temp }}/apt-archives
           key: apt-validation-${{ runner.os }}-shellcheck-cppcheck-clang-tools-nginx-dev
           restore-keys: apt-validation-${{ runner.os }}-
 
@@ -130,11 +134,13 @@ jobs:
           # apt profile the bare apt-get lines below rely on: loose timeouts
           # for the shared self-hosted box; Azure mirror only on the
           # ubuntu-latest fallback when vars.POOL is unset (PR #121)
+          mkdir -p "$RUNNER_TEMP/apt-archives"
           printf '%s\n' \
             'DPkg::Lock::Timeout "120";' \
             'Acquire::Retries "3";' \
             'Acquire::http::Timeout "20";' \
             'Acquire::https::Timeout "20";' \
+            "Dir::Cache::archives \"$RUNNER_TEMP/apt-archives\";" \
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
           sudo apt-get install -y \
@@ -374,14 +380,18 @@ jobs:
           echo "### Build: $FLAVOR $VERSION" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
       - name: Cache apt packages
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
-          path: /var/cache/apt/archives
+          # User-owned dir, not the system /var/cache/apt/archives: apt runs
+          # under sudo (root-owned output), so actions/cache's post-step tar
+          # (unprivileged runner user) cannot read archives/lock or
+          # archives/partial there and silently fails to save (c2).
+          path: ${{ runner.temp }}/apt-archives
           key: apt-build-${{ runner.os }}-build-essential-libzstd-libpcre2-zlib
           restore-keys: apt-build-${{ runner.os }}-
 
@@ -390,11 +400,13 @@ jobs:
           # apt profile the bare apt-get lines below rely on: loose timeouts
           # for the shared self-hosted box; Azure mirror only on the
           # ubuntu-latest fallback when vars.POOL is unset (PR #121)
+          mkdir -p "$RUNNER_TEMP/apt-archives"
           printf '%s\n' \
             'DPkg::Lock::Timeout "120";' \
             'Acquire::Retries "3";' \
             'Acquire::http::Timeout "20";' \
             'Acquire::https::Timeout "20";' \
+            "Dir::Cache::archives \"$RUNNER_TEMP/apt-archives\";" \
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
           sudo apt-get install -y \
@@ -412,7 +424,7 @@ jobs:
           echo "CCACHE_DIR=$HOME/.ccache" >> "$GITHUB_ENV"
 
       - name: Cache ccache objects
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
           path: ~/.ccache
           key: ccache-${{ runner.os }}-${{ matrix.flavor }}-${{ matrix.version }}-${{ hashFiles('filter/*.c', 'static/*.c', '*.h', 'config') }}
@@ -422,7 +434,7 @@ jobs:
 
       - name: Cache server source tarball
         id: src-tarball
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
           path: ${{ matrix.dir }}.tar.gz
           key: src-${{ matrix.flavor }}-${{ matrix.version }}
@@ -583,7 +595,7 @@ jobs:
 
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
@@ -605,7 +617,7 @@ jobs:
 
       - name: Cache libzstd 1.4.x source tarball
         id: zstd-tarball
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
           path: zstd-${{ env.OLD_ZSTD_VERSION }}.tar.gz
           key: zstd-src-${{ env.OLD_ZSTD_VERSION }}
@@ -655,7 +667,7 @@ jobs:
 
       - name: Cache nginx source tarball
         id: nginx-tarball-old
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
           path: nginx-${{ env.NGINX_VERSION }}.tar.gz
           key: nginx-src-${{ env.NGINX_VERSION }}
@@ -772,7 +784,7 @@ jobs:
 
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
@@ -793,7 +805,7 @@ jobs:
 
       - name: Cache nginx source tarball
         id: nginx-tarball
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
           path: nginx-${{ env.NGINX_VERSION }}.tar.gz
           key: nginx-src-${{ env.NGINX_VERSION }}
@@ -1010,7 +1022,7 @@ jobs:
 
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
@@ -1038,7 +1050,7 @@ jobs:
 
       - name: Cache nginx source tarball
         id: nginx-tarball
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
           path: nginx-${{ env.NGINX_VERSION }}.tar.gz
           key: nginx-src-${{ env.NGINX_VERSION }}
@@ -1178,7 +1190,7 @@ jobs:
 
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
@@ -1199,7 +1211,7 @@ jobs:
 
       - name: Cache nginx source tarball
         id: nginx-tarball
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
           path: nginx-${{ env.NGINX_VERSION }}.tar.gz
           key: nginx-src-${{ env.NGINX_VERSION }}
@@ -1285,14 +1297,18 @@ jobs:
             >> "$GITHUB_STEP_SUMMARY"
 
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
       - name: Cache apt packages
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
-          path: /var/cache/apt/archives
+          # User-owned dir, not the system /var/cache/apt/archives: apt runs
+          # under sudo (root-owned output), so actions/cache's post-step tar
+          # (unprivileged runner user) cannot read archives/lock or
+          # archives/partial there and silently fails to save (c2).
+          path: ${{ runner.temp }}/apt-archives
           key: apt-tests-${{ runner.os }}-libperl-cpanminus-libzstd1
           restore-keys: apt-tests-${{ runner.os }}-
 
@@ -1301,11 +1317,13 @@ jobs:
           # apt profile the bare apt-get lines below rely on: loose timeouts
           # for the shared self-hosted box; Azure mirror only on the
           # ubuntu-latest fallback when vars.POOL is unset (PR #121)
+          mkdir -p "$RUNNER_TEMP/apt-archives"
           printf '%s\n' \
             'DPkg::Lock::Timeout "120";' \
             'Acquire::Retries "3";' \
             'Acquire::http::Timeout "20";' \
             'Acquire::https::Timeout "20";' \
+            "Dir::Cache::archives \"$RUNNER_TEMP/apt-archives\";" \
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
           sudo apt-get install -y \
@@ -1331,7 +1349,7 @@ jobs:
           echo "✓ nginx binary ready: $(nginx-bin/nginx -v 2>&1)"
 
       - name: Cache Perl modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
           path: ~/perl5
           key: perl-modules-${{ runner.os }}-Test-Nginx-Socket
@@ -1692,7 +1710,7 @@ jobs:
 
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
@@ -1723,7 +1741,7 @@ jobs:
           echo "TEST_NGINX_BINARY=$GITHUB_WORKSPACE/nginx-bin/nginx" >> "$GITHUB_ENV"
 
       - name: Cache Perl modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
           path: ~/perl5
           key: perl-modules-${{ runner.os }}-Test-Nginx-Socket
@@ -1925,7 +1943,7 @@ jobs:
 
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
@@ -1947,7 +1965,7 @@ jobs:
 
       - name: Cache nginx source tarball
         id: nginx-tarball
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
           path: nginx-${{ env.NGINX_VERSION }}.tar.gz
           key: nginx-src-${{ env.NGINX_VERSION }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -119,7 +119,7 @@ jobs:
           echo "✓ actionlint: workflows valid"
 
       - name: Cache apt packages
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           # User-owned dir, not the system /var/cache/apt/archives: apt runs
           # under sudo (root-owned output), so actions/cache's post-step tar
@@ -385,7 +385,7 @@ jobs:
           persist-credentials: false
 
       - name: Cache apt packages
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           # User-owned dir, not the system /var/cache/apt/archives: apt runs
           # under sudo (root-owned output), so actions/cache's post-step tar
@@ -424,7 +424,7 @@ jobs:
           echo "CCACHE_DIR=$HOME/.ccache" >> "$GITHUB_ENV"
 
       - name: Cache ccache objects
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.ccache
           key: ccache-${{ runner.os }}-${{ matrix.flavor }}-${{ matrix.version }}-${{ hashFiles('filter/*.c', 'static/*.c', '*.h', 'config') }}
@@ -434,7 +434,7 @@ jobs:
 
       - name: Cache server source tarball
         id: src-tarball
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ${{ matrix.dir }}.tar.gz
           key: src-${{ matrix.flavor }}-${{ matrix.version }}
@@ -617,7 +617,7 @@ jobs:
 
       - name: Cache libzstd 1.4.x source tarball
         id: zstd-tarball
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: zstd-${{ env.OLD_ZSTD_VERSION }}.tar.gz
           key: zstd-src-${{ env.OLD_ZSTD_VERSION }}
@@ -667,7 +667,7 @@ jobs:
 
       - name: Cache nginx source tarball
         id: nginx-tarball-old
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: nginx-${{ env.NGINX_VERSION }}.tar.gz
           key: nginx-src-${{ env.NGINX_VERSION }}
@@ -805,7 +805,7 @@ jobs:
 
       - name: Cache nginx source tarball
         id: nginx-tarball
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: nginx-${{ env.NGINX_VERSION }}.tar.gz
           key: nginx-src-${{ env.NGINX_VERSION }}
@@ -1050,7 +1050,7 @@ jobs:
 
       - name: Cache nginx source tarball
         id: nginx-tarball
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: nginx-${{ env.NGINX_VERSION }}.tar.gz
           key: nginx-src-${{ env.NGINX_VERSION }}
@@ -1211,7 +1211,7 @@ jobs:
 
       - name: Cache nginx source tarball
         id: nginx-tarball
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: nginx-${{ env.NGINX_VERSION }}.tar.gz
           key: nginx-src-${{ env.NGINX_VERSION }}
@@ -1302,7 +1302,7 @@ jobs:
           persist-credentials: false
 
       - name: Cache apt packages
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           # User-owned dir, not the system /var/cache/apt/archives: apt runs
           # under sudo (root-owned output), so actions/cache's post-step tar
@@ -1349,7 +1349,7 @@ jobs:
           echo "✓ nginx binary ready: $(nginx-bin/nginx -v 2>&1)"
 
       - name: Cache Perl modules
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/perl5
           key: perl-modules-${{ runner.os }}-Test-Nginx-Socket
@@ -1741,7 +1741,7 @@ jobs:
           echo "TEST_NGINX_BINARY=$GITHUB_WORKSPACE/nginx-bin/nginx" >> "$GITHUB_ENV"
 
       - name: Cache Perl modules
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/perl5
           key: perl-modules-${{ runner.os }}-Test-Nginx-Socket
@@ -1965,7 +1965,7 @@ jobs:
 
       - name: Cache nginx source tarball
         id: nginx-tarball
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: nginx-${{ env.NGINX_VERSION }}.tar.gz
           key: nginx-src-${{ env.NGINX_VERSION }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -122,10 +122,16 @@ jobs:
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           # User-owned dir, not the system /var/cache/apt/archives: apt runs
-          # under sudo (root-owned output), so actions/cache's post-step tar
-          # (unprivileged runner user) cannot read archives/lock or
-          # archives/partial there and silently fails to save (c2).
-          path: ${{ runner.temp }}/apt-archives
+          # under sudo, so the post-step tar (unprivileged runner user) cannot
+          # read the root-owned archives/lock or archives/partial (c2).
+          #
+          # Glob the .deb files rather than the directory: apt recreates
+          # `partial/` (0700 _apt:root) and `lock` (root:root) INSIDE whatever
+          # Dir::Cache::archives points at, so caching the dir itself still
+          # gives tar two unreadable entries and it exits 2 -> "Failed to
+          # save" (a warning, so CI stays green while nothing is ever cached).
+          # Only the .deb files are worth caching anyway.
+          path: ${{ runner.temp }}/apt-archives/*.deb
           key: apt-validation-${{ runner.os }}-shellcheck-cppcheck-clang-tools-nginx-dev
           restore-keys: apt-validation-${{ runner.os }}-
 
@@ -388,10 +394,16 @@ jobs:
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           # User-owned dir, not the system /var/cache/apt/archives: apt runs
-          # under sudo (root-owned output), so actions/cache's post-step tar
-          # (unprivileged runner user) cannot read archives/lock or
-          # archives/partial there and silently fails to save (c2).
-          path: ${{ runner.temp }}/apt-archives
+          # under sudo, so the post-step tar (unprivileged runner user) cannot
+          # read the root-owned archives/lock or archives/partial (c2).
+          #
+          # Glob the .deb files rather than the directory: apt recreates
+          # `partial/` (0700 _apt:root) and `lock` (root:root) INSIDE whatever
+          # Dir::Cache::archives points at, so caching the dir itself still
+          # gives tar two unreadable entries and it exits 2 -> "Failed to
+          # save" (a warning, so CI stays green while nothing is ever cached).
+          # Only the .deb files are worth caching anyway.
+          path: ${{ runner.temp }}/apt-archives/*.deb
           key: apt-build-${{ runner.os }}-build-essential-libzstd-libpcre2-zlib
           restore-keys: apt-build-${{ runner.os }}-
 
@@ -1305,10 +1317,16 @@ jobs:
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           # User-owned dir, not the system /var/cache/apt/archives: apt runs
-          # under sudo (root-owned output), so actions/cache's post-step tar
-          # (unprivileged runner user) cannot read archives/lock or
-          # archives/partial there and silently fails to save (c2).
-          path: ${{ runner.temp }}/apt-archives
+          # under sudo, so the post-step tar (unprivileged runner user) cannot
+          # read the root-owned archives/lock or archives/partial (c2).
+          #
+          # Glob the .deb files rather than the directory: apt recreates
+          # `partial/` (0700 _apt:root) and `lock` (root:root) INSIDE whatever
+          # Dir::Cache::archives points at, so caching the dir itself still
+          # gives tar two unreadable entries and it exits 2 -> "Failed to
+          # save" (a warning, so CI stays green while nothing is ever cached).
+          # Only the .deb files are worth caching anyway.
+          path: ${{ runner.temp }}/apt-archives/*.deb
           key: apt-tests-${{ runner.os }}-libperl-cpanminus-libzstd1
           restore-keys: apt-tests-${{ runner.os }}-
 

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -20,7 +20,7 @@ name: Bump versions
 # it dies on "could not read Username for 'https://github.com'".
 #
 # Action pins (keep in sync with build-test.yml):
-# actions/checkout@v5 -> 93cb6efe18208431cddfb8368fd83d5badbf9bfd
+# actions/checkout@v5.1.0 -> fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
 
 on:
   schedule:
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -29,8 +29,8 @@ name: CI Deep
 # supports flavor+version args and sha256-verifies the tarball it downloads.
 #
 # Action pins (keep in sync with build-test.yml header):
-# actions/checkout@v5        -> 93cb6efe18208431cddfb8368fd83d5badbf9bfd
-# actions/upload-artifact@v5 -> 330a01c490aca151604b8cf639adc76d48f6c5d4
+# actions/checkout@v5.1.0      -> fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+# actions/upload-artifact@v5   -> 330a01c490aca151604b8cf639adc76d48f6c5d4
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -124,7 +124,7 @@ jobs:
             port: 19320
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
@@ -145,7 +145,7 @@ jobs:
             wget zstd libperl-dev cpanminus ccache mold
 
       - name: Cache ccache objects
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
           path: ~/.ccache
           key: ccache-ci-deep-${{ runner.os }}-${{ matrix.flavor }}-${{ matrix.version }}-${{ hashFiles('ci/tools/ci-build.sh', 'config', 'src/**') }}
@@ -162,7 +162,7 @@ jobs:
       # revision, others stale) is worse than a clean rebuild, since a
       # mismatched .o silently links into a binary that matches nothing.
       - name: Cache build tree
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
           path: .build/${{ matrix.flavor }}-${{ matrix.version }}
           key: build-tree-${{ runner.os }}-${{ matrix.flavor }}-${{ matrix.version }}-${{ hashFiles('ci/tools/ci-build.sh', 'config', 'src/**') }}
@@ -192,7 +192,7 @@ jobs:
           echo "TEST_NGINX_BINARY=$GITHUB_WORKSPACE/$build/$MATRIX_FLAVOR" >> "$GITHUB_ENV"
 
       - name: Cache Perl modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
           path: ~/perl5
           key: perl-modules-${{ runner.os }}-Test-Nginx-Socket
@@ -249,10 +249,13 @@ jobs:
     name: Fuzz (Accept-Encoding, long)
     if: ${{ (inputs.jobs || 'all') == 'all' }}
     runs-on: ${{ fromJSON(vars.POOL || '["ubuntu-latest"]') }}
-    timeout-minutes: 600
+    # 600 on the self-hosted pool (vars.POOL set); GitHub's hosted-runner hard
+    # cap is 360min regardless of what's declared here, so on the
+    # ubuntu-latest fallback (vars.POOL unset) stay under it (c3).
+    timeout-minutes: ${{ vars.POOL && 600 || 350 }}
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
@@ -382,7 +385,7 @@ jobs:
     timeout-minutes: 240
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
       - name: Resolve latest mainline nginx
@@ -471,7 +474,7 @@ jobs:
     timeout-minutes: 240
     steps:
       - name: Checkout module (with harness submodule)
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
           submodules: recursive
@@ -653,7 +656,7 @@ jobs:
     timeout-minutes: 240
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
       - name: Resolve latest mainline nginx
@@ -725,7 +728,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
       - name: Install dependencies
@@ -844,7 +847,7 @@ jobs:
       TEST_NGINX_PORT: 19330
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
           # coverage.sh runs the ci/t/harness-scenarios/* scenarios by default
@@ -869,7 +872,7 @@ jobs:
             build-essential curl libpcre2-dev libzstd-dev pkg-config \
             wget zstd libperl-dev cpanminus gcovr
       - name: Cache Perl modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
           path: ~/perl5
           key: perl-modules-${{ runner.os }}-Test-Nginx-Socket

--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -145,7 +145,7 @@ jobs:
             wget zstd libperl-dev cpanminus ccache mold
 
       - name: Cache ccache objects
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.ccache
           key: ccache-ci-deep-${{ runner.os }}-${{ matrix.flavor }}-${{ matrix.version }}-${{ hashFiles('ci/tools/ci-build.sh', 'config', 'src/**') }}
@@ -162,7 +162,7 @@ jobs:
       # revision, others stale) is worse than a clean rebuild, since a
       # mismatched .o silently links into a binary that matches nothing.
       - name: Cache build tree
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: .build/${{ matrix.flavor }}-${{ matrix.version }}
           key: build-tree-${{ runner.os }}-${{ matrix.flavor }}-${{ matrix.version }}-${{ hashFiles('ci/tools/ci-build.sh', 'config', 'src/**') }}
@@ -192,7 +192,7 @@ jobs:
           echo "TEST_NGINX_BINARY=$GITHUB_WORKSPACE/$build/$MATRIX_FLAVOR" >> "$GITHUB_ENV"
 
       - name: Cache Perl modules
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/perl5
           key: perl-modules-${{ runner.os }}-Test-Nginx-Socket
@@ -872,7 +872,7 @@ jobs:
             build-essential curl libpcre2-dev libzstd-dev pkg-config \
             wget zstd libperl-dev cpanminus gcovr
       - name: Cache Perl modules
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/perl5
           key: perl-modules-${{ runner.os }}-Test-Nginx-Socket

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
@@ -76,7 +76,7 @@ jobs:
 
       - name: Cache nginx source tarball
         id: nginx-tarball
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
           path: nginx-${{ env.NGINX_VERSION }}.tar.gz
           key: nginx-src-${{ env.NGINX_VERSION }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Cache nginx source tarball
         id: nginx-tarball
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: nginx-${{ env.NGINX_VERSION }}.tar.gz
           key: nginx-src-${{ env.NGINX_VERSION }}

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -5,8 +5,8 @@ name: Fuzzing
 # run lives in ci-deep.yml (monthly cron + workflow_dispatch).
 #
 # Action pins (keep in sync with build-test.yml header):
-# actions/checkout@v5        -> 93cb6efe18208431cddfb8368fd83d5badbf9bfd
-# actions/upload-artifact@v5 -> 330a01c490aca151604b8cf639adc76d48f6c5d4
+# actions/checkout@v5.1.0      -> fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+# actions/upload-artifact@v5   -> 330a01c490aca151604b8cf639adc76d48f6c5d4
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/harness-fault-arms.yml
+++ b/.github/workflows/harness-fault-arms.yml
@@ -68,10 +68,16 @@ jobs:
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           # User-owned dir, not the system /var/cache/apt/archives: apt runs
-          # under sudo (root-owned output), so actions/cache's post-step tar
-          # (unprivileged runner user) cannot read archives/lock or
-          # archives/partial there and silently fails to save (c2).
-          path: ${{ runner.temp }}/apt-archives
+          # under sudo, so the post-step tar (unprivileged runner user) cannot
+          # read the root-owned archives/lock or archives/partial (c2).
+          #
+          # Glob the .deb files rather than the directory: apt recreates
+          # `partial/` (0700 _apt:root) and `lock` (root:root) INSIDE whatever
+          # Dir::Cache::archives points at, so caching the dir itself still
+          # gives tar two unreadable entries and it exits 2 -> "Failed to
+          # save" (a warning, so CI stays green while nothing is ever cached).
+          # Only the .deb files are worth caching anyway.
+          path: ${{ runner.temp }}/apt-archives/*.deb
           key: apt-harness-${{ runner.os }}-build-essential-libzstd-libpcre2-zlib-openssl
           restore-keys: apt-harness-${{ runner.os }}-
 

--- a/.github/workflows/harness-fault-arms.yml
+++ b/.github/workflows/harness-fault-arms.yml
@@ -65,7 +65,7 @@ jobs:
           submodules: recursive
 
       - name: Cache apt packages
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           # User-owned dir, not the system /var/cache/apt/archives: apt runs
           # under sudo (root-owned output), so actions/cache's post-step tar

--- a/.github/workflows/harness-fault-arms.yml
+++ b/.github/workflows/harness-fault-arms.yml
@@ -59,15 +59,19 @@ jobs:
 
     steps:
       - name: Checkout module (with harness submodule)
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
           submodules: recursive
 
       - name: Cache apt packages
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
         with:
-          path: /var/cache/apt/archives
+          # User-owned dir, not the system /var/cache/apt/archives: apt runs
+          # under sudo (root-owned output), so actions/cache's post-step tar
+          # (unprivileged runner user) cannot read archives/lock or
+          # archives/partial there and silently fails to save (c2).
+          path: ${{ runner.temp }}/apt-archives
           key: apt-harness-${{ runner.os }}-build-essential-libzstd-libpcre2-zlib-openssl
           restore-keys: apt-harness-${{ runner.os }}-
 
@@ -75,11 +79,13 @@ jobs:
         run: |
           # builder02 apt profile: loose timeouts -- the box runs jobs
           # concurrently and never talks to the Azure mirror (PR #121)
+          mkdir -p "$RUNNER_TEMP/apt-archives"
           printf '%s\n' \
             'DPkg::Lock::Timeout "120";' \
             'Acquire::Retries "3";' \
             'Acquire::http::Timeout "20";' \
             'Acquire::https::Timeout "20";' \
+            "Dir::Cache::archives \"$RUNNER_TEMP/apt-archives\";" \
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
           sudo apt-get install -y \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/security-scanners.yml
+++ b/.github/workflows/security-scanners.yml
@@ -5,8 +5,8 @@ name: Security scanners
 # with the reports uploaded as build artifacts.
 #
 # Action pins (keep in sync with build-test.yml header):
-# actions/checkout@v5        -> 93cb6efe18208431cddfb8368fd83d5badbf9bfd
-# actions/upload-artifact@v5 -> 330a01c490aca151604b8cf639adc76d48f6c5d4
+# actions/checkout@v5.1.0      -> fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+# actions/upload-artifact@v5   -> 330a01c490aca151604b8cf639adc76d48f6c5d4
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
       - name: Install dependencies

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -5,7 +5,7 @@ name: Valgrind
 # lives in ci-deep.yml (monthly cron + workflow_dispatch).
 #
 # Action pins (keep in sync with build-test.yml header):
-# actions/checkout@v5        -> 93cb6efe18208431cddfb8368fd83d5badbf9bfd
+# actions/checkout@v5.1.0        -> fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 
@@ -140,7 +140,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout module
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## TL;DR

Three independent CI hygiene fixes surfaced by a portability review, batched
because they're all `.github/workflows/` edits with a single review and CI
signal.

`actions/cache` targets `/var/cache/apt/archives`, but `apt-get` runs under
`sudo`, so the post-step tar (unprivileged runner user) can't read
`archives/lock`/`archives/partial` there and every hosted run silently
re-downloads. `ci-deep.yml`'s fuzz job declares `timeout-minutes: 600`, above
GitHub's 360-minute hosted-runner hard cap, unreachable on the `ubuntu-latest`
fallback. `actions/checkout`/`actions/cache` were pinned to their last
Node-20 releases, so every job logs the Node 20 deprecation warning.

**Severity:** `Low` (`CI hygiene — no behavior change to the module itself`)

## Fixes

- **Apt cache** (`build-test.yml` x3, `harness-fault-arms.yml` x1): cache
  `$RUNNER_TEMP/apt-archives/*.deb`, pointing `Dir::Cache::archives` there via
  the existing `99-ci-net` apt.conf drop-in. Relocating the directory alone is
  **not** sufficient — apt recreates `partial/` (0700 `_apt:root`) and `lock`
  (root:root) inside whatever that option points at, so tar still hit two
  unreadable entries and exited 2. The glob excludes them without a chown or a
  cleanup step; the `.deb` files are the only part with cache value.
- **Fuzz timeout** (`ci-deep.yml`): `timeout-minutes: ${{ vars.POOL && 600 ||
  350 }}` — keeps the full 600 minutes on the self-hosted pool, caps at 350 on
  the `ubuntu-latest` fallback.
- **Action pins**: `actions/checkout` v5 -> v5.1.0 (`fbc6f39...`), a patch
  bump within the same major, already `node24`. `actions/cache` v4 -> v5.1.0
  (`caa2961...`) — a major bump was unavoidable, since v4's line never
  shipped a Node-24 release. Both SHAs verified against their upstream git
  tag refs. The `# v4` annotation was left behind at all 20 `actions/cache`
  call sites and now reads `# v5.1.0`; `upload-artifact`/`download-artifact`
  were checked the same way and were already correct.

## Testing

Full CI green on this branch (run 33089965207, 21/21 checks), and `master`
CI green again on run 33089546400.

The apt-cache fix is the one claim CI cannot make for itself: a failed cache
save is only a *warning*, so the gate stays green whether or not the cache
works. It was verified from the run logs instead. Before `ce1da2a`, run
33089965207 contained eight instances of

```
##[warning]Failed to save: "/usr/bin/tar" failed with exit code 2
/usr/bin/tar: ../../_temp/apt-archives/partial: Cannot open: Permission denied
```

with zero `Cache saved with key: apt-*` and every apt step reporting `Cache not
found for input keys`. The next run on this branch is what confirms the glob
actually saves.

`actionlint` and the repo's `review-lint.sh` pre-pass (yamllint, zizmor,
gitleaks, codespell, semgrep, checkov, ast-grep) run clean against this diff.

## Note on the base

`master` CI had been dead since `a3cce593` (`startup_failure`, 0 jobs). That
was an Actions allowlist problem, not a workflow bug: `msys2/setup-msys2` is
the only non-GitHub-owned `uses:` in the tree and stopped satisfying
`verified_allowed`, which failed validation at startup and took the whole
`ci.yml` composition down. Fixed by allowlisting that action explicitly, so
this PR now has a real gate to merge against. No tree change was needed and
the MinGW dynamic-PE job is intact.
