### PR TITLE
fix: cap the directio frame-probe alignment at 64 KB

### DIFF
--- a/ci/t/01-static.t
+++ b/ci/t/01-static.t
@@ -886,13 +886,15 @@ aligned probe on directio file
 
 
 
-=== TEST 34: the directio probe honors directio_alignment above the 4 KB floor
-# Review: the probe geometry must follow the operator's declared
-# alignment (the core copy filter honours clcf->directio_alignment the
-# same way) — a hardcoded 4 KB read fails EINVAL on storage configured
-# above that, and a failed validation read now DECLINES rather than
-# serving unvalidated. With 16 KB declared, the witness line must show
-# a 16384-byte probe and the oversized window must still be declined.
+=== TEST 34: the directio probe follows directio_alignment up to the cap
+# Review: the probe geometry follows the operator's declared alignment
+# between the 4 KB floor and the NGX_HTTP_ZSTD_STATIC_DIO_PROBE_MAX
+# (64 KB) ceiling, so storage declaring a larger block size than the
+# floor still gets an aligned read, and a failed validation read
+# DECLINES rather than serving unvalidated. 16 KB is inside that band
+# and so is honoured verbatim: the witness line must show a 16384-byte
+# probe and the oversized window must still be declined. TEST 34b pins
+# the other end of the band.
 --- config
     location /bw/ {
         zstd_static on;
@@ -917,6 +919,74 @@ big-window directio alignment body
 dioal.js.zst
 declares a 134217728-byte decompression window
 16384-byte aligned probe on directio file
+
+
+
+=== TEST 34b: the probe alignment is capped, and the cap applies to a client that does NOT accept zstd
+# s1 regression, two properties in one block.
+#
+# (1) CAP. "directio_alignment" is ngx_conf_set_off_slot on an off_t
+# with no upper bound in core (ngx_http_core_module.c), and core spends
+# it on the copy filter's BODY buffer, where a large value is a
+# throughput choice. O_DIRECT legality is a property of the device's
+# logical block size, not of that directive, so an 18-byte frame-HEADER
+# probe has nothing to gain from scaling with it. Uncapped, the probe
+# did ngx_pmemalign(align * 2) plus a 2*align O_DIRECT read per
+# request; at "directio_alignment 1m" that is a 2 MB allocation and a
+# 2 MB read to inspect 18 bytes. The probe alignment is now clamped to
+# NGX_HTTP_ZSTD_STATIC_DIO_PROBE_MAX, so the witness must say
+# 65536-byte, NOT 1048576-byte.
+#
+# (2) NON-ACCEPTING CLIENT. TESTs 26/33/34/46 all send an accepting
+# client, so nothing covered the directio probe on the path a client
+# that does not accept zstd takes — which is precisely the path the
+# amplification was reachable on, because #202 moved the
+# "return NGX_DECLINED" for such a client to AFTER the probe (the probe
+# result is required to decide whether Vary is truthful). This block
+# sends "Accept-Encoding: gzip" and still asserts the probe ran, so the
+# cap is pinned on the request shape that motivated it.
+#
+# Falsifiability, both directions:
+#   - remove the clamp -> the witness line reads "1048576-byte aligned
+#     probe", the 65536 pattern does not match, and this block goes red.
+#   - restore the pre-#202 early return for a non-accepting client ->
+#     no probe runs at all, so neither the witness line NOR the Vary
+#     header appears, and this block goes red on both.
+# The 1048576 negative assertion makes the first direction fail loudly
+# rather than merely stop matching.
+#
+# Vary is asserted because it is the reason the probe is allowed to run
+# for this client at all: the .zst is a valid, usable variant here (a
+# small window, unlike TEST 34), so the identity response really is
+# Accept-Encoding-dependent and must say so. The .zst is padded past
+# the "directio 512" threshold so the open really is O_DIRECT.
+--- config
+    location /cap/ {
+        zstd_static on;
+        directio 512;
+        directio_alignment 1m;
+        root html;
+    }
+--- user_files eval
+">>> cap/noaccept.js\ncapped probe identity body\n>>> cap/noaccept.js.zst\n"
+. pack("C*", 0x28, 0xB5, 0x2F, 0xFD, 0x00, 0x00, 0x19, 0x00, 0x00)
+. "hi\n"
+. ("\0" x 2048)
+--- request
+GET /cap/noaccept.js
+--- more_headers
+Accept-Encoding: gzip
+--- response_headers
+! Content-Encoding
+Vary: Accept-Encoding
+--- response_body
+capped probe identity body
+--- error_code: 200
+--- error_log
+65536-byte aligned probe on directio file
+--- no_error_log
+1048576-byte aligned probe on directio file
+[error]
 
 
 

--- a/src/ngx_http_zstd_static_module.c
+++ b/src/ngx_http_zstd_static_module.c
@@ -93,12 +93,37 @@
  * FLOOR for the probe read size under directio: O_DIRECT requires
  * buffer, offset and length aligned to the device's logical block
  * size. Offset 0 is aligned by definition; 4 KB covers 512-byte and
- * 4K-native devices, and the effective size is raised to the
- * operator's directio_alignment when that is larger (the same
- * geometry the core copy filter honours). A short read at EOF is
- * permitted, so files smaller than the probe work too.
+ * 4K-native devices. A short read at EOF is permitted, so files
+ * smaller than the probe work too.
  */
 #define NGX_HTTP_ZSTD_STATIC_DIO_PROBE   4096
