### PR TITLE
fix: soak.sh ASan/UBSan gate on finding content, not log existence (A27-F9)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -296,6 +296,27 @@ jobs:
           # compiler.
           bash "$GITHUB_WORKSPACE"/ci/tools/test_compressbound_skip_gate.sh
 
+      - name: soak.sh ASAN/UBSAN verdict unit fixture (A27-F9)
+        run: |
+          # A27-F9: ci/tools/soak.sh's ASan/UBSan check used to fail on
+          # whether "$WORK/logs/asan*" merely EXISTED, never reading its
+          # content -- so LeakSanitizer's own "ptrace appears to be
+          # blocked" startup diagnostic (this runner pool's LXC
+          # seccomp/yama profile blocks its exit-time tracer; see
+          # test_reload_leak.sh and the smoke-tests step above for the
+          # same signature) failed the soak exactly like a real finding.
+          # Observed in CI: PR #214 run 33117464973 job "A/UBSan" attempt
+          # 1 failed on pure ptrace noise with all four soak workers
+          # clean; attempt 2 (identical build) passed.
+          # ci/tools/soak_asan_verdict.sh now extracts the fixed triage
+          # (real finding -> fail, ptrace-blocked -> INDETERMINATE warn,
+          # no log/no finding -> pass) into one function soak.sh sources,
+          # and this fixture drives it directly against ptrace-only,
+          # real-ASan, real-UBSan and absent-log cases, plus a negative
+          # control proving the original ls-only gate fails on the
+          # ptrace-only fixture. No nginx, no libzstd -- pure Bash.
+          bash "$GITHUB_WORKSPACE"/ci/tools/test_soak_asan_verdict_unit.sh
+
       - name: Configure a real nginx source tree (for scan-build headers)
         run: |
           # scan-build needs the COMPLETE nginx headers — including the

--- a/ci/tools/soak.sh
+++ b/ci/tools/soak.sh
@@ -264,11 +264,32 @@ kill -QUIT "$NGINX_PID" 2>/dev/null || true
 wait "$NGINX_PID" 2>/dev/null
 rc=$?
 
+# shellcheck source=ci/tools/soak_asan_verdict.sh
+. "$(cd "$(dirname "$0")" && pwd)/soak_asan_verdict.sh"
+
 problems=0
+indeterminate=0
 if ls "$WORK"/logs/asan* >/dev/null 2>&1; then
-    echo "FAIL: ASAN/UBSAN report:"
+    echo "ASAN/UBSAN log:"
     cat "$WORK"/logs/asan*
-    problems=1
+    set +e
+    soak_asan_verdict "$WORK"/logs/asan*
+    asan_rc=$?
+    set -e
+    case "$asan_rc" in
+        0) : ;;
+        2)
+            echo "::warning::LeakSanitizer could not run its exit-time check" \
+                 "(ptrace blocked on this runner — LXC seccomp / yama). Soak" \
+                 "leak check INDETERMINATE, not clean; fix the runner profile" \
+                 "to restore coverage."
+            indeterminate=1
+            ;;
+        *)
+            echo "FAIL: ASAN/UBSAN report (see log above)"
+            problems=1
+            ;;
+    esac
 fi
 if ls "$WORK"/logs/valgrind.* "$WORK"/logs/helgrind.* >/dev/null 2>&1; then
     if grep -qE 'ERROR SUMMARY: [1-9]|definitely lost: [1-9]' \
@@ -305,4 +326,10 @@ if [ "$rc" -ne 0 ] && [ "$rc" -ne 130 ]; then
 fi
 
 [ "$problems" -ne 0 ] && exit 1
-echo "✓ soak clean: ${DURATION}s @ ${CONC} concurrent, no sanitizer/leak/crash"
+if [ "$indeterminate" -ne 0 ]; then
+    echo "⚠ soak passed: ${DURATION}s @ ${CONC} concurrent, no crash/sanitizer" \
+         "finding, but the leak lane is INDETERMINATE this run (ptrace" \
+         "blocked -- see warning above)"
+else
+    echo "✓ soak clean: ${DURATION}s @ ${CONC} concurrent, no sanitizer/leak/crash"
+fi

