### PR TITLE
perf: skip ZSTD_compressBound() for known-large bodies, unroll the qvalue fraction walk

### DIFF
--- a/ci/t/00-filter.t
+++ b/ci/t/00-filter.t
@@ -2796,3 +2796,142 @@ sub {
 first-chunk-second-chunk-third-chunk-fourth-chunk-tail
 --- no_error_log
 [error]
+
+
+
+=== TEST 101: pledged size just below the configured buffer size still round-trips
+# Boundary regression for skipping ZSTD_compressBound() when the pledged
+# Content-Length is already >= the configured zstd_buffers size (that
+# skip cannot shrink buf_size below what the call would have produced --
+# see the get_buf() comment). zstd_buffers is pinned to a small, exact
+# size (1 buffer of 512 bytes) so the boundary sits at an exact byte
+# count instead of the 128 KB default. This case pledges 511 bytes --
+# ONE BYTE UNDER buf_size -- which must still take the ORIGINAL
+# ZSTD_compressBound() path (pledged_size < buf_size), unaffected by the
+# new skip branch. Correctness oracle: byte-exact round-trip.
+--- config eval
+"    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        zstd_buffers 1 512;
+        proxy_pass http://127.0.0.1:\$TEST_NGINX_SERVER_PORT/src;
+    }
+    location /src {
+        default_type text/plain;
+        return 200 \"" . ("A" x 511) . "\";
+    }"
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+!Content-Length
+Content-Encoding: zstd
+--- response_body_filters eval
+sub {
+    my $zstd = $_[0];
+    require File::Temp;
+    my ($tfh, $tmp) = File::Temp::tempfile("zstd_t101_XXXXXX",
+                                           TMPDIR => 1, UNLINK => 1);
+    binmode($tfh); print $tfh $zstd; close($tfh);
+    open(my $r, "-|", "zstd", "-dqc", $tmp) or do { unlink $tmp; return "ERR" };
+    local $/; my $d = <$r>; close($r); my $rc = $?; unlink $tmp;
+    return "ERR-DECODE rc=$rc" if $rc != 0;
+    return $d;
+}
+--- response_body eval
+"A" x 511
+--- no_error_log
+[error]
+
+
+
+=== TEST 102: pledged size EXACTLY EQUAL to the configured buffer size still round-trips
+# The exact boundary the skip's ">=" comparison turns on: pledged_size ==
+# buf_size (512 == 512) takes the NEW skip path (get_buf():
+# "(size_t) ctx->pledged_size >= buf_size"). ZSTD_compressBound(512) + 64
+# is provably >= 512, so the clamp this call feeds would never have fired
+# here either -- this case is the one boundary value where that claim
+# must hold exactly, not just in the general case covered by TEST 103.
+--- config eval
+"    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        zstd_buffers 1 512;
+        proxy_pass http://127.0.0.1:\$TEST_NGINX_SERVER_PORT/src;
+    }
+    location /src {
+        default_type text/plain;
+        return 200 \"" . ("B" x 512) . "\";
+    }"
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+!Content-Length
+Content-Encoding: zstd
+--- response_body_filters eval
+sub {
+    my $zstd = $_[0];
+    require File::Temp;
+    my ($tfh, $tmp) = File::Temp::tempfile("zstd_t102_XXXXXX",
+                                           TMPDIR => 1, UNLINK => 1);
+    binmode($tfh); print $tfh $zstd; close($tfh);
+    open(my $r, "-|", "zstd", "-dqc", $tmp) or do { unlink $tmp; return "ERR" };
+    local $/; my $d = <$r>; close($r); my $rc = $?; unlink $tmp;
+    return "ERR-DECODE rc=$rc" if $rc != 0;
+    return $d;
+}
+--- response_body eval
+"B" x 512
+--- no_error_log
+[error]
+
+
+
+=== TEST 103: pledged size well ABOVE the configured buffer size still round-trips
+# Deep into the skip path: a body several times larger than buf_size,
+# well past the boundary, still round-trips byte-exact with the
+# ZSTD_compressBound() call skipped on the first buffer. (4000 bytes,
+# not larger: nginx's config-file tokenizer has its own line-length
+# limit on a quoted "return" literal, well under a size that would
+# still usefully exercise this boundary -- 4000 is comfortably above
+# both buf_size=512 and that unrelated limit.)
+--- config eval
+"    location /filter {
+        zstd on;
+        zstd_min_length 1;
+        zstd_types text/plain;
+        zstd_buffers 4 512;
+        proxy_pass http://127.0.0.1:\$TEST_NGINX_SERVER_PORT/src;
+    }
+    location /src {
+        default_type text/plain;
+        return 200 \"" . ("C" x 4000) . "\";
+    }"
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+!Content-Length
+Content-Encoding: zstd
+--- response_body_filters eval
+sub {
+    my $zstd = $_[0];
+    require File::Temp;
+    my ($tfh, $tmp) = File::Temp::tempfile("zstd_t103_XXXXXX",
+                                           TMPDIR => 1, UNLINK => 1);
+    binmode($tfh); print $tfh $zstd; close($tfh);
+    open(my $r, "-|", "zstd", "-dqc", $tmp) or do { unlink $tmp; return "ERR" };
+    local $/; my $d = <$r>; close($r); my $rc = $?; unlink $tmp;
+    return "ERR-DECODE rc=$rc" if $rc != 0;
+    return $d;
+}
+--- response_body eval
+"C" x 4000
+--- no_error_log
+[error]

