### PR TITLE
fix: correct false ILP32 proof in compressBound skip gate, add qvalue fraction oracle

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -266,6 +266,24 @@ jobs:
           # Needs only a C compiler.
           bash "$GITHUB_WORKSPACE"/ci/tools/test_read_dict_file_unit.sh
 
+      - name: compressBound skip gate unit fixture (size_t-width correctness)
+        run: |
+          # A27-F4: get_buf()'s ZSTD_compressBound() skip is gated on a
+          # compile-time proof that off_t's range cannot reach
+          # ZSTD_MAX_INPUT_SIZE -- but that libzstd constant is itself
+          # size_t-width-dependent (0xFF00FF00FF00FF00 on an 8-byte size_t,
+          # 0xFF00FF00 on a 4-byte one), so an off_t-only gate is wrong on
+          # an ILP32 target built with a 64-bit off_t
+          # (_FILE_OFFSET_BITS=64). This repo builds and tests only on
+          # LP64 hosts, where the old (wrong) and the corrected gate
+          # evaluate identically, so this is the only way to observe the
+          # difference without standing up a cross-compiled ILP32 leg.
+          # Extracts the shipped #if/#endif verbatim and evaluates it
+          # under substituted NGX_MAX_OFF_T_VALUE/SIZE_MAX pairs for
+          # LP64, ILP32+64-bit-off_t and plain ILP32. Needs only a C
+          # compiler.
+          bash "$GITHUB_WORKSPACE"/ci/tools/test_compressbound_skip_gate.sh
+
       - name: Configure a real nginx source tree (for scan-build headers)
         run: |
           # scan-build needs the COMPLETE nginx headers — including the

--- a/ci/tests/unit/test_accept_encoding.c
+++ b/ci/tests/unit/test_accept_encoding.c
@@ -92,6 +92,7 @@
 #include "../../fuzz/ngx_shim.h"
 #include "../../fuzz/generated_parser.inc"
 
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -385,6 +386,215 @@ case_skip_quoted_unterminated(void)
 }
 
 
