### PR TITLE
fix: dcz byte-accounting double-count and unpinned Test::Nginx::Socket in CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,6 +16,18 @@ env:
   # the current mainline release and feeds it via needs.resolve.outputs.*; per-
   # job env: blocks below override this placeholder with the resolved value.
   NGINX_VERSION: ""
+  # Single source of truth for every `cpanm ... Test::Nginx::Socket` call
+  # site in this file (keep in sync with ci-deep.yml's own copy). An
+  # unpinned `cpanm Test::Nginx::Socket` resolves to whatever CPAN serves
+  # at run time -- a cold runner can silently change test behaviour with
+  # no repository diff, and a warm cache can retain a different historical
+  # release, so two runners can disagree with nothing in git explaining
+  # it. Pinned to 0.32 because that is what every install site already
+  # resolved to as of this pin (verified against a recent successful CI
+  # run's "Install Test::Nginx::Socket" log: "Test::Nginx::Socket is up to
+  # date. (0.32)"), which is also CPAN's current latest release -- this
+  # pin is a no-op in behaviour, not a dependency bump.
+  TEST_NGINX_SOCKET_VERSION: "0.32"
   # The `resolve` job scrapes nginx.org for the current mainline release at run
   # time and feeds it to every job via `needs.resolve.outputs.nginx_version`
   # (and the build matrix JSON). This makes the weekly cron actually test the
@@ -1388,12 +1400,23 @@ jobs:
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/perl5
-          key: perl-modules-${{ runner.os }}-Test-Nginx-Socket
+          key: perl-modules-${{ runner.os }}-Test-Nginx-Socket-${{ env.TEST_NGINX_SOCKET_VERSION }}
 
       - name: Install Test::Nginx::Socket
         run: |
-          cpanm -l ~/perl5 --notest Test::Nginx::Socket
+          cpanm -l ~/perl5 --notest "Test::Nginx::Socket@${TEST_NGINX_SOCKET_VERSION}"
           echo "PERL5LIB=$HOME/perl5/lib/perl5:$PERL5LIB" >> "$GITHUB_ENV"
+          # Assert the pinned version regardless of whether this came from
+          # a fresh cpanm install or a warm ~/perl5 cache restore -- a
+          # cache-key mismatch (or any other drift) must fail loudly here,
+          # before the test suite runs, rather than as a confusing test
+          # failure downstream.
+          installed="$(perl -I "$HOME/perl5/lib/perl5" -MTest::Nginx::Socket -e 'print $Test::Nginx::Socket::VERSION')"
+          echo "Test::Nginx::Socket installed version: $installed"
+          if [ "$installed" != "$TEST_NGINX_SOCKET_VERSION" ]; then
+            echo "::error::Test::Nginx::Socket version mismatch: pinned $TEST_NGINX_SOCKET_VERSION, got $installed"
+            exit 1
+          fi
 
       - name: Run filter module tests
         env:
@@ -1780,12 +1803,18 @@ jobs:
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/perl5
-          key: perl-modules-${{ runner.os }}-Test-Nginx-Socket
+          key: perl-modules-${{ runner.os }}-Test-Nginx-Socket-${{ env.TEST_NGINX_SOCKET_VERSION }}
 
       - name: Install Test::Nginx::Socket
         run: |
-          cpanm -l ~/perl5 --notest Test::Nginx::Socket
+          cpanm -l ~/perl5 --notest "Test::Nginx::Socket@${TEST_NGINX_SOCKET_VERSION}"
           echo "PERL5LIB=$HOME/perl5/lib/perl5:$PERL5LIB" >> "$GITHUB_ENV"
+          installed="$(perl -I "$HOME/perl5/lib/perl5" -MTest::Nginx::Socket -e 'print $Test::Nginx::Socket::VERSION')"
+          echo "Test::Nginx::Socket installed version: $installed"
+          if [ "$installed" != "$TEST_NGINX_SOCKET_VERSION" ]; then
+            echo "::error::Test::Nginx::Socket version mismatch: pinned $TEST_NGINX_SOCKET_VERSION, got $installed"
+            exit 1
+          fi
 
       - name: Run Perl suites under ASAN+UBSAN
         # Put the static-file / magic-probe / conditional / HEAD paths (covered