--- a/src/ngx_http_zstd_common.h
+++ b/src/ngx_http_zstd_common.h
@@ -87,17 +87,38 @@ ngx_http_zstd_skip_quoted(u_char *p, const u_char *end)
 static ngx_int_t
 ngx_http_zstd_parse_q_fraction(const u_char *end, u_char **p)
 {
-    /* ngx_int_t (not int) so the digit*scale product widens before the
+    /* ngx_int_t (not int) so each digit*weight product widens before the
      * add — avoids a theoretical int overflow CodeQL flags (the operands
      * are tiny in practice). */
-    ngx_int_t  scale = 100;
     ngx_int_t  frac = 0;
     u_char    *q = *p;
 
-    while (q < end && *q >= '0' && *q <= '9' && scale > 0) {
-        frac += (*q - '0') * scale;
-        scale /= 10;
+    /*
+     * RFC 9110's qvalue grammar permits at most three fractional digits
+     * ("0" "." 0*3DIGIT), so the walk is fixed at three guarded steps
+     * with literal weights 100/10/1 instead of a loop counting a
+     * runtime `scale` down by dividing by 10 each iteration. Each step
+     * is behaviour-identical to one loop iteration of the original: it
+     * only fires if the previous step also fired (so a mismatch or
+     * end-of-input at digit N leaves N-1..2 unconsumed, exactly as the
+     * loop's own condition would stop it), and after the third digit
+     * `q` is NOT advanced again -- a fourth or later digit byte is
+     * deliberately left for the caller's trailing-junk check to reject,
+     * the same contract the loop's `scale > 0` guard enforced.
+     */
+    if (q < end && *q >= '0' && *q <= '9') {
+        frac += (*q - '0') * 100;
         q++;
+
+        if (q < end && *q >= '0' && *q <= '9') {
+            frac += (*q - '0') * 10;
+            q++;
+
+            if (q < end && *q >= '0' && *q <= '9') {
+                frac += (*q - '0') * 1;
+                q++;
+            }
+        }
     }
 
     *p = q;

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -2773,24 +2773,66 @@ ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
          * streaming case, so this never fires there.
          */
         if (first_buf && ctx->pledged_size >= 0) {
-            size_t  bound = ZSTD_compressBound((size_t) ctx->pledged_size);
 
+#if NGX_MAX_OFF_T_VALUE <= 0xFF00FF00FF00FF00ULL
             /*
-             * ZSTD_compressBound() covers only the compressed payload; pad
-             * it for libzstd's own frame/block header overhead. Never grow
-             * past the configured size, and keep a small floor so
-             * tiny/empty bodies still get a buffer the frame overhead fits
-             * inside.
+             * ZSTD_compressBound(n) == n + (n>>8) + margin, margin >= 0
+             * always (see zstd.h's ZSTD_COMPRESSBOUND macro) -- so the
+             * bound this call would return can never be smaller than
+             * `ctx->pledged_size` itself, and the `+= 64` pad below only
+             * grows it further. When the pledged size is already at
+             * least the configured buffer size, `bound` (however it is
+             * computed) can therefore never satisfy `bound < buf_size`,
+             * so the clamp two lines down never fires and buf_size is
+             * left exactly as it already is. Skip the call entirely on
+             * that path -- one fewer external libzstd call per known
+             * large response, same buf_size either way.
+             *
+             * Gated on the compile-time proof that `off_t`'s range
+             * cannot reach ZSTD_MAX_INPUT_SIZE: NGX_MAX_OFF_T_VALUE is
+             * nginx's own auto-detected max for the platform's off_t
+             * (objs/ngx_auto_config.h, from auto/types/sizeof), and
+             * ZSTD_MAX_INPUT_SIZE is 0xFF00FF00FF00FF00 on any platform
+             * where zstd.h sees an 8-byte size_t (checked via the same
+             * constant here, not a sizeof, so this is decided at
+             * preprocessing before zstd.h's own size_t-width branch is
+             * evaluated). Every off_t this nginx build can produce is
+             * provably inside ZSTD_MAX_INPUT_SIZE here, so
+             * ZSTD_compressBound() cannot hit its own overflow branch
+             * (return 0) for any value pledged_size can hold -- the skip
+             * is safe. A target where this #if is false keeps the
+             * original call and clamp below, unchanged.
              */
-            bound += 64;
+            if ((size_t) ctx->pledged_size >= buf_size) {
+                goto skip_bound;
+            }
+#endif
 
-            if (bound < 256) {
-                bound = 256;
+            {
+                size_t  bound = ZSTD_compressBound((size_t) ctx->pledged_size);
+
+                /*
+                 * ZSTD_compressBound() covers only the compressed
+                 * payload; pad it for libzstd's own frame/block header
+                 * overhead. Never grow past the configured size, and
+                 * keep a small floor so tiny/empty bodies still get a
+                 * buffer the frame overhead fits inside.
+                 */
+                bound += 64;
+
+                if (bound < 256) {
+                    bound = 256;
+                }
+
+                if (bound < buf_size) {
+                    buf_size = bound;
+                }
             }
 
-            if (bound < buf_size) {
-                buf_size = bound;
-            }
+#if NGX_MAX_OFF_T_VALUE <= 0xFF00FF00FF00FF00ULL
+skip_bound:
+            ;
+#endif
         }
 
         /*


### PR DESCRIPTION
Two rows from the parked perf queue survived measurement; three others in the same slice did not and aren't in this diff.

When a response's exact size is already known and it's bigger than the output buffer nginx has configured, there's a size check this module runs before allocating that buffer that can never change its answer for a body that size, so it's skipped. Separately, an HTTP client's quality-value ("how much do I want this encoding") has at most three decimal digits by rule, so a loop that walked "however many digits show up, down to none" became three fixed steps instead.

In code terms: `ngx_http_zstd_filter_get_buf()` (`src/ngx_http_zstd_filter_module.c:2775`) skips the `ZSTD_compressBound()` call when `(size_t) ctx->pledged_size >= buf_size`, and `ngx_http_zstd_parse_q_fraction()` (`src/ngx_http_zstd_common.h:88`) replaces its `scale`-divide-by-10 loop with three guarded steps at literal weights 100/10/1.

**Severity:** `None` (performance: call/instruction-count reductions with no behaviour change, verified equivalent output on every path including the boundary)

## What is going on and why it is safe

**`ZSTD_compressBound()` skip.** zstd's own macro (`ZSTD_COMPRESSBOUND` in `zstd.h`) is `srcSize + (srcSize >> 8) + margin`, and `margin` is never negative, so `bound(n) >= n` for every valid `n`. If `pledged_size >= buf_size`, then `bound(pledged_size) + 64 >= pledged_size + 64 > buf_size`, so the existing `if (bound < buf_size) buf_size = bound;` clamp two lines down can never fire either way, so computing `bound` at all is wasted work on that path.

The skip is gated behind `#if NGX_MAX_OFF_T_VALUE <= 0xFF00FF00FF00FF00ULL` (zstd's `ZSTD_MAX_INPUT_SIZE`, the point past which `ZSTD_compressBound()` itself returns 0 as an overflow signal). `NGX_MAX_OFF_T_VALUE` is nginx's own auto-detected max for the platform's `off_t` (`objs/ngx_auto_config.h`, driven by `auto/types/sizeof`), and on every target with a 64-bit `off_t` (every nginx-supported target today, since large-file support pins `_FILE_OFFSET_BITS=64`) that's `2^63 - 1`, comfortably under zstd's threshold. A hypothetical target where the proof doesn't hold keeps the original unconditional call.

**qvalue fraction unroll.** RFC 9110's qvalue grammar is `"0" [ "." 0*3DIGIT ]`, so the walk is bounded at 3 digits by rule, not by a runtime counter. The old loop kept a `scale` variable it divided by 10 each iteration (`scale > 100 > 10 > 1 > 0`, the last iteration hitting `scale == 0` to stop); the new form just writes the three literal weights inline. The fourth-digit-unconsumed contract (the caller's own trailing-junk check relies on `q=1.2345` leaving the last `5` unread) falls out of the same nested-`if` structure the loop's guard used to enforce.

## Testing

- `ci/t/00-filter.t` TESTS 101-103 (new): pledged Content-Length one byte under, exactly at, and 8x over a pinned `zstd_buffers 1 512`/`4 512`, asserting byte-exact round-trip through `zstd -dqc` at each boundary.
- Full local suite: `TEST_NGINX_BINARY=.build/nginx-1.31.4/objs/nginx prove ci/t/*.t` — `Files=4, Tests=2072, Result: PASS` (up from 2069 baseline: the delta is the three new cases).
- `ci/tests/unit/run.sh`: 45/45, and `ci/tests/unit/test_accept_encoding`: 31/31, including the existing "a fourth q decimal digit makes the element non-matching" case, which exercises the unrolled walk end to end through `ngx_http_zstd_eval_qvalue()`.
- Differential test (not committed, run locally): the old loop-based `parse_q_fraction` against the new unrolled one, exhausting every buffer length 0-5 and every truncation point over a small alphabet including digits and non-digits: 390,277 cases, 0 diffs.
- `ci/fuzz/build.sh` (ASan+UBSan) replayed against the full existing corpus + regressions (`fuzz_ae -runs=0 ci/fuzz/corpus ci/fuzz/regressions`, 13,404 cases): clean, no crashes.
- Assembly, both changes, this repo's actual build flags (`gcc -O -fPIC -Werror`, matching `objs/Makefile`): the `ZSTD_compressBound` relocation is present exactly once in the compiled object and the boundary branch (`cmp %r14,%rdi; jb <call-site>`) sends `pledged_size >= buf_size` straight to `ngx_create_temp_buf` without it; the qvalue walk has zero `0xcccccccccccccccd`-style magic-number-divide sequences left (present in the original at `-O3 -fno-inline`, matching the row's own claim).
- Mutation proof, `ZSTD_compressBound` skip: reverted `ngx_http_zstd_filter_module.c` to the pre-change form, rebuilt (`ccache gcc ... -o objs/addon/src/ngx_http_zstd_filter_module.o`, fresh mtime), disassembled: `4711: jns 47d9 <...>; ... call ZSTD_compressBound` with no `buf_size` comparison in between. The call fires unconditionally whenever `pledged_size >= 0`, confirming the guard is what the patched version adds.
- Mutation proof, qvalue unroll: changed the second digit's weight from 10 to 11 in the unrolled form; the existing 31 Accept-Encoding unit tests all still passed (none of them assert an exact 2+-digit milli-unit value), but the differential harness above went from 0 to 38,136 diffs on the same 390,277-case sweep. The load-bearing oracle for this change is the differential, not the existing suite.

## Refuted in the same slice, not shipped

- **Guard the output-buffer cursor store** (`ctx->out_buf->last += ...` in `ngx_http_zstd_filter_compress()`) the way the input-cursor store already is. `ngx_buf_t.last` sits at struct offset 8, in the same cache line as fields the surrounding code already touches every call, so there's no dirty-store cost the guard would actually avoid. A synthetic guarded-vs-unconditional-add microbenchmark showed no consistent winner (within ~2-5% noise, guarded sometimes slower): a branch added to the dominant nonzero-output path for no effect.
- **Inline 32-byte digest-compare** instead of `ngx_memcmp()` in the dcz dictionary lookup. The call is genuinely not inlined at this repo's real `-O` flag: `objdump -dr` shows an `R_X86_64_PLT32 memcmp` relocation at the exact 32-byte, stride-0x68 loop site. A standalone word-compare helper measured about 5x faster per call than glibc's `memcmp` for this length. But the lookup it feeds is gated behind five earlier checks (secure-context, Accept-Encoding present, Available-Dictionary present, Sec-Fetch-Site, dcz coding weight) and loops over at most ~16 configured dictionaries on an already-rare request path — worst case a few nanoseconds to about 16ns saved per already-uncommon request, unmeasurable against the compression that request is about to do. Real win, unmeasurable end-to-end, and adding a new helper plus its own differential tests is complexity for that.
- **16-word circular SHA-256 message schedule** in the portable (no-libcrypto) fallback, config-load only. Merging the schedule-expansion and round loops to reuse a 16-word buffer measured 8.95% slower at `-O1` (this repo's build flag), 10.70% slower at `-O2`, 4.53% slower at `-O3` in a controlled `compress()`-only microbenchmark against the original 64-word form. Never a win at any level tested. Correctness held throughout (200,000-trial randomized differential against the original, both fixed and randomized chaining state, 0 diffs; FIPS/NIST vectors up to 1,000,000 bytes via `ci/tools/test_sha256_unit.sh` also pass on both forms), so this was a clean measured loss, not a correctness problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of response compression buffer sizing for large or boundary-sized responses.
  * Preserved accurate compressed output when configured buffer limits are reached.

* **Tests**
  * Added coverage for multiple compression buffer boundary conditions.
  * Verified byte-exact decompression results for proxied responses.

* **Refactor**
  * Simplified fractional quality-value parsing while maintaining existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->