+/*
+ * Direct oracle on ngx_http_zstd_parse_q_fraction() itself -- every case
+ * above only ever asks "did the whole header accept or decline", which is
+ * satisfied by any weight > 0 (or, for a q=0 case, is satisfied by any
+ * weight == 0). Neither shape can tell an exact milliweight, or a wrong
+ * cursor, from a correct one: a tens-digit arithmetic mistake that still
+ * lands on "some positive number" or "exactly zero" is invisible to
+ * decide(). These cases call the pure digit-walk helper directly and
+ * assert BOTH of its documented outputs -- the returned weight, and the
+ * cursor position it leaves in *p -- which is the only way to observe
+ * that "10s digit worth 10" specifically (not just "worth something") and
+ * that "a 4th digit is left unconsumed" (the caller's trailing-junk
+ * contract, ngx_http_zstd_eval_qvalue()'s q += ... callers all depend on
+ * *p pointing AT the offending byte, not past it).
+ *
+ * OBSERVED: mutating the tens weight from `* 10` to `* 11` in
+ * ngx_http_zstd_parse_q_fraction() left all 31 pre-existing checks above
+ * still green (every accept/decline decision the header drives is
+ * unaffected by an 11-vs-10 tens digit, since every fixture above uses at
+ * most one nonzero fractional digit or crosses the q>0/q==0 boundary by a
+ * wide margin). case_fraction_exhaustive_three_digit() below is what
+ * catches it -- see ci/adoption-findings.md for the exact command and
+ * its failing output.
+ */
+static void
+run_one_fraction(const char *digits, ngx_int_t want_frac,
+    ptrdiff_t want_consumed, const char *what)
+{
+    u_char        *p;
+    const u_char  *end;
+    ngx_int_t      frac;
+    ptrdiff_t      consumed;
+
+    p = (u_char *) digits;
+    end = (const u_char *) digits + strlen(digits);
+
+    frac = ngx_http_zstd_parse_q_fraction(end, &p);
+    consumed = p - (u_char *) digits;
+
+    if (frac != want_frac || consumed != want_consumed) {
+        printf("FAIL %s (got frac=%ld consumed=%ld, want frac=%ld "
+               "consumed=%ld)\n",
+               what, (long) frac, (long) consumed, (long) want_frac,
+               (long) want_consumed);
+        checks++;
+        failures++;
+        return;
+    }
+
+    check(1, what);
+}
+
+static void
+case_fraction_empty_input(void)
+{
+    /* "" -- end == p already, no digit consumed at all. */
+    run_one_fraction("", 0, 0, "fraction: empty input -> frac=0, cursor=0");
+}
+
+static void
+case_fraction_one_digit(void)
+{
+    run_one_fraction("5", 500, 1, "fraction: one digit '5' -> frac=500, "
+                                  "cursor advances 1");
+}
+
+static void
+case_fraction_two_digit(void)
+{
+    /* This is exactly the boundary the auditor's tens-weight mutation
+     * (10 -> 11) breaks: '5' contributes 50 only if the tens digit is
+     * genuinely worth 10 per unit. */
+    run_one_fraction("05", 50, 2, "fraction: two digits '05' -> frac=50 "
+                                  "(tens digit worth exactly 10/unit), "
+                                  "cursor advances 2");
+}
+
+static void
+case_fraction_three_digit(void)
+{
+    run_one_fraction("123", 123, 3, "fraction: three digits '123' -> "
+                                    "frac=123, cursor advances 3");
+}
+
+static void
+case_fraction_four_digit_leaves_fourth_unconsumed(void)
+{
+    /*
+     * The documented contract this row exists to pin: after three digits
+     * the cursor stops WITHOUT consuming a fourth digit byte, so the
+     * caller's trailing-junk check (ngx_http_zstd_eval_qvalue() /
+     * ngx_http_zstd_coding_weight()'s post-qvalue scan) sees the '4' and
+     * rejects the element. Assert the exact stop position, not just "some
+     * prefix was consumed".
+     */
+    run_one_fraction("1234", 123, 3,
+        "fraction: four digits '1234' -> only the first three are "
+        "consumed (frac=123), the 4th digit is LEFT UNCONSUMED");
+}
+
+static void
+case_fraction_truncated_mid_walk(void)
+{
+    /* `end` reached after one digit: the walk must stop at `end`, not
+     * read past it, and the cursor must sit exactly at `end`. */
+    u_char        buf[1] = { '7' };
+    u_char       *p = buf;
+    const u_char *end = buf + 1;
+    ngx_int_t     frac = ngx_http_zstd_parse_q_fraction(end, &p);
+
+    check(frac == 700 && p == end,
+          "fraction: input truncated after one digit -- cursor stops "
+          "exactly at end, frac=700");
+}
+
+static void
+case_fraction_truncated_mid_walk_two_digits(void)
+{
+    u_char        buf[2] = { '4', '2' };
+    u_char       *p = buf;
+    const u_char *end = buf + 2;
+    ngx_int_t     frac = ngx_http_zstd_parse_q_fraction(end, &p);
+
+    check(frac == 420 && p == end,
+          "fraction: input truncated after two digits -- cursor stops "
+          "exactly at end, frac=420");
+}
+
+static void
+case_fraction_non_digit_terminator_not_consumed(void)
+{
+    /* A non-digit byte (here ';', the real-world terminator after
+     * "q=0.5") must stop the walk WITHOUT consuming it -- the caller
+     * needs *p pointing AT that byte, e.g. to continue scanning
+     * parameters. */
+    run_one_fraction("5;q=1", 500, 1,
+        "fraction: non-digit terminator ';' is not consumed, "
+        "cursor sits on it");
+}
+
+static void
+case_fraction_non_digit_terminator_at_start(void)
+{
+    /* Not even one digit: the very first byte is non-digit, so nothing
+     * is consumed and frac stays 0. */
+    run_one_fraction("x", 0, 0,
+        "fraction: non-digit terminator at position 0 -- frac=0, "
+        "cursor=0 (nothing consumed)");
+}
+
+static void
+case_fraction_exhaustive_three_digit(void)
+{
+    /*
+     * Exhaustive 000..999: every three-digit fraction, asserting the
+     * EXACT returned weight (hundreds*100 + tens*10 + units*1) and that
+     * the cursor always advances by exactly 3. This is the check that
+     * actually catches an arithmetic-weight mutation on any single digit
+     * position -- a spot check on a handful of values can miss a
+     * mutation whose effect happens to cancel out on those particular
+     * inputs, but summing every input in the space cannot.
+     */
+    char       digits[3];
+    int        n, h, t, u;
+    int        local_failures = 0;
+
+    for (n = 0; n < 1000; n++) {
+        h = n / 100;
+        t = (n / 10) % 10;
+        u = n % 10;
+
+        digits[0] = (char) ('0' + h);
+        digits[1] = (char) ('0' + t);
+        digits[2] = (char) ('0' + u);
+
+        {
+            u_char        *p = (u_char *) digits;
+            const u_char  *end = (const u_char *) digits + 3;
+            ngx_int_t      frac = ngx_http_zstd_parse_q_fraction(end, &p);
+            ngx_int_t      want = h * 100 + t * 10 + u;
+            ptrdiff_t      consumed = p - (u_char *) digits;
+
+            checks++;
+
+            if (frac != want || consumed != 3) {
+                if (local_failures < 5) {
+                    printf("FAIL fraction: exhaustive \"%s\" -> got "
+                           "frac=%ld consumed=%ld, want frac=%ld "
+                           "consumed=3\n",
+                           digits, (long) frac, (long) consumed,
+                           (long) want);
+                }
+                local_failures++;
+                failures++;
+            }
+        }
+    }
+
+    if (local_failures == 0) {
+        printf("ok   fraction: exhaustive 000..999 all match "
+               "hundreds*100+tens*10+units*1, cursor always advances 3 "
+               "(1000 cases)\n");
+    } else {
+        printf("FAIL fraction: exhaustive 000..999 -- %d/1000 mismatched "
+               "(first 5 shown above)\n", local_failures);
+    }
+}
+
+
 int
 main(void)
 {
@@ -413,6 +623,17 @@ main(void)
     case_skip_quoted_unterminated();
     case_nonq_param_is_skipped_trailing_q_honoured();
     case_nonq_param_quoted_value_delimiter_scan();
+
+    case_fraction_empty_input();
+    case_fraction_one_digit();
+    case_fraction_two_digit();
+    case_fraction_three_digit();
+    case_fraction_four_digit_leaves_fourth_unconsumed();
+    case_fraction_truncated_mid_walk();
+    case_fraction_truncated_mid_walk_two_digits();
+    case_fraction_non_digit_terminator_not_consumed();
+    case_fraction_non_digit_terminator_at_start();
+    case_fraction_exhaustive_three_digit();
 
     printf("\n%d/%d checks passed\n", checks - failures, checks);
     return failures ? 1 : 0;

--- a/ci/tools/test_compressbound_skip_gate.sh
+++ b/ci/tools/test_compressbound_skip_gate.sh
@@ -1,0 +1,223 @@
+#!/bin/bash
+# Copyright (C) 2026 Thijs Eilander
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Unit fixture for the ZSTD_compressBound() skip gate in
+# ngx_http_zstd_filter_module.c's get_buf() -- the
+# "#if NGX_MAX_OFF_T_VALUE <= ... && SIZE_MAX >= ..." block
+# that decides, at PREPROCESSING time, whether a build is allowed to skip
+# the real ZSTD_compressBound() call for a first output buffer whose
+# pledged size is already >= the configured buffer size.
+#
+# WHY THIS EXISTS: the skip is only safe if libzstd's own
+# ZSTD_MAX_INPUT_SIZE is provably above every off_t this build can pledge.
+# zstd.h defines that constant as size_t-width-dependent:
+#
+#   #define ZSTD_MAX_INPUT_SIZE \
+#       ((sizeof(size_t)==8) ? 0xFF00FF00FF00FF00ULL : 0xFF00FF00U)
+#
+# so a build with a 32-bit size_t (ILP32) has a MUCH smaller real ceiling
+# (0xFF00FF00) than a build with a 64-bit size_t, regardless of what
+# off_t's own width is -- an ILP32 target commonly builds with a 64-bit
+# off_t (_FILE_OFFSET_BITS=64), so an off_t-only gate is satisfied on a
+# platform where the skip is NOT actually safe. This repo builds and
+# tests only on LP64 hosts, so the wrong (off_t-only) gate and the
+# corrected (off_t AND size_t) gate evaluate IDENTICALLY here -- there is
+# no way to observe the difference by just building and testing on this
+# host. This fixture evaluates the LITERAL gate expression shipped in
+# src/ngx_http_zstd_filter_module.c, extracted verbatim (never
+# hand-copied) under substituted NGX_MAX_OFF_T_VALUE / SIZE_MAX
+# pairs standing in for the four width combinations a real build can have,
+# which is the cheap alternative to standing up an actual cross-compiled
+# ILP32 CI leg (out of proportion for this row).
+#
+# No nginx tree, no libzstd needed: pure preprocessor evaluation.
+set -euo pipefail
+
+# ci/tools/ -> ci/ -> repo root.
+cd "$(dirname "$0")/../.."
+
+SRC="src/ngx_http_zstd_filter_module.c"
+CC="${CC:-cc}"
+OUT="$(mktemp -d "${TMPDIR:-/tmp}/zstd-compressbound-gate-unit.XXXXXX")"
+trap 'rm -rf "$OUT"' EXIT
+mkdir -p "$OUT"
+
+# Locate the gate's #if...#endif verbatim, by its distinctive opening line,
+# so a future edit to the comment or the guarded body cannot silently
+# desync this fixture from the shipped condition -- only the #if/#endif
+# pair itself is extracted.
+START_LINE="$(grep -n '^#if NGX_MAX_OFF_T_VALUE <= 0xFF00FF00FF00FF00ULL' "$SRC" \
+              | head -1 | cut -d: -f1)"
+if [ -z "$START_LINE" ]; then
+    echo "FAIL: could not locate the compressBound skip gate's #if in $SRC" >&2
+    exit 1
+fi
+
+# The matching #endif: the first "#endif" at or after START_LINE whose
+# nesting returns to zero. The gate's own block has no nested #if, so the
+# first #endif after START_LINE is it.
+REL_END="$(tail -n "+${START_LINE}" "$SRC" | grep -n '^#endif' | head -1 | cut -d: -f1)"
+if [ -z "$REL_END" ]; then
+    echo "FAIL: could not locate the gate's matching #endif in $SRC" >&2
+    exit 1
+fi
+END_LINE=$((START_LINE + REL_END - 1))
+
+sed -n "${START_LINE},${END_LINE}p" "$SRC" > "$OUT/generated_gate.inc"
+
+if ! grep -q 'SIZE_MAX' "$OUT/generated_gate.inc"; then
+    echo "FAIL: extracted gate does not reference SIZE_MAX" \
+         "-- extraction range wrong, or the gate regressed to the" \
+         "off_t-only form this row exists to fix" >&2
+    cat "$OUT/generated_gate.inc" >&2
+    exit 1
+fi
+if ! grep -q 'NGX_MAX_OFF_T_VALUE' "$OUT/generated_gate.inc"; then
+    echo "FAIL: extracted gate does not reference NGX_MAX_OFF_T_VALUE" \
+         "-- extraction range wrong" >&2
+    exit 1
+fi
+
+# run_case OFF_MAX SIZE_MAX EXPECT_SKIP LABEL
+#
+# Compile a tiny TU that #defines NGX_MAX_OFF_T_VALUE/SIZE_MAX
+# to the given stand-in values (mirroring what auto/types/sizeof would have
+# produced for that width), #includes the extracted gate verbatim, and
+# reports via a preprocessor #if/#else whether SKIP_TAKEN got defined.
+# EXPECT_SKIP is "1" (gate must compile the skip in) or "0" (gate must
+# compile out to the always-call path).
+run_case() {
+    local off_max="$1" size_max="$2" expect="$3" label="$4"
+    local tu="$OUT/case.c"
+
+    # Wrap the extracted gate in a function body with stand-in identifiers
+    # matching the production call site ((size_t) ctx->pledged_size,
+    # buf_size). The extracted text is exactly:
+    #
+    #   #if COND
+    #               if ((size_t) ctx->pledged_size >= buf_size) {
+    #                   /* Skip: ... */
+    #               } else
+    #   #endif
+    #
+    # so #include-ing it immediately followed by "{ took_call = 1; }"
+    # reproduces the production shape "#if ... if (cond) {SKIP} else
+    # #endif {CALL}" verbatim: took_call starts 0 and is set to 1 by
+    # whichever branch's trailing statement is that block --
+    #   * COND false: the whole #if/#else/#endif vanishes, leaving just
+    #     the plain "{ took_call = 1; }" -- call always taken.
+    #   * COND true and pledged_size >= buf_size: the "if" arm runs (its
+    #     body is a comment only) and the "else" -- and therefore the
+    #     following block -- is skipped. took_call stays 0: skip taken.
+    #   * COND true and pledged_size < buf_size: the "if" arm is skipped,
+    #     "else" runs, which is "else { took_call = 1; }" (the following
+    #     block is the else-statement) -- call taken, matching the real
+    #     ZSTD_compressBound() path.
+    cat > "$tu" <<EOF
+/* <stddef.h>, not <stdint.h>: only size_t is needed, and per C99/C11
+ * <stddef.h> never defines SIZE_MAX itself, so the #define below cannot
+ * collide with a real one. Do not switch this to <stdint.h> without
+ * dropping the #define -- a live SIZE_MAX would make this a redefinition
+ * error under -Werror instead of the intended stand-in. */
+#include <stddef.h>
+
+#define NGX_MAX_OFF_T_VALUE  ${off_max}
+#define SIZE_MAX ${size_max}
+
+/* Stand-in for the ctx field the real call site reads -- same name, so
+ * the #included gate compiles unmodified. */
+struct fake_ctx { long long pledged_size; };
+
+static int
+gate_took_skip(struct fake_ctx *ctx, size_t buf_size)
+{
+    int took_call = 0;
+
+    /* When the #if below is false, the whole guarded if/else vanishes and
+     * neither ctx nor buf_size is referenced anywhere in this function --
+     * that IS the property being tested (the gate compiling out), so
+     * silence the resulting -Wunused-parameter rather than weakening it. */
+    (void) ctx;
+    (void) buf_size;
+
+#include "generated_gate.inc"
+    {
+        took_call = 1;
+    }
+
+    return !took_call;
+}
+
+int
+main(void)
+{
+    struct fake_ctx ctx;
+    int             took_skip;
+
+    /* pledged_size == buf_size: the exact boundary the real call site's
+     * "(size_t) ctx->pledged_size >= buf_size" turns on. Above the
+     * boundary is gate-irrelevant (the C comparison itself, not the
+     * #if, decides it) -- this fixture is only about whether the #if
+     * compiles the fast path in AT ALL for a given width pair. */
+    ctx.pledged_size = 1000;
+    took_skip = gate_took_skip(&ctx, (size_t) 1000);
+
+    if (took_skip != ${expect}) {
+        return 1;
+    }
+
+    return 0;
+}
+EOF
+
+    "$CC" -Wall -Wextra -Werror -O1 -I"$OUT" -o "$OUT/case" "$tu" 2>"$OUT/case.err" \
+        || { echo "FAIL: $label did not compile"; cat "$OUT/case.err" >&2; exit 1; }
+
+    if ! "$OUT/case"; then
+        echo "FAIL: $label -- gate took the wrong arm (expected skip=${expect})" >&2
+        exit 1
+    fi
+
+    echo "OK: $label"
+}
+
+# Four width combinations an auto/types/sizeof run can actually produce.
+#
+# NGX_MAX_OFF_T_VALUE stand-ins are the exact values auto/types/sizeof
+# emits for 8-byte and 4-byte types (2147483647 / 9223372036854775807LL --
+# see auto/types/sizeof). SIZE_MAX stand-ins are the true (unsigned) max
+# of an 8-byte or 4-byte size_t (0xFFFFFFFFFFFFFFFFULL /
+# 0xFFFFFFFFU) -- NOT nginx's NGX_MAX_SIZE_T_VALUE, which is the signed
+# max and is smaller than the 0xFF00FF00FF00FF00 bound on every width
+# (see the header comment above); using it would have made this fixture
+# assert a gate that can never fire, silently disabling the optimization
+# on every platform instead of proving anything width-specific.
+#
+#   LP64   (8-byte off_t, 8-byte size_t): the common server target.
+#          ZSTD_MAX_INPUT_SIZE is the 64-bit constant -> skip is safe.
+run_case 9223372036854775807LL 0xFFFFFFFFFFFFFFFFULL 1 \
+    "LP64 (8-byte off_t, 8-byte size_t) -- skip compiled IN"
+
+#   ILP32 with 64-bit off_t (_FILE_OFFSET_BITS=64): off_t alone looks
+#   64-bit-safe, but size_t is 32-bit, so ZSTD_MAX_INPUT_SIZE is really
+#   0xFF00FF00. THIS is the case the false proof got wrong -- the OLD
+#   off_t-only gate would have compiled the skip IN here; the corrected
+#   gate must compile it OUT.
+run_case 9223372036854775807LL 0xFFFFFFFFU 0 \
+    "ILP32 + 64-bit off_t (_FILE_OFFSET_BITS=64) -- skip compiled OUT"
+
+#   Plain ILP32 (4-byte off_t, 4-byte size_t): off_t's own range already
+#   excludes it (NGX_MAX_OFF_T_VALUE > the 64-bit constant is false only
+#   when off_t is 8 bytes) -- also must compile out.
+run_case 2147483647 0xFFFFFFFFU 0 \
+    "plain ILP32 (4-byte off_t, 4-byte size_t) -- skip compiled OUT"
+
+#   Hypothetical 8-byte off_t with a narrower still-valid size_t is
+#   covered by the ILP32+64-bit-off_t case above; a 4-byte off_t can never
+#   pair with an 8-byte size_t on any real ABI, so that combination is not
+#   modelled here.
+
+echo "OK: compressBound skip gate is size_t-width-correct across all" \
+     "modelled platform combinations (extracted from current $SRC," \
+     "lines ${START_LINE}-${END_LINE})"

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -2774,7 +2774,6 @@ ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
          */
         if (first_buf && ctx->pledged_size >= 0) {
 
-#if NGX_MAX_OFF_T_VALUE <= 0xFF00FF00FF00FF00ULL
             /*
              * ZSTD_compressBound(n) == n + (n>>8) + margin, margin >= 0
              * always (see zstd.h's ZSTD_COMPRESSBOUND macro) -- so the
@@ -2783,31 +2782,68 @@ ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
              * grows it further. When the pledged size is already at
              * least the configured buffer size, `bound` (however it is
              * computed) can therefore never satisfy `bound < buf_size`,
-             * so the clamp two lines down never fires and buf_size is
-             * left exactly as it already is. Skip the call entirely on
-             * that path -- one fewer external libzstd call per known
-             * large response, same buf_size either way.
+             * so the clamp below never fires and buf_size is left
+             * exactly as it already is. Skip the call entirely on that
+             * path -- one fewer external libzstd call per known large
+             * response, same buf_size either way -- PROVIDED the call
+             * could not instead have hit ZSTD_compressBound()'s own
+             * overflow branch (return 0), which the gate below rules out.
              *
-             * Gated on the compile-time proof that `off_t`'s range
-             * cannot reach ZSTD_MAX_INPUT_SIZE: NGX_MAX_OFF_T_VALUE is
-             * nginx's own auto-detected max for the platform's off_t
-             * (objs/ngx_auto_config.h, from auto/types/sizeof), and
-             * ZSTD_MAX_INPUT_SIZE is 0xFF00FF00FF00FF00 on any platform
-             * where zstd.h sees an 8-byte size_t (checked via the same
-             * constant here, not a sizeof, so this is decided at
-             * preprocessing before zstd.h's own size_t-width branch is
-             * evaluated). Every off_t this nginx build can produce is
-             * provably inside ZSTD_MAX_INPUT_SIZE here, so
-             * ZSTD_compressBound() cannot hit its own overflow branch
-             * (return 0) for any value pledged_size can hold -- the skip
-             * is safe. A target where this #if is false keeps the
-             * original call and clamp below, unchanged.
+             * ZSTD_MAX_INPUT_SIZE is NOT platform-invariant: zstd.h
+             * defines it as
+             *   (sizeof(size_t) == 8) ? 0xFF00FF00FF00FF00ULL
+             *                         : 0xFF00FF00U
+             * so on an ILP32 target (32-bit size_t) it is 0xFF00FF00,
+             * not the 64-bit constant. A build with a 32-bit size_t but
+             * a 64-bit off_t (_FILE_OFFSET_BITS=64 is common on such
+             * targets) would satisfy an off_t-only gate while still
+             * being able to pledge a size_t-valued length above
+             * 0xFF00FF00 -- exactly the case where the real
+             * ZSTD_compressBound() would hit its overflow branch and
+             * this skip must not fire.
+             *
+             * Gate on BOTH auto-detected platform maxima, neither derived
+             * from the other, so neither can stand in for the other:
+             *
+             *   NGX_MAX_OFF_T_VALUE  (nginx's own auto-detected off_t
+             *                        max, from auto/types/sizeof into
+             *                        objs/ngx_auto_config.h) proves
+             *                        ctx->pledged_size (an off_t) cannot
+             *                        exceed the 64-bit ZSTD_MAX_INPUT_SIZE
+             *                        constant;
+             *   SIZE_MAX             (the standard <stdint.h> constant,
+             *                        already included above) proves
+             *                        sizeof(size_t) == 8 on this build,
+             *                        i.e. that ZSTD_MAX_INPUT_SIZE
+             *                        actually IS that 64-bit constant and
+             *                        not the 32-bit one. NGX_MAX_SIZE_T_VALUE
+             *                        is NOT usable here even though the
+             *                        name suggests it: nginx defines it as
+             *                        the max value of size_t treated as
+             *                        SIGNED (9223372036854775807LL, i.e.
+             *                        INT64_MAX, for %d-style formatting
+             *                        bounds elsewhere in this file), which
+             *                        is smaller than 0xFF00FF00FF00FF00 on
+             *                        every width -- a ">=" test against it
+             *                        would never fire and silently disable
+             *                        the whole optimization rather than
+             *                        proving anything. SIZE_MAX is the
+             *                        type's true (unsigned) maximum and is
+             *                        the correct comparand.
+             *
+             * Both must hold for the skip to be safe. On a target where
+             * either is false (32-bit off_t, or 32-bit size_t under a
+             * 64-bit off_t) this whole block compiles out and the
+             * original ZSTD_compressBound() call and clamp below run
+             * unchanged -- the optimization is 64-bit-server-only by
+             * design, per the audit's accepted resolution.
              */
+#if NGX_MAX_OFF_T_VALUE <= 0xFF00FF00FF00FF00ULL \
+    && SIZE_MAX >= 0xFF00FF00FF00FF00ULL
             if ((size_t) ctx->pledged_size >= buf_size) {
-                goto skip_bound;
-            }
+                /* Skip: buf_size is already provably the final value. */
+            } else
 #endif
-
             {
                 size_t  bound = ZSTD_compressBound((size_t) ctx->pledged_size);
 
@@ -2828,11 +2864,6 @@ ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
                     buf_size = bound;
                 }
             }
