### PR TITLE
fix: print $zstd_bytes_* through the unsigned %uL

### DIFF
--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -5101,7 +5101,7 @@ ngx_http_zstd_bytes_variable(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-    vv->len = ngx_sprintf(vv->data, "%L", value) - vv->data;
+    vv->len = ngx_sprintf(vv->data, "%uL", value) - vv->data;
     vv->valid = 1;
     vv->no_cacheable = 0;
 


### PR DESCRIPTION
> Found by the second-pass audit of #195-#205 (`issues.md` s2). Unrelated to the CI work in #206.

## TL;DR

The two `$zstd_bytes_*` variables hold an unsigned 64-bit byte count but were formatted with nginx's *signed* `%L`. A large enough value would print as a negative number.

`ngx_http_zstd_bytes_variable()` reads a `uint64_t` and passes it to `ngx_sprintf` as `"%L"`. In `ngx_vslprintf()` (`src/core/ngx_string.c:347`) the `'L'` conversion takes `int64_t` unless a preceding `'u'` clears the sign flag, so the correct specifier is `%uL`.

**Severity:** `Low` (`correctness — type mismatch, unreachable at realistic body sizes`)

## Why it is not a live bug

The variable is a per-response byte counter, so misprinting needs a value above `INT64_MAX` — a body over roughly 9.2 exabytes. This is a type-match fix that stops the code lying about its own contract, not a defect anyone can hit.

The buffer is unaffected: `NGX_INT64_LEN` is 20, which covers the 20-digit unsigned maximum, and removing the possible sign character makes the allocation strictly less tight than before.

## Testing

`ci/tests/unit/run.sh` 45/45. Module rebuilt under `-Wextra -Werror -DNGX_TEST_HARNESS` with zero warnings. `review-lint.sh` pre-pass clean on the diff.

No test is added: asserting the difference requires materialising an exabyte-scale counter, and a test that stubs the counter would assert the format string against itself rather than the behaviour.