@@ -2054,8 +2083,14 @@ jobs:
 
       - name: Install Test::Nginx::Socket
         run: |
-          cpanm -l ~/perl5 --notest Test::Nginx::Socket
+          cpanm -l ~/perl5 --notest "Test::Nginx::Socket@${TEST_NGINX_SOCKET_VERSION}"
           echo "PERL5LIB=$HOME/perl5/lib/perl5:$PERL5LIB" >> "$GITHUB_ENV"
+          installed="$(perl -I "$HOME/perl5/lib/perl5" -MTest::Nginx::Socket -e 'print $Test::Nginx::Socket::VERSION')"
+          echo "Test::Nginx::Socket installed version: $installed"
+          if [ "$installed" != "$TEST_NGINX_SOCKET_VERSION" ]; then
+            echo "::error::Test::Nginx::Socket version mismatch: pinned $TEST_NGINX_SOCKET_VERSION, got $installed"
+            exit 1
+          fi
 
       - name: Verify test port band
         # Before the first `prove` -- see ci/tools/max-port.sh.

--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -35,6 +35,13 @@ name: CI Deep
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   NGINX_VERSION: ""
+  # Keep in sync with build-test.yml's own copy of this pin -- see that
+  # file's env: block for the full rationale (unpinned cpanm resolves to
+  # whatever CPAN serves at run time; a warm cache can also retain a
+  # different historical release). 0.32 is what every install site in
+  # this repo already resolves to (verified against a recent successful
+  # CI log) and is also CPAN's current latest release.
+  TEST_NGINX_SOCKET_VERSION: "0.32"
 
 on:
   schedule:
@@ -195,12 +202,18 @@ jobs:
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/perl5
-          key: perl-modules-${{ runner.os }}-Test-Nginx-Socket
+          key: perl-modules-${{ runner.os }}-Test-Nginx-Socket-${{ env.TEST_NGINX_SOCKET_VERSION }}
 
       - name: Install Test::Nginx::Socket
         run: |
-          cpanm -l ~/perl5 --notest Test::Nginx::Socket
+          cpanm -l ~/perl5 --notest "Test::Nginx::Socket@${TEST_NGINX_SOCKET_VERSION}"
           echo "PERL5LIB=$HOME/perl5/lib/perl5:$PERL5LIB" >> "$GITHUB_ENV"
+          installed="$(perl -I "$HOME/perl5/lib/perl5" -MTest::Nginx::Socket -e 'print $Test::Nginx::Socket::VERSION')"
+          echo "Test::Nginx::Socket installed version: $installed"
+          if [ "$installed" != "$TEST_NGINX_SOCKET_VERSION" ]; then
+            echo "::error::Test::Nginx::Socket version mismatch: pinned $TEST_NGINX_SOCKET_VERSION, got $installed"
+            exit 1
+          fi
 
       - name: Verify test port band
         # Before the first `prove` -- see ci/tools/max-port.sh. The three
@@ -875,11 +888,17 @@ jobs:
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/perl5
-          key: perl-modules-${{ runner.os }}-Test-Nginx-Socket
+          key: perl-modules-${{ runner.os }}-Test-Nginx-Socket-${{ env.TEST_NGINX_SOCKET_VERSION }}
       - name: Install Test::Nginx::Socket
         run: |
-          cpanm -l ~/perl5 --notest Test::Nginx::Socket
+          cpanm -l ~/perl5 --notest "Test::Nginx::Socket@${TEST_NGINX_SOCKET_VERSION}"
           echo "PERL5LIB=$HOME/perl5/lib/perl5:$PERL5LIB" >> "$GITHUB_ENV"
+          installed="$(perl -I "$HOME/perl5/lib/perl5" -MTest::Nginx::Socket -e 'print $Test::Nginx::Socket::VERSION')"
+          echo "Test::Nginx::Socket installed version: $installed"
+          if [ "$installed" != "$TEST_NGINX_SOCKET_VERSION" ]; then
+            echo "::error::Test::Nginx::Socket version mismatch: pinned $TEST_NGINX_SOCKET_VERSION, got $installed"
+            exit 1
+          fi
       - name: Verify test port band
         # Before the first `prove` inside coverage.sh -- see ci/tools/max-port.sh.
         run: ci/tools/max-port.sh "$TEST_BASE_PORT"

