### PR TITLE
perf: close the frame on the final input buffer's own ZSTD_e_end call

### DIFF
--- a/.github/workflows/harness-fault-arms.yml
+++ b/.github/workflows/harness-fault-arms.yml
@@ -344,8 +344,14 @@ jobs:
           # survived would look green while measuring nothing about the
           # property in the scenario's title. Require the count halves to have
           # really run -- they are the even-numbered oracles 2, 4, 6, 8 and 10.
+          # The `[^#]*$` tail is load-bearing: without it a SKIP line
+          # ("ok 8 - dcz: total codec calls is 7 # SKIP ...") matches, and this
+          # gate would bank a green for an oracle that asserted nothing --
+          # precisely the false green it exists to prevent. TAP puts the
+          # directive after the description, so requiring no '#' to the end of
+          # the line is what distinguishes a real pass from a SKIP or a TODO.
           for n in 2 4 6 8 10; do
-            if ! grep -qE "^ok $n - .*total codec calls is" \
+            if ! grep -qE "^ok $n - [^#]*total codec calls is [^#]*$" \
                  "$GITHUB_WORKSPACE/codec-call-count-tap.log"; then
               echo "::error::oracle $n (a total-codec-calls assertion) did" \
                 "not pass -- without the count halves this scenario cannot" \

--- a/.github/workflows/harness-fault-arms.yml
+++ b/.github/workflows/harness-fault-arms.yml
@@ -302,6 +302,58 @@ jobs:
             exit 1
           fi
 
+      - name: Run codec-call-count scenario
+        env:
+          PROBER_ROOT: ${{ github.workspace }}
+          PROBER_BUILD: ${{ github.workspace }}/nginx-1.31.4
+          PROBER_MODULE: ngx_http_zstd_filter_module.so
+          PROBER_DIRECTIVE: zstd_probe
+          PROBER_PROBE: "zstd_probe;"
+          # No PROBER_ALLOW_LOG, deliberately: this scenario injects no
+          # faults, so a [crit]/[alert] during it is a real defect. The
+          # terminal-frame bug class it guards announces itself exactly there
+          # ("zero size buf in writer"), so exempting anything would blind the
+          # one signal the scenario most needs.
+        run: |
+          set -euo pipefail
+          cd ci/t/harness/ci/prober
+          ./run-scenario.sh "$GITHUB_WORKSPACE/ci/t/harness-scenarios/codec-call-count" nginx 1.31.4 \
+            | tee "$GITHUB_WORKSPACE/codec-call-count-tap.log"
+
+          # Same belt-and-braces verdict re-derivation as the steps above.
+          if grep -q '^not ok' "$GITHUB_WORKSPACE/codec-call-count-tap.log"; then
+            echo "::error::codec-call-count scenario reported at least one 'not ok' line"
+            exit 1
+          fi
+
+          # Non-vacuity: if every oracle SKIPped, the run banks a green having
+          # asserted nothing about the per-response codec call count.
+          TOTAL_OK=$(grep -c '^ok ' "$GITHUB_WORKSPACE/codec-call-count-tap.log" || true)
+          SKIPPED=$(grep -c '^ok .*# SKIP' "$GITHUB_WORKSPACE/codec-call-count-tap.log" || true)
+          if [ "$TOTAL_OK" -gt 0 ] && [ "$TOTAL_OK" -eq "$SKIPPED" ]; then
+            echo "::error::every oracle in codec-call-count SKIPped -- the" \
+              "scenario asserted nothing about the per-response" \
+              "ZSTD_compressStream2 call count; failing rather than banking" \
+              "a vacuous green"
+            exit 1
+          fi
+
+          # The COUNT oracles specifically. Every arm here is a PAIR: a decode
+          # check and a call-count check. The decode halves pass on both the
+          # optimized and the un-optimized filter, so a run where only they
+          # survived would look green while measuring nothing about the
+          # property in the scenario's title. Require the count halves to have
+          # really run -- they are the even-numbered oracles 2, 4, 6, 8 and 10.
+          for n in 2 4 6 8 10; do
+            if ! grep -qE "^ok $n - .*total codec calls is" \
+                 "$GITHUB_WORKSPACE/codec-call-count-tap.log"; then
+              echo "::error::oracle $n (a total-codec-calls assertion) did" \
+                "not pass -- without the count halves this scenario cannot" \
+                "distinguish the one-call END path from the two-call one"
+              exit 1
+            fi
+          done
+
       - name: Upload TAP log
         if: always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -311,5 +363,6 @@ jobs:
             fault-arms-tap.log
             alloc-neutral-tap.log
             fault-palloc-tap.log
+            codec-call-count-tap.log
           retention-days: 14
           if-no-files-found: ignore