-
-#if NGX_MAX_OFF_T_VALUE <= 0xFF00FF00FF00FF00ULL
-skip_bound:
-            ;
-#endif
         }
 
         /*


### PR DESCRIPTION
## TL;DR

The compressor sometimes skips a size-checking step for large responses, and it only gets to do that because of a proof that the numbers involved can never overflow. That proof quietly assumed something true on the machines we build for, but not guaranteed on every machine that could run this code, and no test proved the skip was ever actually the thing running.

In code terms: `ngx_http_zstd_filter_get_buf()`'s `ZSTD_compressBound()` skip was gated on `NGX_MAX_OFF_T_VALUE <= 0xFF00FF00FF00FF00ULL` alone; it now also requires `SIZE_MAX >= 0xFF00FF00FF00FF00ULL`. Same PR also closes an unrelated test gap in the qvalue fraction parser, batched here because both rows share the "no oracle proves the optimized path ran" theme.

**Severity:** Low (correctness proof: the skip's safety argument didn't hold on a platform combination this repo doesn't build for, so no shipped binary was affected, caught and fixed before it could matter)

## Row 1: compressBound skip gate (A27-F4)

`zstd.h` defines the ceiling the skip has to stay under as:

```c
#define ZSTD_MAX_INPUT_SIZE ((sizeof(size_t)==8) ? 0xFF00FF00FF00FF00ULL : 0xFF00FF00U)
```

That's `size_t`-width-dependent, not platform-invariant. The removed comment asserted "ZSTD_MAX_INPUT_SIZE is 0xFF00FF00FF00FF00 on any platform where zstd.h sees an 8-byte size_t" and then gated only on `NGX_MAX_OFF_T_VALUE` (`off_t`'s auto-detected max) being under that constant. `off_t` and `size_t` are different types with independently configurable widths: an ILP32 target built with `_FILE_OFFSET_BITS=64` has a 64-bit `off_t` and a 32-bit `size_t`. On that build the old gate is satisfied (`off_t`'s max is under the 64-bit constant) while the real `ZSTD_MAX_INPUT_SIZE` is only `0xFF00FF00`, so a `pledged_size` above that value would take the skip on a path where the real `ZSTD_compressBound()` call would have hit its own overflow branch (return 0) instead.

### Fix chosen

`#if NGX_MAX_OFF_T_VALUE <= 0xFF00FF00FF00FF00ULL && SIZE_MAX >= 0xFF00FF00FF00FF00ULL`. `NGX_MAX_OFF_T_VALUE` still proves `off_t`'s range is inside the 64-bit constant; `SIZE_MAX` (the standard `<stdint.h>` constant) independently proves `sizeof(size_t) == 8`, which is what actually decides which branch of `ZSTD_MAX_INPUT_SIZE` applies. Neither macro is derived from the other, so neither can silently stand in for it.

I tried `NGX_MAX_SIZE_T_VALUE` first (the obvious nginx-native candidate) and it's wrong: nginx defines it as the max value of `size_t` treated as *signed* (`9223372036854775807LL`, i.e. `INT64_MAX`, for `%d`-style formatting elsewhere in this file), which is smaller than `0xFF00FF00FF00FF00` on every width, so a `>=` test against it can never fire. `SIZE_MAX` is the type's true unsigned maximum and the correct comparand.

Retaining the real call on ILP32 (rather than deriving a size_t-width bound) is the resolution I took: the optimization's whole value is on 64-bit servers, and gating it out on the platforms this repo doesn't build for is strictly simpler than teaching the skip a second ceiling. This repo builds and tests only on LP64 hosts, so the old and corrected gate evaluate identically here: there's no way to observe the regression from inside this CI without a cross-compiled ILP32 leg, which is out of proportion for the fix.

Also dropped the cross-conditional `goto skip_bound` in favor of a plain `#if`-guarded `if (...) { /* skip */ } else #endif { /* call */ }`: same two `#if` sites, no jump spanning a conditional.