--- a/ci/t/03-dcz.t
+++ b/ci/t/03-dcz.t
@@ -848,3 +848,43 @@ GET /direct
 Content-Encoding: zstd
 --- no_error_log
 [error]
+
+
+
+=== TEST 33: $zstd_bytes_out / $zstd_ratio resolve without fault on a dcz response
+# Regression for the dcz 40-byte prefix being double-counted:
+# ngx_http_zstd_filter_get_buf() writes the prefix into out_buf and
+# advances ->last past it, then the emit path in
+# ngx_http_zstd_filter_compress() (`ctx->bytes_out += ngx_buf_size(b)`)
+# already counts that whole buffer -- prefix included -- when it queues
+# the buffer downstream. A second, separate `ctx->bytes_out +=
+# NGX_HTTP_ZSTD_DCZ_HEADER_LEN` in get_buf() double-counted the prefix on
+# every dcz response.
+#
+# Exact-value correctness (bytes_out equal to the real wire byte count,
+# and the ratio derived from it) is the province of the byte-oracle in
+# tools/test_dcz.py, which can read the response bytes and the access
+# log; the compressed size otherwise depends on the linked libzstd
+# version and is deliberately not pinned here (see TEST 1's own note on
+# wire-format assertions). This test instead pins the same contract
+# TEST 32/39 in 00-filter.t pin for the plain zstd path: referencing
+# both log-phase variables via `set` on a dcz response must resolve
+# without the get_handler faulting.
+--- config
+    location /t {
+        zstd on;
+        zstd_min_length 16;
+        zstd_dcz_dict_file $TEST_NGINX_PERL_PATH/suite/dcz-dict;
+        default_type text/plain;
+        set $unused_bytes_out $zstd_bytes_out;
+        set $unused_ratio     $zstd_ratio;
+        return 200 "dcz negotiation body: shared-boilerplate compute render\n";
+    }
+--- request
+GET /t
+--- more_headers eval
+"Accept-Encoding: zstd, dcz\nAvailable-Dictionary: :$::dict_b64:"
+--- response_headers
+Content-Encoding: dcz
+--- no_error_log
+[error]