+
+/*
+ * CEILING for the probe alignment. The probe reads a frame HEADER (at
+ * most 18 bytes); it is not the body copy, and it does not need the
+ * operator's bulk-I/O buffer size.
+ *
+ * "directio_alignment" is an ngx_conf_set_off_slot with no upper bound
+ * in core (ngx_http_core_module.c), and core applies it to the copy
+ * filter's body buffer (ngx_http_copy_filter_module.c: ctx->alignment),
+ * where a large value is a throughput choice on filesystems such as XFS.
+ * O_DIRECT LEGALITY, by contrast, is a property of the device's logical
+ * block size (512 or 4096 in practice), not of that directive — so
+ * scaling an 18-byte header probe with it buys nothing and costs
+ * "directio_alignment" bytes of pmemalign plus that much O_DIRECT read
+ * on EVERY request that reaches the probe, including one from a client
+ * that does not accept zstd and will be declined moments later (the
+ * probe still has to run for it, to decide whether Vary is truthful).
+ *
+ * 64 KB is a multiple of every logical block size a Linux/BSD block
+ * device reports, so the capped value stays O_DIRECT-legal for the
+ * descriptor; it is also >= the 4 KB floor, which is what guarantees a
+ * whole frame header still fits behind any in-block start position.
+ * Everything downstream (frame_off, base, want, avail) is expressed in
+ * terms of the SAME "align", so capping it preserves the arithmetic
+ * exactly.
+ */
+#define NGX_HTTP_ZSTD_STATIC_DIO_PROBE_MAX  (64 * 1024)
 
 
 typedef struct {
@@ -658,11 +683,17 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
      * ngx_open_cached_file when "directio <size>" is configured and the
      * file meets the threshold), BOTH the read offset and the length
      * must be block-aligned, so the probe rounds each frame offset down