--- a/ci/t/harness-scenarios/codec-call-count/driver.sh
+++ b/ci/t/harness-scenarios/codec-call-count/driver.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+#
+# Scenario: ZSTD_compressStream2() CALL COUNT AT THE END-OF-FRAME SITE.
+#
+# The filter picks its ZSTD_EndDirective once per compress call. END is
+# selected as soon as `ctx->last && ctx->in == NULL` holds -- i.e. on the call
+# that carries the response's final input -- instead of one iteration later,
+# after a ZSTD_e_continue call had already drained that input and the state
+# machine transitioned COMPRESS->END. libzstd accepts pending input under
+# ZSTD_e_end, consumes what it can and closes the frame in the same call, so
+# the earlier selection removes one ZSTD_compressStream2() call from every
+# completed response.
+#
+# WHAT THIS SCENARIO ASSERTS, AND WHY IT IS NOT VACUOUS.
+#
+# A correct response proves nothing about the call count: the two-call and the
+# one-call sequences both produce a valid frame that decodes to the same
+# plaintext. That is the whole difficulty of covering this change -- the
+# observable it turns on is the COUNT, not the bytes. So every oracle here is
+# a PAIR:
+#
+#   (a) the response decodes byte-for-byte to the origin file  -- correctness,
+#       which must hold under both the optimized and the unoptimized path; and
+#   (b) codec_end_calls for that one request equals the expected count       --
+#       the marker unique to the new path, which goes red the moment the extra
+#       ZSTD_e_continue iteration comes back.
+#
+# Dropping (b) leaves a suite that a revert passes. Dropping (a) leaves a
+# suite that a fast, truncating filter passes. Both halves are load-bearing.
+#
+# HOW A PER-REQUEST CALL COUNT IS READ. ngx_http_zstd_probe_codec_fault()
+# advances a per-site counter on every call and fault_set_global ZEROES that
+# counter whenever the site is armed OR disarmed. So `fault_codec_end=-1`
+# (a disarm) is also a counter RESET that leaves no fault armed. Reset, issue
+# exactly ONE request, read /__probe: the counter is that request's call count
+# at that site. Both sites are reset before each measurement so neither can
+# carry a previous case's traffic into this one.
+#
+# The probe request itself never runs the body filter over a compressible
+# response (the probe handler renders its own JSON and the /__probe location
+# has no zstd directive), so reading the counter does not perturb it.
+set -euo pipefail
+
+# shellcheck source=lib.sh
+. "$PROBER_LIB"
+
+HOST=127.0.0.1
+PORT="$PROBER_RESOLVED_PORT"
+ELOG="$PROBER_PREFIX/logs/error.log"
+
+export PROBER_ERROR_LOG="$ELOG"
+
+FAILED=0
+N=0
+
+ok()     { N=$((N + 1)); echo "ok $N - $1"; }
+notok()  { N=$((N + 1)); echo "not ok $N - $1"; FAILED=1; }
+diag()   { echo "# $1"; }
+
+WWW="$PROBER_PREFIX/www"
+mkdir -p "$WWW" "$PROBER_PREFIX/tmp"
+
+# Compressible body, large enough that the filter takes its streaming path
+# (several ZSTD_compressStream2 calls, more than one out_buf) rather than a
+# single trivial frame. A one-buffer response would leave the multi-call END
+# epilogue -- the part most at risk from selecting END earlier -- untested.
+{
+    printf '<html><body>\n'
+    i=0
+    while [ "$i" -lt 4000 ]; do
+        printf '<p>the quick brown fox jumps over the lazy dog %d</p>\n' "$i"
+        i=$((i + 1))
+    done
+    printf '</body></html>\n'
+} >"$WWW/index.html"
+
+# A genuinely EMPTY body: the terminal chain link carries last_buf and no
+# data whatsoever, so the response's only codec call is the END one.
+: >"$WWW/empty.txt"
+
+# The dcz and trained-dictionary arms use a dictionary this scenario's
+# `requires` gate stages into the build's objs/ dir (see there for why that
+# is the only hook early enough). The dcz arm additionally has to NEGOTIATE:
+# the client must send Available-Dictionary carrying the dictionary's raw
+# SHA-256 in the ":<base64>:" structured-field form, or the module answers
+# plain zstd and the arm would measure the wrong path -- which the
+# Content-Encoding assertion inside measure() catches rather than passing.
+# PROBER_SERVER_BIN is the exported <build>/objs/nginx, so its dirname is
+# the same objs/ dir @BUILD_OBJS@ renders into the conf.
+DICT_FILE="$(dirname "$PROBER_SERVER_BIN")/codec-call-count.dict"
+DICT_SHA_B64="$(openssl dgst -sha256 -binary "$DICT_FILE" 2>/dev/null \
+                | openssl base64 -A 2>/dev/null || true)"
+
+# reset_counters: disarm BOTH codec sites. A disarm zeroes that site's call
+# counter (fault_set_global does it on every arm and every disarm alike), so
+# this is the "start counting from here" primitive. Returns non-zero if the
+# probe did not answer, so a measurement can never silently proceed on a
+# counter that was not actually reset.
+reset_counters() {
+    curl -fsS --max-time 5 "http://$HOST:$PORT/__probe?fault_codec=-1" \
+        -o /dev/null || return 1
+    curl -fsS --max-time 5 "http://$HOST:$PORT/__probe?fault_codec_end=-1" \
+        -o /dev/null || return 1
+}
+
+# read_counter NAME: echo one integer field from a fresh probe document.
+read_counter() {
+    local body
+    body="$(prober_probe_body "$HOST" "$PORT")" || return 1
+    prober_probe_field "$body" "$1" || return 1
+}
+
+# fetch PATH OUTFILE [EXTRA_HEADER...]: one bounded GET that asks for zstd and
+# writes the raw (still compressed) body to OUTFILE. --fail is deliberately
+# NOT used: an arm that ends up serving 200-but-identity must be caught by the
+# encoding assertion below, not silently by curl.
+#
+# A caller-supplied Accept-Encoding REPLACES the default rather than adding a
+# second one. curl sends every -H it is given, and two Accept-Encoding header
+# lines are not the same request as one: RFC 9842 SS8.3 makes the module
+# decline dcz on a duplicated negotiation header, so the dcz arm silently fell
+# back to plain zstd and measured the wrong path. (Caught by measure()'s
+# Content-Encoding assertion, which is exactly why that assertion is there.)
+fetch() {
+    local path="$1" out="$2"; shift 2
+    local hdrs="$out.hdrs" rc=0
+    local -a extra=()
+    local h have_ae=0
+    for h in "$@"; do
+        case "$h" in
+            [Aa]ccept-[Ee]ncoding:*) have_ae=1 ;;
+        esac
+        extra+=(-H "$h")
+    done
+    [ "$have_ae" -eq 1 ] || extra=(-H 'Accept-Encoding: zstd' "${extra[@]}")
+    curl -sS --max-time 15 -D "$hdrs" -o "$out" "${extra[@]}" \
+        "http://$HOST:$PORT$path" 2>"$out.err" || rc=$?
+    return "$rc"
+}
+
+# encoded_as HDRFILE ENC: did the response actually carry Content-Encoding:
+# ENC? Guards every oracle against the vacuous case where the filter declined
+# and the body is plain -- a call count of 0 would then be "correct" for a
+# response the scenario is not measuring at all.
+encoded_as() {
+    grep -qi "^content-encoding:[[:space:]]*$2" "$1"
+}
+
+# decodes_to RAWFILE ORIGINFILE: the compressed body decodes byte-for-byte to
+# the origin. This is half (a) of every oracle pair.
+decodes_to() {
+    local raw="$1" origin="$2" dec="$1.dec"
+    zstd -d -q -f -o "$dec" "$raw" 2>/dev/null || return 1
+    cmp -s "$dec" "$origin"
+}
+
+# measure LABEL PATH ORIGIN ENC EXPECT_TOTAL_CALLS [EXTRA_HEADER...]
+#
+# The whole oracle pair in one place: reset both counters, issue exactly one
+# request, then assert (a) it was encoded as ENC and decodes to ORIGIN and
+# (b) the response made EXPECT_TOTAL_CALLS ZSTD_compressStream2() calls in
+# total, summed across BOTH sites.
+#
+# THE SUM, NOT codec_end_calls. This was measured, not assumed, and the
+# distinction is the entire value of the oracle. The call this change removes
+# is the redundant ZSTD_e_continue that used to precede the frame close, and
+# a ZSTD_e_continue lands at the STREAMING site (CODEC), not the end-of-frame
+# site (CODEC_END) -- the fault-injection split is keyed on
+# `directive == ZSTD_e_end`. Both the optimized and the reverted path close
+# the frame in exactly one END call, so codec_end_calls is 1 either way and
+# an oracle asserting it passes on both: a textbook vacuous control. Reverting
+# the optimization and re-running showed codec_end_calls unchanged at 1 while
+# codec_calls moved 6 -> 7. The sum is what actually discriminates.
+#
+# EXPECT_TOTAL_CALLS is an exact `-eq`, never a `-le`. A range would be
+# satisfied by the reverted path on every arm whose span includes its value,
+# which is the whole failure mode this scenario exists to catch.
+measure() {
+    local label="$1" path="$2" origin="$3" enc="$4" expect="$5"; shift 5
+    local raw="$PROBER_PREFIX/tmp/${label//\//_}.bin"
+    local got
+
+    if ! reset_counters; then
+        notok "$label: probe did not answer the counter reset"
+        notok "$label: total codec calls (not measured -- reset failed)"
+        return
+    fi
+
+    if ! fetch "$path" "$raw" "$@"; then
+        notok "$label: request failed or timed out"
+        notok "$label: total codec calls (not measured -- request failed)"
+        return
+    fi
+
+    if ! encoded_as "$raw.hdrs" "$enc"; then
+        diag "$label: headers were: $(tr -d '\r' <"$raw.hdrs" | tr '\n' ' ')"
+        notok "$label: response carried Content-Encoding: $enc"
+        notok "$label: total codec calls (not measured -- wrong encoding)"
+        return
+    fi
+
+    if decodes_to "$raw" "$origin"; then
+        ok "$label: response decodes byte-for-byte to the origin"
+    else
+        notok "$label: response decodes byte-for-byte to the origin"
+    fi
+
+    local ends
+    if ! got="$(read_counter codec_calls)" \
+       || ! ends="$(read_counter codec_end_calls)"; then
+        notok "$label: codec call count (probe field absent)"
+        return
+    fi
+    got=$((got + ends))
+
+    if [ "$got" -eq "$expect" ]; then
+        ok "$label: total codec calls is $expect"
+    else
+        diag "$label: codec_calls+codec_end_calls=$got expected=$expect"
+        notok "$label: total codec calls is $expect (got $got)"
+    fi
+}
+
+# --- oracle plan --------------------------------------------------------
+#  1,2  default arm: many-buffer streaming body, ONE END call
+#  3,4  tiny configured output buffers (zstd_buffers 4 4k)
+#  5,6  data-less final buffer (empty body)
+#  7,8  dcz framing (40-byte skippable prefix in the first buffer)
+#  9,10 flush + last (proxy_buffering off)
+# 11    a completed response makes at least one NON-end codec call too, so
+#       the split between the two sites is real and oracle 2 is not counting
+#       the whole response
+# 12    client abort mid-response does not wedge the worker
+# 13    error log carries no crit/alert/emerg across the whole run
+#
+# There is no separate trained-dictionary arm: zstd_dict_file is MAIN_CONF
+# only, so enabling it would load the CDict for EVERY location here and move
+# every count in the table below rather than isolating one arm. The dcz arm
+# above is this scenario's dictionary-loaded CCtx coverage -- it goes through
+# the same CDict-backed compressor, plus the skippable-prefix framing. The
+# non-dcz trained-dictionary path keeps its existing coverage in ci/t/03-dcz.t
+# and tools/test_dcz.py.
+echo "1..13"
+
+# EVERY EXPECTED COUNT BELOW WAS MEASURED, on this conf, against both the
+# optimized and the reverted filter. Each one is exactly one lower with the
+# optimization than without it, which is the row's claim stated as a number:
+#
+#   arm            optimized   reverted   delta
+#   default            7           8       -1
+#   tiny-buffers       7           8       -1
+#   empty-body         1           2       -1
+#   dcz                7           8       -1
+#   flush-last        57          58       -1
+#
+# Because they are exact, they are also the scenario's most brittle
+# assertions: a change to a body fixture, to zstd_buffers, or to libzstd's
+# internal buffering will move them and this scenario will red. That is
+# intended -- the count IS the property under test, and a count that could
+# drift without anyone noticing would not be one. When an intentional change
+# moves a number here, re-measure and update the table above with it; do NOT
+# widen the comparison to a range, which is precisely what would let the
+# removed call creep back unnoticed.
+#
+# The flush-last arm's 57 reflects proxy_buffering off chunking the body into
+# many small upstream writes, each of which drives its own compress calls.
+# Its absolute value is an artifact of that chunking; its DELTA of one is the
+# part that carries meaning, and it is the arm where a pending ctx->flush
+# coexists with last_buf.
+
+measure "default" "/index.html" "$WWW/index.html" zstd 7
+
+# Tiny output buffers: the compressed body still fits well inside one 4k
+# buffer's remaining space at the point the frame closes, so this stays 1 --
+# but it reaches that point having already cycled several output buffers,
+# which is the property being covered. If a future libzstd needs more than
+# one END call here, this is the oracle that will say so, loudly, rather
+# than a range that hides it.
+measure "tiny-buffers" "/tiny/index.html" "$WWW/index.html" zstd 7
+
+# Data-less final buffer: an empty body's terminal link carries last_buf and
+# nothing else. Under the old two-call sequence this response reached END
+# via the state machine's transition; now the directive selection picks END
+# on the first and only call.
+measure "empty-body" "/empty" "$WWW/empty.txt" zstd 1
+
+# flush + last. proxy_buffering off makes the upstream force flushes around
+# chunks the encoder buffers internally, so ctx->flush can still be pending
+# when last_buf arrives. END must win the directive selection there -- if
+# the pending flush won instead, the frame would never be closed and this
+# request would hang until the 15s deadline rather than decode.
+if [ -n "$DICT_SHA_B64" ]; then
+    measure "dcz" "/dcz/index.html" "$WWW/index.html" dcz 7 \
+        "Accept-Encoding: zstd, dcz" \
+        "Available-Dictionary: :$DICT_SHA_B64:"
+else
+    ok "dcz: response decodes byte-for-byte to the origin # SKIP openssl unavailable"
+    ok "dcz: total codec calls is 7 # SKIP openssl unavailable"
+fi
+
+measure "flush-last" "/flushlast" "$WWW/index.html" zstd 57
+
+# The two sites really are split. If the END selection had swallowed the
+# whole response (every call landing at the END site), codec_calls would be
+# 0 and oracle 2's "1" would be counting the entire compression rather than
+# just the frame close -- a passing number for the wrong reason.
+if reset_counters \
+   && fetch "/index.html" "$PROBER_PREFIX/tmp/split.bin" \
+   && encoded_as "$PROBER_PREFIX/tmp/split.bin.hdrs" zstd; then
+    NONEND="$(read_counter codec_calls || echo -1)"
+    if [ "$NONEND" -ge 1 ]; then
+        ok "streaming site is still reached ($NONEND non-END calls)"
+    else
+        diag "codec_calls=$NONEND"
+        notok "streaming site is still reached (got $NONEND non-END calls)"
+    fi
+else
+    notok "streaming site is still reached (request or reset failed)"
+fi
+
+# Client abort: tear the connection down mid-response and require the worker
+# to still serve a clean, decodable 200 afterwards. A terminal-frame change
+# that leaks a half-closed frame or wedges ctx->done would show up here as a
+# dead or wrong follow-up response.
+(
+    exec 3<>"/dev/tcp/$HOST/$PORT" || exit 1
+    printf 'GET /index.html HTTP/1.1\r\nHost: prober\r\n' >&3
+    printf 'Accept-Encoding: zstd\r\nConnection: close\r\n\r\n' >&3
+    head -c 64 <&3 >/dev/null 2>&1 || true
+) >/dev/null 2>&1 || true
+
+if fetch "/index.html" "$PROBER_PREFIX/tmp/after-abort.bin" \
+   && encoded_as "$PROBER_PREFIX/tmp/after-abort.bin.hdrs" zstd \
+   && decodes_to "$PROBER_PREFIX/tmp/after-abort.bin" "$WWW/index.html"; then
+    ok "a full response still decodes after a mid-response client abort"
+else
+    notok "a full response still decodes after a mid-response client abort"
+fi
+
+# No crit/alert/emerg anywhere in this run. This scenario injects no faults,
+# so any such line is a real defect -- and the terminal-frame bug class this
+# change touches announces itself exactly there ("zero size buf in writer").
+if grep -qE '\[(crit|alert|emerg)\]' "$ELOG" 2>/dev/null; then
+    diag "$(grep -E '\[(crit|alert|emerg)\]' "$ELOG" | head -3)"
+    notok "error log carries no crit/alert/emerg lines"
+else
+    ok "error log carries no crit/alert/emerg lines"
+fi
+
+exit "$FAILED"