--- a/ci/tools/test_dcz.py
+++ b/ci/tools/test_dcz.py
@@ -241,6 +241,12 @@ pid logs/nginx.pid;
 events {{ }}
 http {{
     access_log off;
+    # $zstd_bytes_out / $zstd_ratio are log-phase variables (only valid
+    # once the filter has finished writing the response); this format
+    # exists so the dcz byte-accounting oracle below can read the
+    # module's own count of bytes it queued downstream and cross-check
+    # it against the bytes actually received over the socket.
+    log_format zstd_bytes_fmt "$zstd_bytes_out $zstd_ratio";
     types {{ application/javascript js; }}
     default_type application/octet-stream;
     gzip_vary on;
@@ -257,6 +263,7 @@ http {{
         listen 127.0.0.1:{port};
         zstd_dcz_assume_secure_transport on;
         root html;
+        access_log logs/zstd_bytes.log zstd_bytes_fmt;
     }}
 
 {tls_server}
@@ -304,6 +311,27 @@ def content_encoding(headers) -> str:
 
 def vary_values(headers) -> str:
     return ",".join(headers.get_all("Vary") or []).lower()
+
+
+def read_last_log_line(path: pathlib.Path, timeout: float = 10.0) -> str:
+    """Poll for the access log line the most recent request just wrote.
+
+    $zstd_bytes_out / $zstd_ratio are log-phase variables: nginx writes
+    the access_log line only after the response is fully sent, which can
+    race a fast local request. Poll instead of reading once, mirroring
+    test_encoding.py's validate_ratio_log.
+    """
+    deadline = time.time() + timeout
+    line = ""
+    while time.time() < deadline:
+        if path.exists():
+            content = path.read_text(encoding="utf-8", errors="replace")
+            lines = [l for l in content.splitlines() if l.strip()]
+            if lines:
+                line = lines[-1]
+                break
+        time.sleep(0.05)
+    return line
 
 
 def decode_dcz(
@@ -540,6 +568,52 @@ def main() -> int:
                 len(dcz_body) < len(plain_body),
                 f"(dcz {len(dcz_body)} vs zstd {len(plain_body)})",
             )
+
+            # -- $zstd_bytes_out / $zstd_ratio byte-accounting oracle.
+            #
+            # Regression for the 40-byte dcz prefix being counted twice:
+            # ngx_http_zstd_filter_get_buf() advances out_buf->last past
+            # the 40-byte skippable-frame prefix AND used to separately
+            # add 40 to ctx->bytes_out, while the emit path in
+            # ngx_http_zstd_filter_compress() already counts the whole
+            # buffer (prefix included) via ngx_buf_size(). Ground truth
+            # is len(dcz_body): the exact bytes this request put on the
+            # wire, already captured above. $zstd_bytes_out must equal it
+            # exactly -- not "close", not "within 40" -- and $zstd_ratio
+            # (bytes_in*1000/bytes_out, truncated to 3 decimals) must be
+            # derivable from that same bytes_out.
+            bytes_log_line = read_last_log_line(root / "logs" / "zstd_bytes.log")
+            check(
+                "$zstd_bytes_out / $zstd_ratio access_log line was written",
+                bool(bytes_log_line),
+                f"(zstd_bytes.log: {bytes_log_line!r})",
+            )
+            if bytes_log_line:
+                logged_bytes_out_str, logged_ratio_str = bytes_log_line.split(" ", 1)
+                logged_bytes_out = int(logged_bytes_out_str)
+                check(
+                    "$zstd_bytes_out equals the actual dcz response byte "
+                    "length (prefix counted exactly once)",
+                    logged_bytes_out == len(dcz_body),
+                    f"(zstd_bytes_out={logged_bytes_out}, wire body={len(dcz_body)})",
+                )
+
+                # Ground truth is len(dcz_body), NOT logged_bytes_out: the
+                # ratio must match the ACTUAL wire bytes. Deriving the
+                # expectation from logged_bytes_out instead would make
+                # this check vacuous under the exact bug this test guards
+                # against (bytes_out inflated by 40 would inflate the
+                # expectation the same way and the two would always
+                # agree, however wrong bytes_out is).
+                bytes_in = len(resource)
+                scaled = bytes_in * 1000 // len(dcz_body)
+                expected_ratio = f"{scaled // 1000}.{scaled % 1000:03d}"
+                check(
+                    "$zstd_ratio matches bytes_in*1000/bytes_out computed "
+                    "from the actual wire byte count",
+                    logged_ratio_str == expected_ratio,
+                    f"(logged {logged_ratio_str!r}, expected {expected_ratio!r})",
+                )
 
             # -- content checksum (defence in depth): the inner zstd frame
             # starts right after the 40-byte dcz header, so byte 44 is its

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -2900,7 +2900,17 @@ ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
                                              ctx->dcz_dict->frame_header,
                                              NGX_HTTP_ZSTD_DCZ_HEADER_LEN);
 
-            ctx->bytes_out += NGX_HTTP_ZSTD_DCZ_HEADER_LEN;
+            /*
+             * Do NOT add NGX_HTTP_ZSTD_DCZ_HEADER_LEN to ctx->bytes_out
+             * here. Advancing ->last above already grows ngx_buf_size()
+             * of this same buffer by 40 bytes, and the emit path in
+             * ngx_http_zstd_filter_compress() (`ctx->bytes_out +=
+             * ngx_buf_size(b)`) counts this buffer's full size -- prefix
+             * included -- exactly once when it is queued. A separate
+             * increment here double-counted the 40-byte prefix on every
+             * dcz response ($zstd_bytes_out and the $zstd_ratio derived
+             * from it were both 40 bytes too high).
+             */
             ctx->dcz_header_sent = 1;
 
             ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,


### PR DESCRIPTION
> Two small, independent audit rows bundled per dispatch instructions:
> a dcz byte-accounting fix (F1) and a CI dependency-pinning fix (F6).

## TL;DR

Two things going on here. First: when a response uses zstd's dictionary
mode, the module glues a fixed 40-byte tag onto the front of the
compressed body, and it was counting that tag twice when it reported
how many bytes it sent — so the byte counter (and the compression-ratio
metric computed from it) always read 40 bytes higher than what actually
went out. Second: our CI installs a Perl test-harness package with no
version pinned, so a run could silently pick up a different release
than the last one, with nothing in the repository saying so.

In code terms: `ngx_http_zstd_filter_get_buf()` no longer adds
`NGX_HTTP_ZSTD_DCZ_HEADER_LEN` to `ctx->bytes_out` after writing the dcz
prefix into `out_buf`, since `ngx_http_zstd_filter_compress()`'s emit
path already counts that same buffer's full size via `ngx_buf_size(b)`.
The CI workflows now install `Test::Nginx::Socket@0.32` instead of an
unpinned `Test::Nginx::Socket`, across all five install sites in
`build-test.yml` and `ci-deep.yml`.

**Severity:** `Low` (`observability — $zstd_bytes_out/$zstd_ratio over-report by a fixed 40 bytes on every dcz response; no wire-format or memory-safety impact`)

## Byte-accounting fix (dcz prefix double-counted)

`ngx_http_zstd_filter_get_buf()` writes the 40-byte dcz skippable-frame
prefix into a freshly allocated `out_buf` and advances `out_buf->last`
past it (`src/ngx_http_zstd_filter_module.c:2869`). It then used to add
`NGX_HTTP_ZSTD_DCZ_HEADER_LEN` to `ctx->bytes_out` as a separate
increment. That double-counted the prefix: the emit path in
`ngx_http_zstd_filter_compress()` (`ctx->bytes_out += ngx_buf_size(b)`,
line 2574) already counts the whole buffer — prefix included — once
`->last` has advanced past it, when it queues the buffer downstream.

I verified both premises the fix depends on directly in the code rather
than assuming them:

* **(a) `->last` really is advanced before emit sees the buffer.**
  `ngx_cpymem(ctx->out_buf->last, ctx->dcz_dict->frame_header,
  NGX_HTTP_ZSTD_DCZ_HEADER_LEN)` runs and reassigns `->last` inside
  `get_buf()`, before `get_buf()` returns and before
  `ngx_http_zstd_filter_compress()` runs on that same buffer.
* **(b) the emit path always runs for that first buffer on every dcz
  response — there is no path where get_buf's increment was the only
  accounting.** The suppression branch that could otherwise skip a
  buffer (`if (ngx_buf_size(ctx->out_buf) == 0 && !last) return
  NGX_AGAIN;`) can never fire for the prefix buffer: `ngx_buf_size` is
  `last - pos`, `pos` is 0 on a fresh buffer, and `->last` is already
  40 bytes in from the prefix write, so the buffer's size is never zero
  while it carries the prefix — it always falls through to the emit
  line. The error path (`get_buf`/`compress` returning `NGX_ERROR`)
  aborts the whole request without ever reporting `$zstd_bytes_out` on
  a completed response, so it isn't a live undercounting path either.
  A comment already in `ngx_http_zstd_filter_compress()` (right above
  the terminal-frame check) independently confirms the prefix rides
  inside the same buffer `ngx_buf_size()` sees.

## Testing

* `ci/t/03-dcz.t` TEST 33 (new): references `$zstd_bytes_out` and
  `$zstd_ratio` via `set` on a dcz response, mirroring TEST 32/39 in
  `00-filter.t` — pins that both log-phase variables resolve without
  the get_handler faulting on the dcz path. Ran locally against a
  built module: 118/118 tests pass (up from 115 before this PR).
* `ci/tools/test_dcz.py` (extended): added a byte-accounting oracle
  that reads a scoped `access_log` line (`log_format zstd_bytes_fmt
  "$zstd_bytes_out $zstd_ratio"`) after the dcz happy-path request and
  asserts `$zstd_bytes_out` equals the exact response body length
  already captured for the wire-format checks, and that `$zstd_ratio`
  matches `bytes_in*1000/bytes_out` computed from that same real byte
  count (not from the logged value, so the ratio check can't be
  vacuous under the same bug). This is the file this suite already
  documents as the home for wire-byte-exactness checks — the exact
  compressed size depends on the linked libzstd version and isn't
  pinned as a literal anywhere in this repo's tests.
* **Negative control**: restored the deleted `ctx->bytes_out +=
  NGX_HTTP_ZSTD_DCZ_HEADER_LEN;` line, rebuilt the module
  (`cc ... -o objs/ngx_http_zstd_filter_module.so`, confirmed fresh
  mtime), and reran `test_dcz.py`. Both new checks went red exactly as
  predicted:
  ```
  FAIL - $zstd_bytes_out equals the actual dcz response byte length (prefix counted exactly once) (zstd_bytes_out=963, wire body=923)
  FAIL - $zstd_ratio matches bytes_in*1000/bytes_out computed from the actual wire byte count (logged '49.961', expected '52.126')
  ```
  963 − 923 = 40, exactly the double-counted prefix. Removed the
  mutation, rebuilt, reran: both checks pass again.
* `.claude/skills/_shared/review-lint.sh --diff HEAD` — full roster ran
  (no `== coverage gap ==` block, so nothing was skipped); the only
  findings are pre-existing and outside this diff's changed lines
  (two bandit/semgrep findings in untouched `test_dcz.py` code, a
  pre-existing `checkov` finding on `ci-deep.yml`'s unrelated
  `workflow_dispatch` inputs, and long-line yamllint warnings on lines
  this diff didn't touch).

## CI dependency pin (unversioned Test::Nginx::Socket)

All five `cpanm -l ~/perl5 --notest Test::Nginx::Socket` call sites
(`build-test.yml:1389/1792/2068`, `ci-deep.yml:209/894` after this
diff) resolved to whatever CPAN currently serves, with no repository
record of which release that was. Pinned all five to
`Test::Nginx::Socket@0.32` via one `TEST_NGINX_SOCKET_VERSION: "0.32"`
entry in each workflow file's top-level `env:` block (mirroring how
`NGINX_VERSION` is already handled in both files), referenced from
every install/cache-key site instead of five independent literals.

I confirmed 0.32 is what CI already runs, not a version bump: I pulled
the most recent successful `master` run's logs
(`gh api repos/myguard-labs/nginx-zstd-module/actions/runs/33113727133/logs`)
and all three build-test.yml jobs that install it logged
`Test::Nginx::Socket is up to date. (0.32)`. 0.32 is also CPAN's
current latest release (`metacpan.org` release API, dated
2026-03-03), so there's no legacy-drift risk either.

The four cache-hit call sites' `actions/cache` keys
(`perl-modules-${{ runner.os }}-Test-Nginx-Socket`) now include
`${{ env.TEST_NGINX_SOCKET_VERSION }}`, so a cache saved under the old
unpinned install cannot be restored for a differently-pinned future
bump. The fifth site (`build-test.yml`'s coverage job) has no cache
step to version — it always cpanm-installs fresh — so it only needed
the pin and the assertion.

Every "Install Test::Nginx::Socket" step now also asserts the
installed version right after the install, on both the cold-install
and cache-hit paths:
```bash
installed="$(perl -I "$HOME/perl5/lib/perl5" -MTest::Nginx::Socket -e 'print $Test::Nginx::Socket::VERSION')"
echo "Test::Nginx::Socket installed version: $installed"
if [ "$installed" != "$TEST_NGINX_SOCKET_VERSION" ]; then
  echo "::error::Test::Nginx::Socket version mismatch: pinned $TEST_NGINX_SOCKET_VERSION, got $installed"
  exit 1
fi
```

I did not trust a green rollup for this half: `actions/cache` reports
a failed save as a warning annotation, never a failing step, so a green
check here would prove nothing about whether the cache key or the
assertion actually took effect. I verified both from a locally-run
install instead — `cpanm -l <tmp> --notest "Test::Nginx::Socket@0.32"`
resolved cleanly, and the version-comparison shell logic produces the
`::error::` line and a nonzero exit for a deliberately wrong pinned
value, and prints the match silently otherwise. After this PR's own CI
runs, the "Install Test::Nginx::Socket" job logs should show the
`Test::Nginx::Socket installed version: 0.32` line on every one of the
five sites and no `::error::` line; I'll check those logs once the
run reaches that step, since a green rollup alone can't confirm a
warning-only cache-key mechanism actually did anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected dcz response byte counts by preventing the frame header from being counted twice.
  * Fixed derived compression ratio values for dcz responses.

* **Tests**
  * Added coverage verifying dcz byte-count and ratio variables.
  * Expanded end-to-end checks to validate logged output against actual response sizes.

* **Chores**
  * Pinned the test framework version to ensure consistent CI results across test, coverage, and build jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->