-     * to max(NGX_HTTP_ZSTD_STATIC_DIO_PROBE, directio_alignment) and
-     * reads two such blocks into an equally-aligned pool buffer,
-     * parsing the frame at its offset inside them — honoring the
-     * operator's declared geometry the same way the core copy filter
-     * does. Rounding the OFFSET is what the skippable-frame walk needs:
+     * to directio_alignment CLAMPED to
+     * [NGX_HTTP_ZSTD_STATIC_DIO_PROBE, NGX_HTTP_ZSTD_STATIC_DIO_PROBE_MAX]
+     * and reads two such blocks into an equally-aligned pool buffer,
+     * parsing the frame at its offset inside them. The clamp follows the
+     * operator's declared geometry only as far as a header probe can
+     * use it: the floor is what keeps the read legal on 512-byte and
+     * 4K-native devices, and the ceiling is why an unbounded
+     * "directio_alignment" cannot turn an 18-byte header check into a
+     * multi-megabyte allocation and O_DIRECT read on every request that
+     * reaches the probe. Rounding the OFFSET is what the skippable-frame
+     * walk needs:
      * the second and later probes are at whatever offset the previous
      * frame's declared length produced (40 for a canonical dcz prefix),
      * which an O_DIRECT descriptor rejects with EINVAL if passed raw.