--- a/ci/t/harness-scenarios/codec-call-count/driver.sh
+++ b/ci/t/harness-scenarios/codec-call-count/driver.sh
@@ -88,6 +88,9 @@ mkdir -p "$WWW" "$PROBER_PREFIX/tmp"
 # PROBER_SERVER_BIN is the exported <build>/objs/nginx, so its dirname is
 # the same objs/ dir @BUILD_OBJS@ renders into the conf.
 DICT_FILE="$(dirname "$PROBER_SERVER_BIN")/codec-call-count.dict"
+# openssl(1) presence is already proven by this scenario's `requires` gate, so
+# an empty result here means the dictionary FILE is unreadable, not that the
+# tool is missing -- which is why the failure branch below says so.
 DICT_SHA_B64="$(openssl dgst -sha256 -binary "$DICT_FILE" 2>/dev/null \
                 | openssl base64 -A 2>/dev/null || true)"
 
@@ -294,8 +297,15 @@ if [ -n "$DICT_SHA_B64" ]; then
         "Accept-Encoding: zstd, dcz" \
         "Available-Dictionary: :$DICT_SHA_B64:"
 else
-    ok "dcz: response decodes byte-for-byte to the origin # SKIP openssl unavailable"
-    ok "dcz: total codec calls is 7 # SKIP openssl unavailable"
+    # NOT a SKIP. openssl(1) is a hard requires-gate for this scenario, so
+    # reaching here means the hash derivation failed for some other reason --
+    # an unreadable or truncated dictionary file. A SKIP would print
+    # "ok ... # SKIP", which reads as a pass to anything grepping for the
+    # oracle, so the dcz arm would assert nothing while the run stayed green.
+    # Fail loudly instead, and say what actually broke rather than blaming a
+    # missing tool the gate already proved is present.
+    notok "dcz: response decodes byte-for-byte to the origin (could not derive the dictionary hash from $DICT_FILE)"
+    notok "dcz: total codec calls is 7 (not measured -- no dictionary hash)"
 fi
 
 measure "flush-last" "/flushlast" "$WWW/index.html" zstd 57