--- a/ci/tools/soak_asan_verdict.sh
+++ b/ci/tools/soak_asan_verdict.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 Thijs Eilander
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# soak_asan_verdict() -- triage an ASAN_OPTIONS log_path glob's content and
+# decide whether the soak passes, fails, or is INDETERMINATE.
+#
+# A27-F9: ci/tools/soak.sh used to gate on whether ANY "$WORK/logs/asan*"
+# file existed at all, never reading it. log_path (see soak.sh's
+# ASAN_OPTIONS) makes the sanitizer runtime write EVERY file it wants to
+# emit into that glob -- including pure diagnostics that are not findings,
+# such as LeakSanitizer's own "ptrace appears to be blocked (is seccomp
+# enabled?)" startup warning. On this runner pool (LXC seccomp/yama on
+# builder02) that warning fires routinely: the same signature shows up in
+# ci/tools/test_reload_leak.sh and the "Run smoke tests under ASAN+UBSAN"
+# step in .github/workflows/build-test.yml, both of which already read
+# content instead of existence for exactly this reason. This file extracts
+# that same triage into one function so soak.sh and this unit fixture share
+# one source of truth instead of two copies drifting apart.
+#
+# Verdict (mirrors the valgrind/helgrind branch a few lines below this
+# call site in soak.sh, and the two existing ptrace-aware call sites
+# above):
+#   0 (pass, clean)          -- no log, or a log with no recognized
+#                                sanitizer finding and no ptrace-blocked
+#                                signature (diagnostics of some other,
+#                                unrecognized kind still count as clean
+#                                here -- this function only fails on an
+#                                actual finding).
+#   1 (fail)                 -- a real ASan/LSan/UBSan finding.
+#   2 (indeterminate)        -- LeakSanitizer's exit-time check could not
+#                                run (ptrace blocked). NOT a pass and NOT
+#                                a fail: the leak lane checked nothing
+#                                this run, so a plain 0 would misreport
+#                                "no leaks" when nothing was actually
+#                                verified.
+#
+# The log content (if any) is always echoed by the caller-visible path
+# (soak.sh cats it), independent of this function's return code, so the
+# condition stays visible in the job log instead of going silent -- this
+# function only classifies, it does not print.
+#
+# Usage: soak_asan_verdict <file> [<file> ...]
+#   A caller like `soak_asan_verdict "$WORK"/logs/asan*` that had no
+#   matching files (glob left unexpanded, nullglob off) is handled: this
+#   function treats a sole non-existent path as "no log" (verdict 0),
+#   the same as the historical `ls ... >/dev/null 2>&1` gate finding
+#   nothing.
+soak_asan_verdict() {
+    local existing=()
+    local f
+
+    for f in "$@"; do
+        [ -f "$f" ] && existing+=("$f")
+    done
+
+    # No log at all: nothing to triage, and nothing was written, so this
+    # is a clean pass (the historical "ls found nothing" case).
+    [ "${#existing[@]}" -eq 0 ] && return 0
+
+    # Real sanitizer findings fail unconditionally, checked FIRST: a run
+    # can produce a ptrace warning from one worker and a real finding
+    # from another (log_path writes one file per process), and checking
+    # ptrace first would let the warning short-circuit the verdict and
+    # mask the finding -- the same ordering test_reload_leak.sh and the
+    # build-test.yml smoke-tests step already use, for the same reason.
+    #
+    # Patterns, and why these specifically -- this repo builds with
+    # -fsanitize=address,undefined -fno-sanitize-recover=undefined, and
+    # these are what each sanitizer's real output actually looks like,
+    # not a guess from memory:
+    #   ERROR: (Address|Leak|UndefinedBehavior)Sanitizer  -- the banner
+    #     every ASan/LSan finding opens with (heap-buffer-overflow,
+    #     use-after-free, detected memory leaks, ...).
+    #   SUMMARY: (Address|Leak|UndefinedBehavior)Sanitizer -- the summary
+    #     line every finding also emits; belt and suspenders in case a
+    #     report is truncated before its ERROR banner but the summary
+    #     line still lands.
+    #   runtime error: -- UBSan's OWN finding format. It is not an
+    #     "ERROR:"/"SUMMARY:" banner at all -- that shape belongs to
+    #     ASan/LSan. -fno-sanitize-recover=undefined means the process
+    #     aborts on the first one, so a single line is sufficient.
+    if grep -qE 'ERROR: (Address|Leak|UndefinedBehavior)Sanitizer|SUMMARY: (Address|Leak|UndefinedBehavior)Sanitizer|runtime error:' \
+        "${existing[@]}" 2>/dev/null; then
+        return 1
+    fi
+
+    # The known lockdown signature (see the file header): LSan's
+    # exit-time tracer was blocked/killed before it could inspect
+    # anything. No verdict exists in either direction for the leak lane.
+    if grep -qE 'ptrace appears to be blocked|LeakSanitizer may hang|Child exited with signal' \
+        "${existing[@]}" 2>/dev/null; then
+        return 2
+    fi
+
+    # A log existed but held neither a recognized finding nor the
+    # ptrace-blocked signature: pass. (Nothing currently writes
+    # log_path files outside those two shapes, but this function's job
+    # is to fail on findings, not on "log exists" -- the exact defect
+    # A27-F9 exists to fix.)
+    return 0
+}
+
+# Allow direct execution for ad hoc triage of an already-captured log:
+#   ci/tools/soak_asan_verdict.sh /path/to/asan.*
+# Sourcing (as soak.sh and the unit fixture do) must not run this --
+# BASH_SOURCE differs from $0 only when sourced.
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    soak_asan_verdict "$@"
+    exit $?
+fi