@@ -707,9 +738,20 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
         }
 
         if (of.is_directio) {
+            /*
+             * Clamped to [PROBE, PROBE_MAX]. The floor keeps the read
+             * O_DIRECT-legal on 512-byte and 4K-native devices and
+             * leaves room for a frame header behind any in-block start;
+             * the ceiling stops an unbounded "directio_alignment" from
+             * scaling a header probe that never needs more than 18
+             * bytes. See NGX_HTTP_ZSTD_STATIC_DIO_PROBE_MAX.
+             */
             align = NGX_HTTP_ZSTD_STATIC_DIO_PROBE;
             if ((size_t) clcf->directio_alignment > align) {
                 align = (size_t) clcf->directio_alignment;
+            }
+            if (align > NGX_HTTP_ZSTD_STATIC_DIO_PROBE_MAX) {
+                align = NGX_HTTP_ZSTD_STATIC_DIO_PROBE_MAX;
             }
 
             /*


### PR DESCRIPTION
> Fixes issue s1 from the second-pass audit of PRs #195-#205. Independent of
> other open work; touches only the static module's directio probe.

## TL;DR

Under `directio`, the zstd frame probe sized its aligned read from
`directio_alignment` with no ceiling and then doubled it, so an operator who set
`directio_alignment 1m;` made every request that reached the probe allocate 2 MB
and issue a 2 MB `O_DIRECT` read — to inspect an 18-byte frame header. Since the
Vary fix that cost is also paid by clients that never asked for zstd.

Clamp the probe alignment to `[NGX_HTTP_ZSTD_STATIC_DIO_PROBE,
NGX_HTTP_ZSTD_STATIC_DIO_PROBE_MAX]` = `[4096, 65536]` in
`ngx_http_zstd_static_handler()`; the copy path is untouched.

**Severity:** `Low` (`resource amplification — operator-bounded per-request allocation and O_DIRECT read on a path that previously cost nothing`)

## Why this happens

Two independently correct changes combined badly:

* #197 widened the probe buffer from `want = align` to `want = align * 2`. That
  is load-bearing: the read offset is rounded *down* to `align`, so a frame
  header can start as late as `align - 1` into the first block and would
  otherwise straddle the boundary. Two blocks guarantee a header always fits.
* #202 moved the `return NGX_DECLINED` for a non-accepting client from *before*
  the probe to *after* it. Also load-bearing: `Vary: Accept-Encoding` must be
  emitted for the non-accepting client too — a shared cache filled by one must
  not serve the stored identity body to a client that does accept — but only
  once the `.zst` is proven a usable variant, so a truncated frame or an
  oversized window still declines silently.

Neither is wrong. The result is that `align = max(4096, directio_alignment)` now
scales an 18-byte header check by an unbounded operator value, on a request rate
a non-accepting client controls. `directio_alignment` is `ngx_conf_set_off_slot`
on an `off_t` with no upper bound in core (`ngx_http_core_module.c:447`).

## The fix, and why capping rather than caching

Both options the audit named were considered.

**Chosen — cap the probe alignment.** `O_DIRECT` legality is a property of the
device's *logical block size* (512 or 4096 in practice), not of
`directio_alignment`. Core spends that directive on the copy filter's **body**
buffer (`ngx_http_copy_filter_module.c:114`, `ctx->alignment`), where a large
value is a throughput choice on filesystems such as XFS. A header probe has
nothing to gain from it. 64 KB is a multiple of every logical block size a
Linux/BSD block device reports, so the capped value stays `O_DIRECT`-legal for
the descriptor, and it remains at or above the 4 KB floor that guarantees a whole
frame header fits behind any in-block start position.

The arithmetic is safe because every downstream term derives from the *same*
`align`: `frame_off = pos % align`, `base = pos - frame_off`, `want = align * 2`,
`avail = n - frame_off`, `frame = hdr + frame_off`. Clamping `align` before any
of them is evaluated preserves each invariant exactly — in particular
`frame + avail <= hdr + n <= hdr + want` still holds, and the two-block guarantee
is unchanged because the cap is well above the 18-byte maximum header.

**Rejected — cache the verdict with the open_file_cache entry.** The verdict
would have to hang off `ngx_open_file_info_t` / the cache node, which is nginx
core; a module cannot extend it. A module-side parallel cache would need its own
shared-memory zone, LRU and eviction, plus coherence with
`open_file_cache_valid` and mtime — substantially more surface, and more
invalidation risk, than the amplification it removes. Not cleanly reachable from
this module, so option (a).

Note this only bounds the probe. `directio_alignment` is still honoured in full
by core for the body copy, which is what the directive is actually for.

## What the new test proves

`TEST 34b` covers **directio plus a client that does not accept zstd** — the
combination no existing test exercised (`TEST 26/33/34/46` all send an accepting
client), which is why the amplification reached master.

With `directio_alignment 1m;` and `Accept-Encoding: gzip` it asserts:

* the debug witness reads `65536-byte aligned probe on directio file`;
* it does **not** read `1048576-byte …`;
* the response is identity with `Vary: Accept-Encoding` and no `[error]`.

It is falsifiable in both directions. Compiling the clamp out (`if (0 && …)`)
and rebuilding turns it red on both witness assertions — observed, with the
unclamped run logging `1048576-byte aligned probe on directio file` for an
`Accept-Encoding: gzip` request, which is the defect itself. Restoring the clamp
returns it to green. Restoring the pre-#202 early return would instead remove the
probe and the Vary header entirely, so the block goes red on those too — it pins
the fix without re-opening the cache-correctness bug #202 closed.

`TEST 34` keeps `16k`, inside the band, and its comment is corrected: a 4 KB read
does not fail `EINVAL` merely because `directio_alignment` declares more. That
premise was the reason the probe scaled without a ceiling.

## Testing

Local, against `.build/nginx-1.31.4` (`--with-debug`, required — the witness
lines are `ngx_log_debug` output):

* `prove ci/t/01-static.t` — 618/618 pass
* `prove ci/t/03-dcz.t ci/t/02-conf-warn.t` — 203/203 pass
* `bash ci/tests/unit/run.sh` — 45/45 pass
* `.build/nginx-1.31.4-harness` rebuilt under `-Wextra -Werror
  -DNGX_TEST_HARNESS` — zero warnings
* mutation control on `TEST 34b`: green → clamp compiled out → red (only that
  block) → restored → green
* `review-lint.sh --diff HEAD` — all linters clean, no coverage gap; the
  remaining `ast-grep` candidates are pre-existing lines this diff does not touch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Capped direct I/O probe alignment at 64 KB while retaining the 4 KB minimum.
  - Prevented excessively large aligned buffers and reads when larger direct I/O alignments are configured.
  - Ensured the alignment limit also applies to clients that do not accept compressed responses.
  - Preserved `Vary: Accept-Encoding` on identity responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->