--- a/ci/t/harness-scenarios/codec-call-count/nginx.conf
+++ b/ci/t/harness-scenarios/codec-call-count/nginx.conf
@@ -1,0 +1,98 @@
+@LOAD@
+# Local scenario (NOT vendored, NOT gitignored). Same shape as alloc-neutral:
+# this repo IS the module under test, so PROBER_MODULE is
+# ngx_http_zstd_filter_module.so itself and @LOAD@ already load_modules it.
+# The module registers ZONELESS hooks, so codec_calls / codec_end_calls reach
+# the driver through the module_render path.
+daemon off;
+pid @PREFIX@/nginx.pid;
+error_log @PREFIX@/logs/error.log info;
+worker_processes 1;
+events { worker_connections 16; }
+http {
+    default_type text/plain;
+
+    server {
+        listen 127.0.0.1:@PORT@;
+
+        # A REAL STATIC ROOT, not `return 200`: a return directive fires at
+        # the REWRITE phase and short-circuits later phases, so the body
+        # filter chain this module lives in would never run and every
+        # call-count oracle would measure zero calls and pass vacuously.
+        root @PREFIX@/www;
+
+        # Default arm: ordinary compression, module-default output buffers.
+        location / {
+            zstd on;
+            zstd_min_length 0;
+        }
+
+        # TINY configured output buffers. This is the arm that forces the
+        # ZSTD_e_end epilogue across SEVERAL calls (zrc > 0 -> ctx->redo),
+        # which is precisely the loop the one-call selection must keep
+        # re-driving correctly rather than truncating. 4k matches the
+        # smallest value 00-filter.t TEST 49 already pins as valid.
+        location /tiny/ {
+            alias @PREFIX@/www/;
+            zstd on;
+            zstd_min_length 0;
+            zstd_buffers 4 4k;
+        }
+
+        # proxy_buffering off: the upstream forces a FLUSH around chunks the
+        # encoder buffers internally, so this arm exercises flush-then-last
+        # -- a pending ctx->flush arriving together with last_buf. END must
+        # still win the directive selection there.
+        location /flushlast {
+            zstd on;
+            zstd_min_length 0;
+            proxy_buffering off;
+            proxy_http_version 1.1;
+            proxy_pass http://127.0.0.1:@PORT@/origin/index.html;
+        }
+
+        # dcz framing: the 40-byte skippable prefix is written into the
+        # first compressor buffer by get_buf BEFORE the first compress call,
+        # so this is the arm where "this call produced no output" and "the
+        # out_buf is non-empty" disagree -- the exact distinction the
+        # END-transition arm is keyed on. Negotiated by the driver with an
+        # Available-Dictionary request header. The dictionary is staged into
+        # the build's objs/ dir by this scenario's `requires` gate, which is
+        # the only hook that runs before nginx's config test opens it.
+        location /dcz/ {
+            alias @PREFIX@/www/;
+            zstd on;
+            zstd_min_length 0;
+            zstd_dcz_dict_file @BUILD_OBJS@/codec-call-count.dict;
+            # The prober speaks plaintext HTTP, and dcz is refused on a
+            # non-secure hop unless the operator asserts the client hop was
+            # secure. Without this the module answers plain zstd and this arm
+            # silently measures the wrong path -- caught, not hidden, by
+            # measure()'s Content-Encoding assertion. ci/t/03-dcz.t sets the
+            # same flag on every one of its blocks for the same reason.
+            zstd_dcz_assume_secure_transport on;
+        }
+
+        # Plain (uncompressed) origin for the proxied arm above.
+        location /origin/ {
+            alias @PREFIX@/www/;
+            zstd off;
+        }
+
+        # An EMPTY body: the terminal buffer carries last_buf and no data at
+        # all, so the END call is the only codec call the response makes.
+        # `location = /empty`, an EXACT match, not a prefix. A prefix
+        # location whose alias does not end in a separator is the
+        # alias-traversal shape (gixy alias_traversal): a request for
+        # /emptyX would be aliased to <www>/empty.txtX. Nothing here serves
+        # attacker-controlled paths, but a test fixture should not model a
+        # pattern the repo's own linters flag.
+        location = /empty {
+            zstd on;
+            zstd_min_length 0;
+            alias @PREFIX@/www/empty.txt;
+        }
+
+        location /__probe { @PROBE@ }
+    }
+}