--- a/ci/tools/test_soak_asan_verdict_unit.sh
+++ b/ci/tools/test_soak_asan_verdict_unit.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Unit fixture for soak_asan_verdict() (ci/tools/soak_asan_verdict.sh).
+#
+# A27-F9: ci/tools/soak.sh used to fail the ASAN/UBSAN soak when
+# "$WORK/logs/asan*" merely EXISTED, never reading its content -- so a
+# LeakSanitizer that could not even start (ptrace blocked by this runner
+# pool's LXC seccomp/yama profile -- see soak_asan_verdict.sh's header)
+# looked identical to a real finding. Observed in CI: PR #214 run
+# 33117464973, job "A/UBSan / ASan/UBSan soak (60s)" attempt 1 failed
+# with "FAIL: ASAN/UBSAN report:" whose entire payload was
+#   ==4635==WARNING: ptrace appears to be blocked (is seccomp enabled?).
+#   ==4635==Child exited with signal 32.
+# with all four soak workers having reported clean in the same run.
+# Attempt 2 (identical binary, identical soak) passed with no asan* file
+# written at all.
+#
+# This drives soak_asan_verdict() directly against four fixtures, sources
+# the SAME file soak.sh sources (no hand-copied logic to drift), and ends
+# with a mandatory negative control: the ORIGINAL `ls`-only gate applied to
+# the ptrace-only fixture, proving that gate fails on exactly this input --
+# the false-failure this whole row exists to fix.
+#
+# No nginx, no libzstd, no network -- pure Bash.
+#
+# Usage: tools/test_soak_asan_verdict_unit.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=ci/tools/soak_asan_verdict.sh
+. "$SCRIPT_DIR/soak_asan_verdict.sh"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/soak-asan-verdict-unit.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# assert_verdict <fixture-file-or-empty> <expected-rc> <label>
+# expected-rc: 0 pass, 1 fail (real finding), 2 indeterminate (ptrace).
+# A "-" fixture means "no log file at all" (absent-log case).
+assert_verdict() {
+    local fixture="$1" expected="$2" label="$3"
+    local rc
+
+    if [ "$fixture" = "-" ]; then
+        set +e
+        soak_asan_verdict "$WORK/does-not-exist.*"
+        rc=$?
+        set -e
+    else
+        set +e
+        soak_asan_verdict "$fixture"
+        rc=$?
+        set -e
+    fi
+
+    if [ "$rc" -ne "$expected" ]; then
+        echo "FAIL: $label -- soak_asan_verdict returned $rc, want $expected" >&2
+        fail=1
+        return
+    fi
+    echo "OK: $label (rc=$rc)"
+}
+
+# ── Fixture 1: ptrace/seccomp startup noise only, no finding ──────────
+# Verbatim shape of the PR #214 attempt-1 payload above.
+cat >"$WORK/asan.ptrace_only" <<'EOF'
+==4635==WARNING: ptrace appears to be blocked (is seccomp enabled?). LeakSanitizer may hang.
+==4635==Child exited with signal 32.
+EOF
+assert_verdict "$WORK/asan.ptrace_only" 2 "ptrace/seccomp warning only => INDETERMINATE (not a finding)"
+
+# ── Fixture 2: a real ASan finding ────────────────────────────────────
+cat >"$WORK/asan.real_asan" <<'EOF'
+==4712==ERROR: AddressSanitizer: heap-use-after-free on address 0x60200000eff0 at pc 0x0000004a3b21 bp 0x7ffd7f3b3aa0 sp 0x7ffd7f3b3a98
+READ of size 8 at 0x60200000eff0 thread T0
+    #0 0x4a3b20 in ngx_http_zstd_body_filter
+SUMMARY: AddressSanitizer: heap-use-after-free
+EOF
+assert_verdict "$WORK/asan.real_asan" 1 "real heap-use-after-free => FAIL"
+
+# ── Fixture 3: a real UBSan finding (its own "runtime error:" shape,
+#    NOT the ERROR:/SUMMARY: banner ASan/LSan use) ────────────────────
+cat >"$WORK/asan.real_ubsan" <<'EOF'
+ngx_http_zstd_filter_module.c:512:14: runtime error: signed integer overflow: 2147483647 + 1 cannot be represented in type 'int'
+EOF
+assert_verdict "$WORK/asan.real_ubsan" 1 "UBSan runtime error: line => FAIL"
+
+# ── Fixture 4: no log at all (absent) ─────────────────────────────────
+assert_verdict "-" 0 "no asan* log file at all => PASS"
+
+# ── Mandatory negative control ────────────────────────────────────────
+# Revert to the historical bug: a bare `ls ... >/dev/null 2>&1` gate that
+# fails on EXISTENCE alone, applied to fixture 1 (ptrace-only noise, no
+# finding). It must now report FAIL -- proving this fixture reproduces
+# the exact false-positive PR #214 hit, and that soak_asan_verdict() is
+# the thing that fixes it rather than something incidental.
+echo
+echo "-- negative control: reverting to the ls-only existence gate --"
+neg_control_output=""
+neg_control_rc=0
+if ls "$WORK"/asan.ptrace_only >/dev/null 2>&1; then
+    neg_control_output="FAIL: ASAN/UBSAN report:
+$(cat "$WORK/asan.ptrace_only")"
+    neg_control_rc=1
+fi
+echo "$neg_control_output"
+if [ "$neg_control_rc" -ne 1 ]; then
+    echo "FAIL: negative control did not reproduce the original bug" \
+         "(expected the ls-only gate to fail on ptrace-only noise)" >&2
+    fail=1
+else
+    echo "OK: negative control reproduces the original false failure" \
+         "(ls-only gate FAILs on ptrace-only noise, as PR #214 observed)"
+fi
+
+if [ "$fail" -ne 0 ]; then
+    echo "FAIL: soak_asan_verdict unit fixture had failures" >&2
+    exit 1
+fi
+echo "OK: soak_asan_verdict unit fixture -- all cases + negative control passed"