### Testing

`ci/tools/test_compressbound_skip_gate.sh` (new) extracts the shipped `#if`/`#endif` verbatim (grepped, not hand-copied) and evaluates it under three `(NGX_MAX_OFF_T_VALUE, SIZE_MAX)` stand-in pairs, using the real values `auto/types/sizeof` produces for 4- and 8-byte types:

```
OK: LP64 (8-byte off_t, 8-byte size_t) -- skip compiled IN
OK: ILP32 + 64-bit off_t (_FILE_OFFSET_BITS=64) -- skip compiled OUT
OK: plain ILP32 (4-byte off_t, 4-byte size_t) -- skip compiled OUT
```

**Negative control:** reverted to the off_t-only `#if NGX_MAX_OFF_T_VALUE <= 0xFF00FF00FF00FF00ULL` (no `SIZE_MAX` conjunct) and reran the same script. Observed failure:

```
FAIL: extracted gate does not reference SIZE_MAX -- extraction range wrong, or the gate regressed to the off_t-only form this row exists to fix
#if NGX_MAX_OFF_T_VALUE <= 0xFF00FF00FF00FF00ULL
            if ((size_t) ctx->pledged_size >= buf_size) {
                /* Skip: buf_size is already provably the final value. */
            } else
#endif
exit=1
```