--- a/ci/t/harness-scenarios/codec-call-count/nginx.conf
+++ b/ci/t/harness-scenarios/codec-call-count/nginx.conf
@@ -74,6 +74,15 @@ http {
         }
 
         # Plain (uncompressed) origin for the proxied arm above.
+        #
+        # `zstd off` here is belt-and-braces, not the mechanism: `zstd` is off
+        # by default and every `zstd on` in this conf is location-scoped, so
+        # this location would serve identity anyway. It is worth keeping
+        # explicit because nginx does NOT strip Accept-Encoding on the proxy
+        # hop, so the client's `Accept-Encoding: zstd` really does arrive
+        # here -- and if anyone later adds a server- or http-level `zstd on`,
+        # this line is what stops /flushlast from compressing twice and
+        # measuring a call count for the wrong stream.
         location /origin/ {
             alias @PREFIX@/www/;
             zstd off;

--- a/ci/t/harness-scenarios/codec-call-count/requires
+++ b/ci/t/harness-scenarios/codec-call-count/requires
@@ -37,6 +37,21 @@ if ! command -v zstd >/dev/null 2>&1; then
     exit 1
 fi
 
+# openssl(1) is gated on exactly the same reasoning, and it is the CLI that is
+# required, not libssl: the driver shells out to `openssl dgst`/`openssl base64`
+# to derive the Available-Dictionary hash the dcz arm negotiates with. Without
+# it that arm cannot run.
+#
+# It is a hard gate rather than a driver-side SKIP deliberately. A SKIP prints
+# an "ok ... # SKIP" line, which reads as a pass to every consumer that greps
+# for the oracle -- so the dcz arm would assert nothing while the run stayed
+# green, which is the false green this scenario exists to remove. Failing the
+# whole scenario here is loud and impossible to misread.
+if ! command -v openssl >/dev/null 2>&1; then
+    echo "openssl(1) not found -- the dcz arm derives its Available-Dictionary hash with \"openssl dgst -sha256 | openssl base64\"; the CLI is required, not just libssl"
+    exit 1
+fi
+
 # Stage the dictionary fixture the dcz and trained-dict arms need.
 #
 # It has to exist before nginx runs its CONFIG TEST -- zstd_dcz_dict_file and

--- a/ci/t/harness-scenarios/codec-call-count/requires
+++ b/ci/t/harness-scenarios/codec-call-count/requires
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Gate: the tree run-scenario.sh is about to boot must be a TEST_HARNESS build.
+# This scenario reads the codec_calls / codec_end_calls counters out of the
+# probe document, and without both TEST_HARNESS=1 and -DNGX_TEST_HARNESS the
+# probe endpoint compiles out entirely -- `nginx -t` would then reject the
+# `zstd_probe;` in nginx.conf and the scenario would red for a build reason
+# rather than a module one.
+#
+# Derived the same way run-scenario.sh/lib.sh resolve the build tree, so this
+# gate can never SKIP a tree the engine would boot fine or pass one it would
+# reject -- identical reasoning to fault-arms/requires and alloc-neutral's.
+set -euo pipefail
+
+FLAVOR="${2:-nginx}"
+VERSION="${3:-1.31.3}"
+BUILD="${PROBER_BUILD:-${PROBER_ROOT:-$(cd ../.. && pwd)}/.build/${FLAVOR}-${VERSION}}"
+SO="$BUILD/objs/ngx_http_zstd_filter_module.so"
+
+if [ ! -f "$SO" ]; then
+    echo "ngx_http_zstd_filter_module.so not found at $SO -- build it first"
+    exit 1
+fi
+
+if ! nm "$SO" 2>/dev/null | grep -q ' ngx_test_probe_'; then
+    echo "$SO carries no ngx_test_probe_* symbols -- this is a packaged (non-harness) build; configure with TEST_HARNESS=1 CFLAGS=\"\$CFLAGS -DNGX_TEST_HARNESS\" first"
+    exit 1
+fi
+
+# Every call-count oracle here is PAIRED with a decode of the same response
+# against the origin bytes, because a call count on its own is satisfied by a
+# response that is fast and wrong. A missing decoder would silently weaken
+# every one of them to "200 and some bytes". Fail here instead: a gate that
+# cannot run its assertion is not a gate.
+if ! command -v zstd >/dev/null 2>&1; then
+    echo "zstd(1) not found -- every oracle decodes its response and compares it byte-for-byte with the origin file"
+    exit 1
+fi
+
+# Stage the dictionary fixture the dcz and trained-dict arms need.
+#
+# It has to exist before nginx runs its CONFIG TEST -- zstd_dcz_dict_file and
+# zstd_dict_file open their file at configuration time, so a driver-written
+# fixture is far too late (the prefix the driver writes into is not created
+# until prober_render_conf, immediately before that config test). This gate is
+# the only hook that runs earlier, so it stages the file and the conf
+# references it through @BUILD_OBJS@, the one absolute path the renderer
+# substitutes that exists this early.
+#
+# Copied from the repo's own checked-in ci/t/suite/dcz-dict rather than
+# generated, so the dcz arm here negotiates against exactly the dictionary
+# 03-dcz.t already pins the wire contract against.
+DICT_SRC="$(cd "$(dirname "$0")/../../suite" && pwd)/dcz-dict"
+if [ ! -f "$DICT_SRC" ]; then
+    echo "dictionary fixture not found at $DICT_SRC"
+    exit 1
+fi
+if ! cp -f "$DICT_SRC" "$BUILD/objs/codec-call-count.dict"; then
+    echo "cannot stage the dictionary fixture into $BUILD/objs"
+    exit 1
+fi
+
+exit 0

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -2186,24 +2186,58 @@ ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
     pos_in  = ctx->buffer_in.pos;
     pos_out = ctx->buffer_out.pos;
 
-    /*
-     * Determine the compression directive.
-     *
-     * END always wins (terminal frame). Otherwise a pending flush
-     * (ctx->flush) must map to ZSTD_e_flush even while the action state
-     * machine is still COMPRESS: that machine only transitions
-     * COMPRESS->FLUSH *after* a call that returned rc > 0 (zstd already
-     * had output to drain). Under `proxy_buffering off` the upstream
-     * forces a flush around a chunk that zstd consumes/buffers
-     * internally with rc == 0; if the directive stayed ZSTD_e_continue
-     * there, libzstd is never told to flush and holds those bytes
-     * indefinitely. Mapping ctx->flush -> ZSTD_e_flush forces libzstd
-     * to disgorge whatever it has buffered, exactly as the stock nginx
-     * gzip/brotli body filters issue a sync flush on a pending flush.
-     */
-    if (ctx->action == NGX_HTTP_ZSTD_FILTER_END) {
+    /* Determine the compression directive. */
+    if (ctx->action == NGX_HTTP_ZSTD_FILTER_END
+        || (ctx->last && ctx->in == NULL))
+    {
+        /*
+         * END wins, and it is selected as soon as this is provably the
+         * final call's input rather than one iteration later.
+         *
+         * `ctx->last && ctx->in == NULL` is the state machine's own
+         * COMPRESS->END transition predicate (below) minus its
+         * "buffer_in fully drained" clause. That clause is what forced a
+         * separate ZSTD_e_continue call first: the transition could only
+         * fire once libzstd had already eaten the buffer, so the frame
+         * was closed by a SECOND call carrying no new input. libzstd does
+         * not need that. ZSTD_e_end accepts pending input, consumes what
+         * it can and closes the frame in the same call, returning
+         * non-zero while the epilogue still has bytes to write -- which
+         * the existing `zrc > 0 -> ctx->redo = 1` arm below already
+         * re-drives, unchanged. Dropping the clause therefore removes one
+         * ZSTD_compressStream2() call from every completed response and
+         * lets libzstd take its documented first-call ZSTD_e_end fast
+         * path (ZSTD_compress2()) when the whole body and enough output
+         * space are present.
+         *
+         * ctx->in == NULL is load-bearing and stays: it is what proves no
+         * further chain link is queued behind this buffer. Selecting END
+         * with input still queued would close the frame early and
+         * truncate the body -- the 131072-byte truncation PR #49's
+         * transition predicate was written to prevent.
+         *
+         * Compressed bytes are allowed to differ from the two-call
+         * sequence (a frame is a few bytes smaller when libzstd sees the
+         * whole input at once). Frame VALIDITY and byte-identical
+         * decoded plaintext are the contract; the exact compressed byte
+         * stream is deliberately not one.
+         */
         directive = ZSTD_e_end;
+
     } else if (ctx->action == NGX_HTTP_ZSTD_FILTER_FLUSH || ctx->flush) {
+        /*
+         * A pending flush (ctx->flush) must map to ZSTD_e_flush even while
+         * the action state machine is still COMPRESS: that machine only
+         * transitions COMPRESS->FLUSH *after* a call that returned rc > 0
+         * (zstd already had output to drain). Under `proxy_buffering off`
+         * the upstream forces a flush around a chunk that zstd
+         * consumes/buffers internally with rc == 0; if the directive stayed
+         * ZSTD_e_continue there, libzstd is never told to flush and holds
+         * those bytes indefinitely. Mapping ctx->flush -> ZSTD_e_flush
+         * forces libzstd to disgorge whatever it has buffered, exactly as
+         * the stock nginx gzip/brotli body filters issue a sync flush on a
+         * pending flush.
+         */
         directive = ZSTD_e_flush;
     } else {
         directive = ZSTD_e_continue;
@@ -2331,17 +2365,46 @@ ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
         /*
          * rc > 0: zstd has buffered data. For COMPRESS, transition to FLUSH
          * to drain libzstd's internal buffers. For FLUSH/END, keep the action.
+         *
+         * A call that ran ZSTD_e_end is already in the terminal phase even
+         * when ctx->action has not caught up (the directive selection above
+         * picks END directly from `ctx->last && ctx->in == NULL`, one
+         * iteration before this machine would have transitioned). Record
+         * that here rather than parking the action in FLUSH: a FLUSH action
+         * with ctx->last set would still re-select END on the next
+         * iteration -- the directive is correct either way -- but leaving
+         * the state saying "flushing" while the frame epilogue is being
+         * written misdescribes the stream to every later reader of
+         * ctx->action, including the emit trace and the flush accounting
+         * below.
          */
-        if (ctx->action == NGX_HTTP_ZSTD_FILTER_COMPRESS) {
+        if (directive == ZSTD_e_end) {
+            ctx->action = NGX_HTTP_ZSTD_FILTER_END;
+
+        } else if (ctx->action == NGX_HTTP_ZSTD_FILTER_COMPRESS) {
             ctx->action = NGX_HTTP_ZSTD_FILTER_FLUSH;
         }
         ctx->redo = 1;
 
     } else if (ctx->last && ctx->action != NGX_HTTP_ZSTD_FILTER_END
+               && directive != ZSTD_e_end
                && ctx->buffer_in.pos >= ctx->buffer_in.size
                && ctx->in == NULL)
     {
         /*
+         * `directive != ZSTD_e_end` is what keeps this arm meaning what
+         * its body says. It exists for the case where the call that just
+         * ran did NOT close the frame, so a further ZSTD_e_end iteration
+         * still has to happen -- which is why it can return NGX_AGAIN and
+         * suppress the buffer. Since the directive selection above may now
+         * pick END on this very call, the arm would otherwise be reachable
+         * with the frame already terminal (zrc == 0, directive
+         * ZSTD_e_end): it would then swallow the zero-output terminal
+         * buffer and return NGX_AGAIN forever instead of emitting the
+         * zero-length last_buf -- the request hang PR #196 fixed on this
+         * same path. With the guard, a terminal END call falls through to
+         * the `last` computation below, exactly as before.
+         *
          * PR #49: All input consumed; transition to END only when:
          * - last flag is set (we know this is the final chunk)
          * - input buffer fully drained (no more bytes to feed libzstd)

--- a/src/ngx_http_zstd_probe_hooks.c
+++ b/src/ngx_http_zstd_probe_hooks.c
@@ -89,6 +89,15 @@ static ngx_int_t  ngx_http_zstd_probe_fault_codec_end_nth = -1;
  * Counting from the arm instead gives `fault_codec=N` one unambiguous
  * meaning -- the Nth call at this site after you armed it -- which holds
  * no matter what traffic preceded it.
+ *
+ * Both are also RENDERED by module_render below, which makes them an
+ * assertable observable and not just a fault ordinal: disarm a site
+ * (fault_<site>=-1 zeroes its counter), issue exactly one request, then
+ * read /__probe and the counter is that request's ZSTD_compressStream2()
+ * call count at that site. That is the oracle behind the "one END call per
+ * completed response" assertions in ci/t/00-filter.t -- an assertion that
+ * cannot be satisfied by a merely-correct response, only by a response
+ * that also took the intended number of codec calls.
  */
 static ngx_uint_t  ngx_http_zstd_probe_codec_calls;
 static ngx_uint_t  ngx_http_zstd_probe_codec_end_calls;
@@ -245,10 +254,14 @@ ngx_http_zstd_probe_module_render(u_char *buf, u_char *last)
     buf = ngx_slprintf(buf, last,
                         "\"chain_links_allocated\":%ui"
                         ",\"buffers_allocated\":%ui"
-                        ",\"palloc_calls\":%ui",
+                        ",\"palloc_calls\":%ui"
+                        ",\"codec_calls\":%ui"
+                        ",\"codec_end_calls\":%ui",
                         ngx_http_zstd_probe_chain_links,
                         ngx_http_zstd_probe_bufs_allocated,
-                        ngx_http_zstd_probe_palloc_calls);
+                        ngx_http_zstd_probe_palloc_calls,
+                        ngx_http_zstd_probe_codec_calls,
+                        ngx_http_zstd_probe_codec_end_calls);
 
     if (ngx_http_zstd_probe_have_ctx) {
         buf = ngx_slprintf(buf, last,


### PR DESCRIPTION
## TL;DR

When this module finishes compressing a page, it has to write a few closing
bytes that tell the browser "that's the whole thing". We were asking the
compression library to do that in a separate, extra step — hand over the last
of the page, then go back and ask it to close up. It turns out the library is
happy to do both at once, so I dropped the extra step.

Concretely: `ngx_http_zstd_filter_compress()` now selects `ZSTD_e_end` on the
call that carries the final input, instead of waiting for the action state
machine to transition `COMPRESS -> END` after a separate `ZSTD_e_continue`
call. That removes one `ZSTD_compressStream2()` call from every completed
response.

**Severity:** low — a performance and call-count change, no behaviour or
security impact. The one thing worth deliberate review is the byte-stability
decision below.

## Why the extra call existed

The state machine only transitioned to END once `buffer_in` was already
drained, and it could not know that until a call had drained it — so the frame
was always closed by a second call carrying no new input. libzstd never needed
that: `ZSTD_e_end` accepts pending input and returns non-zero only while the
epilogue still has bytes that did not fit in the output buffer, which the
existing `zrc > 0 -> ctx->redo = 1` arm already re-drives.

The new predicate is therefore the state machine's own transition predicate
minus the clause that forced the extra call: `ctx->last && ctx->in == NULL`.
I kept `ctx->in == NULL`, and it is load-bearing — it proves no further chain
link is queued behind this buffer. Selecting END with input still queued would
close the frame early and truncate the body, which is the 131072-byte
truncation PR #49's predicate exists to prevent.

## Compressed bytes are not a contract

Review this bit deliberately. Handing libzstd the whole input at once lets it
emit a slightly smaller frame than the two-call sequence did, so the compressed
byte stream may differ in size and content.

What this module guarantees is that frames stay valid and decode to
byte-identical plaintext; the exact compressed byte stream is explicitly not a
guarantee, and I have written that into the comment at the selection site.
Nothing had to be weakened to land it — no existing test asserted compressed
bytes or length, and the full suite passes unchanged.

## Two guards that come with it

Selecting END one iteration earlier makes two previously-unreachable states
reachable:

- The `zrc > 0` arm now sets `ctx->action = END` when the call that ran was
  `ZSTD_e_end`, rather than parking the action in `FLUSH` while the frame
  epilogue is being written. The directive re-selects END either way, so this
  is about `ctx->action` not misdescribing the stream to the emit trace and the
  flush accounting.

- The END-transition arm gained `directive != ZSTD_e_end`. Without it that arm
  becomes reachable with the frame already terminal (`zrc == 0`), where it
  would swallow the zero-output terminal buffer and return `NGX_AGAIN` forever
  instead of emitting the zero-length `last_buf` — the request hang PR #196
  fixed on this same path. Its existing `ctx->action != END` conjunct does not
  cover this, because on the first END-selecting call the action is still
  `COMPRESS`.

## No speed claim

An interleaved A/B (`ci/tools/ab_bench.py`, 5 rounds, master module vs patched,
same nginx binary) straddles zero:

| conc | body | master rps | e_end rps | delta |
|---|---|---|---|---|
| 8 | 8kb | 8681.0 | 8802.4 | +1.4% |
| 8 | 64kb | 4345.4 | 4246.1 | -2.3% |
| 32 | 8kb | 9303.2 | 9297.6 | -0.1% |
| 32 | 64kb | 7055.4 | 7142.0 | +1.2% |
| 128 | 8kb | 10063.0 | 9743.8 | -3.2% |
| 128 | 64kb | 8025.7 | 7868.7 | -2.0% |

That is noise. The justification is the removed call and the unlocked
first-call `ZSTD_e_end` -> `ZSTD_compress2()` fast path, not measured
throughput.

## Testing

Both the one-call and two-call paths produce a valid frame that decodes
identically, so a correct response proves nothing here — the observable is the
count. `ci/t/harness-scenarios/codec-call-count` asserts it directly:
`src/ngx_http_zstd_probe_hooks.c` renders the probe's two existing per-site
codec counters, and since disarming a site zeroes its counter, a reset plus one
request gives that request's call count.

Each arm pairs a byte-for-byte decode check with an exact total-call assertion:
drop the decode half and a truncating filter passes, drop the count half and
the revert passes.

The counted value is the sum of both sites, not `codec_end_calls` — and I found
that by measuring, not by reasoning. The removed call is a `ZSTD_e_continue`,
which lands at the streaming site, so both paths close the frame in exactly one
END call. I wrote the oracle on `codec_end_calls` first, the mutation run came
back all-green, and that is what sent me looking.

Arms: one and many output buffers, tiny configured buffers, a data-less final
buffer, dcz framing, flush+last under `proxy_buffering off`, and a mid-response
client abort. Allocation-failure (`nomem`) coverage on this path is the
existing `fault-palloc` scenario.

Mutation proof — revert the optimization, rebuild, re-run (exit 1):

```
not ok 2 - default: total codec calls is 7 (got 8)
not ok 4 - tiny-buffers: total codec calls is 7 (got 8)
not ok 6 - empty-body: total codec calls is 1 (got 2)
not ok 8 - dcz: total codec calls is 7 (got 8)
not ok 10 - flush-last: total codec calls is 57 (got 58)
```

Every decode oracle stayed green through that run, which is the property the
TODO row asked for: the mutation adds the call back without breaking decode
correctness. Restoring the patch returns all 13 to `ok`.

Also green: the full Test::Nginx suite (2027 tests), and the `fault-arms`,
`fault-palloc` and `alloc-neutral` scenarios. `fault-arms` oracle 7 is the
existing guard against exactly the terminal-frame hazard this change could have
broken, and it passes. Build is clean under `-Wextra -Werror`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved zstd response finalization to reduce unnecessary codec calls.
  * Fixed handling of empty responses and terminal responses that produce no output.
  * Improved reliability for streaming, buffered, dictionary-based, and client-aborted responses.

* **Tests**
  * Added automated coverage verifying codec call counts, response decoding, worker recovery, and critical log behavior.
  * Added probe metrics to make codec-call behavior observable during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->