### PR DESCRIPTION
## TL;DR

A memory checker sometimes has to admit "I couldn't actually run this check" instead of giving a clean bill of health. Our CI soak test could not tell that apology apart from an actual finding: it failed the whole run whenever the checker had written anything to its report file, whether that file held a real problem or just a note saying it couldn't look.

In code terms: `ASAN_OPTIONS` sets `log_path=$WORK/logs/asan`, so the sanitizer runtime writes every file it wants there, findings and pure diagnostics alike, and `ci/tools/soak.sh`'s gate was `ls "$WORK"/logs/asan* >/dev/null 2>&1`: existence only, content never read.

**Severity:** Medium (test-gate correctness: a runner-environment condition was reported as a sanitizer finding, costing a red required check on unrelated PRs)

## What actually failed

PR #214, run 33117464973, job "A/UBSan / ASan/UBSan soak (60s)", attempt 1:

```
worker 2: 1241 ok, 0 bad/failed, 100 dcz
worker 1: 1241 ok, 0 bad/failed, 89 dcz
worker 4: 1256 ok, 0 bad/failed, 77 dcz
worker 3: 1257 ok, 0 bad/failed, 84 dcz
FAIL: ASAN/UBSAN report:
==4635==WARNING: ptrace appears to be blocked (is seccomp enabled?). LeakSanitizer may hang.
==4635==Child exited with signal 32.
```

All four workers reported clean. The entire "report" that failed the job was LeakSanitizer's own startup warning about not being able to attach its exit-time tracer. Attempt 2, same binary, same soak: no `asan*` file was even written, and the job passed.

## The fix

`ci/tools/soak_asan_verdict.sh` extracts the triage into one function, `soak_asan_verdict()`, that both `soak.sh` and the new unit fixture source. Three outcomes instead of two:

* a real finding fails unconditionally
* the ptrace-blocked signature is INDETERMINATE (`::warning::`, not a pass, not a fail)
* no log, or a log with neither, is a clean pass

Finding patterns, matched against what this repo's sanitizer build (`-fsanitize=address,undefined -fno-sanitize-recover=undefined`) actually emits, not guessed from memory:

* `ERROR: (Address|Leak|UndefinedBehavior)Sanitizer`: the banner every ASan/LSan finding opens with
* `SUMMARY: (Address|Leak|UndefinedBehavior)Sanitizer`: the summary line at the end of a report, in case the banner got truncated by a shutdown race
* `runtime error:`: UBSan's own format. It is not an `ERROR:`/`SUMMARY:` banner at all (that shape belongs to ASan/LSan only), and `-fno-sanitize-recover=undefined` means the process aborts on the first hit, so one line is enough