Restored the fix; back to all three `OK` lines above.

**Path oracle: deferred, not shipped.** I looked for an observable that separates "the skip fired" from "`ZSTD_compressBound()` ran and produced the same buffer size", which is hard by construction: the optimization's whole correctness claim is that those two produce an identical `buf_size`. `ZSTD_COMPRESSBOUND` is a macro; `ZSTD_compressBound` is the actual function this skip avoids calling, and `src/ngx_http_zstd_probe_hooks.c` doesn't currently wrap it.

`ctx->out_buf.size` (already rendered at `/__probe`) looked usable at first. I picked fixture sizes where the call's own clamp is real and measurable (`zstd_buffers 1 350`, pledged 200/350/4000 bytes; `ZSTD_compressBound(200)+64` measures to 327, genuinely below 350) and wired it into the existing `codec-call-count` harness scenario. It didn't work: `ctx->out_buf` is set to `NULL` in `ngx_http_zstd_body_filter()` right after `ngx_chain_update_chains()`, before the snapshot fires at the `ctx->done` return point. Every fixture I could build with a known `Content-Length` completes in one body-filter call, so it always reports `out_buf: {"present": 0, "size": 0}` regardless of which path ran. Confirmed against the real harness build, not assumed: all three boundary cases came back `size=0` on the current, correct tree. Reverted that harness change rather than ship a check that can't fail.

Follow-up row for the queue: **A27-F4b: the compressBound skip has no path oracle.** The natural buffer-size observable is nulled before the harness can read it on any single-call response. Needs either a probe hook directly on `ZSTD_compressBound()`'s call site (distinct from the existing `codec_calls`/`codec_end_calls` counters, which key off `ZSTD_compressStream2()`), or a fixture that keeps the body filter running a second time before `ctx->done` while `pledged_size` is still known.

Full suites, all green: `ci/tests/unit/run.sh` 1040/1040, `ci/t/00-filter.t` 1251/1251 (including TESTs 101-103, the pledged-size-vs-buffer-size boundary tests from #211), `ci/t/harness-scenarios/codec-call-count` 13/13 unchanged. `test_compressbound_skip_gate.sh` is wired into `.github/workflows/build-test.yml` next to the repo's other extracted-fixture unit tests.

## Row 2: qvalue fraction parser test gap (A27-F5)

`ngx_http_zstd_parse_q_fraction()` in `src/ngx_http_zstd_common.h` walks the up-to-three fractional digits of a `q=0.NNN` qvalue. The arithmetic is correct; this is a test-gap fix, not a bug fix.

The existing 31 unit tests in `ci/tests/unit/test_accept_encoding.c` only ever ask "did the whole `Accept-Encoding` header accept or decline", a shape any positive fractional weight or exactly-zero weight satisfies. None assert the exact milliweight returned or where the cursor ends up.

### Fix

Added `case_fraction_*` cases calling `ngx_http_zstd_parse_q_fraction()` directly (already linked into this TU via the same `ci/fuzz/extract_parser.sh` slicing the fuzz target uses, so there's no second copy to drift), asserting both the returned weight and the cursor position:

- exhaustive `000`..`999` (1000 cases): exact `hundreds*100 + tens*10 + units*1`, cursor always `+3`
- empty, one-digit, two-digit, three-digit, four-digit inputs
- truncated input: cursor stops exactly at `end`
- a non-digit terminator (`;`): not consumed, cursor sits on it
- the four-digit case asserts the fourth digit is left unconsumed, the contract `ngx_http_zstd_eval_qvalue()`'s trailing-junk check depends on

### Testing

Exhaustive oracle: all 1000 three-digit cases pass against the current parser.

**Negative control:** changed the tens-digit weight from `* 10` to `* 11`. Before this PR's new tests, all 31 pre-existing checks still passed:

```
31/31 checks passed
```

With the new tests in place, same mutation, rebuilt (binary mtime matches the mutation time), observed failure:

```
FAIL fraction: two digits '05' -> frac=50 (tens digit worth exactly 10/unit), cursor advances 2 (got frac=55 consumed=2, want frac=50 consumed=2)
FAIL fraction: three digits '123' -> frac=123, cursor advances 3 (got frac=125 consumed=3, want frac=123 consumed=3)
FAIL fraction: four digits '1234' -> only the first three are consumed (frac=123), the 4th digit is LEFT UNCONSUMED (got frac=125 consumed=3, want frac=123 consumed=3)
FAIL fraction: input truncated after two digits -- cursor stops exactly at end, frac=420
FAIL fraction: exhaustive "010" -> got frac=11 consumed=3, want frac=10 consumed=3
FAIL fraction: exhaustive "011" -> got frac=12 consumed=3, want frac=11 consumed=3
FAIL fraction: exhaustive "012" -> got frac=13 consumed=3, want frac=12 consumed=3
FAIL fraction: exhaustive "013" -> got frac=14 consumed=3, want frac=13 consumed=3
FAIL fraction: exhaustive "014" -> got frac=15 consumed=3, want frac=14 consumed=3
FAIL fraction: exhaustive 000..999 -- 900/1000 mismatched (first 5 shown above)
136/1040 checks passed
```

Restored the correct `* 10`; back to `1040/1040`.

## Lint

`review-lint.sh --diff HEAD` ran clean: every lens executed (no coverage-gap block). shfmt flagged the new shell script's 4-space indentation as a style deviation from its own default, the same advisory finding every existing `ci/tools/test_*.sh` script in this repo already carries, left as-is for consistency. Self-reviewed the diff before opening this and fixed a stale comment referencing a function name that didn't exist, a dead `digits[3] = '\0'` write in the exhaustive loop, and added a one-line comment on why `#define SIZE_MAX` in the gate test's generated TU can't collide with a real one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compression safety on platforms with differing `off_t` and `size_t` widths.
  * Preserved correct size-bound calculations and clamping behavior across supported platforms.
  * Added broader validation for fractional encoding-quality values, including truncation and digit handling.

* **Tests**
  * Added cross-platform checks for compression-boundary handling across representative 32-bit and 64-bit configurations.
  * Expanded unit test coverage for all three-digit fractional quality values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->