The ptrace-blocked branch checks `ptrace appears to be blocked|LeakSanitizer may hang|Child exited with signal`, the same three-phrase signature `ci/tools/test_reload_leak.sh` and the "Run smoke tests under ASAN+UBSAN" step in `build-test.yml` already grep for. The log is echoed before the verdict is decided either way, so the condition stays visible in the job log instead of going silent when it's diagnostics-only.

## Does LeakSanitizer actually run here?

`detect_leaks=1` is explicit in `soak.sh`'s `ASAN_OPTIONS`, so someone wanted the leak lane load-bearing. Converting the false failure into a quiet pass without checking that would be worse than the bug it replaces: a soak that goes green while silently checking nothing for leaks.

It doesn't run reliably. Same day, same runner pool, master run 33084048220: `ci/tools/test_reload_leak.sh`'s own leak check (the one with a positive-control canary proving LSan can detect a deliberate leak before trusting any verdict) hit "ptrace appears to be blocked" on all four of its reload workers (pids 1848, 1853, 1863, 1868). That's the exit-time tracer being blocked every single time it was exercised in that job, not a one-off. Combined with the asan.yml evidence above (blocked on attempt 1, no log at all on attempt 2, so it isn't even consistently blocked, more a runner-load race), the honest read is that this runner pool's LXC seccomp/yama profile makes LSan's exit-time check unreliable, and the repo already treats that as a known, named condition rather than something to paper over.

So this PR keeps `detect_leaks=1` and makes the degradation loud (the `::warning::` annotation plus an explicit "leak lane is INDETERMINATE this run" line in the final verdict) instead of dropping it or silently passing. That mirrors the disposition already in place for `test_reload_leak.sh` and the smoke-tests step: fix the runner profile to restore real coverage; until then, don't let the soak claim a leak check that didn't happen.

One related gap noticed while gathering this evidence, left alone here because it belongs to a different file: in that same build-test.yml run, the "Run smoke tests under ASAN+UBSAN" step reported `no unsuppressed leaks under the smoke tests` a few seconds *before* `test_reload_leak.sh` hit the ptrace block four times in a row in the same job. That step's own log (`/tmp/lsan-smoke.*`) apparently held neither an `ERROR: LeakSanitizer` nor the ptrace-blocked signature that run, so it read clean, but on a runner where the block is this common, that could just as easily be an LSan that also silently couldn't run. Worth someone checking whether that step's positive control is as solid as `test_reload_leak.sh`'s.

## Testing

New fixture: `ci/tools/test_soak_asan_verdict_unit.sh`, pure Bash, no nginx or libzstd needed. Drives `soak_asan_verdict()` against four cases:

* ptrace/seccomp warning only (verbatim shape of the PR #214 payload) → rc=2 (INDETERMINATE)
* a real `ERROR: AddressSanitizer: heap-use-after-free` / `SUMMARY:` → rc=1 (FAIL)
* a UBSan `runtime error:` line → rc=1 (FAIL)
* no log file at all → rc=0 (PASS)

Mandatory negative control: reverting to the original `ls`-only existence gate and running it against the ptrace-only fixture. Verbatim output:

```
-- negative control: reverting to the ls-only existence gate --
FAIL: ASAN/UBSAN report:
==4635==WARNING: ptrace appears to be blocked (is seccomp enabled?). LeakSanitizer may hang.
==4635==Child exited with signal 32.
OK: negative control reproduces the original false failure (ls-only gate FAILs on ptrace-only noise, as PR #214 observed)
```

Wired into `.github/workflows/build-test.yml` next to the other no-nginx shell/C unit fixtures (`test_compressbound_skip_gate.sh` and friends). `shellcheck --severity=error` and full `shellcheck` (no severity filter) are clean on all three touched/new files. `bash -n` passes on `soak.sh` and both new scripts.

I did not run the actual 60-second soak locally: it is an explicit long-runner this project forbids starting outside CI, and it needs an ASan-instrumented nginx build this repo's CI produces, not something quick to stand up here. The new call site's control flow (variable scoping under `set -euo pipefail`, the `set +e`/`set -e` bracket around the function call, the final indeterminate-vs-clean message) was checked by inspection and by sourcing `soak_asan_verdict()` directly under `set -euo pipefail`, not by a live soak run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sanitizer log evaluation to distinguish clean results, detected failures, and indeterminate leak checks.
  * Prevented ptrace-only diagnostics from being incorrectly reported as sanitizer failures.
  * Final soak results now clearly indicate when leak verification is indeterminate.

* **Tests**
  * Added automated coverage for sanitizer findings, ptrace restrictions, missing logs, and regression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->