### PR TITLE
Add perf stat counter-delta recipe for data-layout repack row

### DIFF
--- a/ci/tools/perf_stat_recipe.py
+++ b/ci/tools/perf_stat_recipe.py
@@ -70,6 +70,7 @@ TOOLS_DIR = pathlib.Path(__file__).resolve().parent
 @dataclasses.dataclass
 class PerfCounters:
     """CPU cache and execution counters from perf stat."""
+
     cache_misses: int
     cache_references: int
     instructions: int
@@ -223,8 +224,7 @@ def parse_perf_output(
     if not required.issubset(counters.keys()):
         missing = required - counters.keys()
         raise RuntimeError(
-            f"perf stat output missing counters: {missing}.\n"
-            f"Output:\n{perf_output}"
+            f"perf stat output missing counters: {missing}.\nOutput:\n{perf_output}"
         )
 
     return counters
@@ -384,6 +384,7 @@ def print_counters(
 @dataclasses.dataclass
 class CounterDelta:
     """Delta between two measurements."""
+
     cache_misses: int
     cache_references: int
     instructions: int
@@ -447,13 +448,17 @@ def compare_results(baseline_json: str, optimized_json: str) -> None:
     print("\n" + "=" * 70)
     if delta.cache_misses < 0:
         claim_pct = delta.cache_misses / baseline.cache_misses
-        print(f"✓ SUPPORTS CLAIM: {abs(delta.cache_misses):,} fewer "
-              f"cache misses ({claim_pct:.1%})")
+        print(
+            f"✓ SUPPORTS CLAIM: {abs(delta.cache_misses):,} fewer "
+            f"cache misses ({claim_pct:.1%})"
+        )
         print("  Repack row retained.")
     else:
         support_pct = delta.cache_misses / baseline.cache_misses
-        print(f"✗ DOES NOT SUPPORT: {delta.cache_misses:+,} cache misses "
-              f"({support_pct:+.1%})")
+        print(
+            f"✗ DOES NOT SUPPORT: {delta.cache_misses:+,} cache misses "
+            f"({support_pct:+.1%})"
+        )
         print("  Repack row should be REFUTED.")
     print("=" * 70 + "\n")
 

--- a/ci/tools/perf_stat_recipe.py
+++ b/ci/tools/perf_stat_recipe.py
@@ -1,0 +1,534 @@
+#!/usr/bin/env python3
+"""CPU cache counter-delta recipe for the data-layout repack optimization row.
+
+HYBRID CPU PINNING STRATEGY
+-----------------------------
+This host is a hybrid Intel 12th-gen (P-core + E-core) CPU: perf stat splits
+every event across two PMUs (cpu_core/* and cpu_atom/*), and the non-pinned
+core type returns <not counted> with 0.00% enable time. Naive perf stat then
+yields half-empty, non-comparable numbers.
+
+Solution: pin the workload to ONE core type and select explicit PMU-qualified
+event names. Hybrid CPUs declare their cores via /sys/devices/cpu_core/cpus
+and /sys/devices/cpu_atom/cpus; this script detects both and pins to P-cores
+(the first range) by default. Pass --core-type=E to pin to E-cores instead.
+
+Performance core (P) CPUs 0-15, Efficiency core (E) CPUs 16-31 on this host.
+
+PURPOSE
+-------
+Measure the cache-miss and instruction-count overhead of dictionary negotiation
+on the request-hot path. The optimization row proposes splitting a 104-byte
+struct-of-arrays lookup into two arrays (a 40-byte index + pointer indirection)
+to reduce cache misses on negotiation. This recipe establishes:
+
+1. A baseline of cache-misses, cache-references, instructions, and cycles for
+   the current (unmodified) code running ab_bench.py release pass
+2. An A/B delta when the optimization is applied
+
+The repack row is retained ONLY if the counter delta supports the "third-cacheline"
+claim (fewer cache misses). Struct size reduction alone (pahole) does not retain
+the row -- smaller struct != fewer misses.
+
+USAGE
+-----
+    # Baseline: measure current code
+    python3 ci/tools/perf_stat_recipe.py --nginx /path/to/nginx --json baseline.json
+
+    # After optimization: measure again
+    python3 ci/tools/perf_stat_recipe.py --nginx /path/to/nginx --json optimized.json
+
+    # Compare
+    python3 ci/tools/perf_stat_recipe.py --compare baseline.json optimized.json
+
+Environment: requires
+  - perf (installed at /usr/bin/perf)
+  - /proc/sys/kernel/perf_event_paranoid <= 1 (this host has 1)
+  - ab_bench.py in the same ci/tools directory
+  - A working nginx binary
+  - wrk load-testing tool
+
+Exit status
+-----------
+0 on success (measurements recorded or comparison printed)
+1 on harness error (missing tools, bad args, workload failed)
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+TOOLS_DIR = pathlib.Path(__file__).resolve().parent
+
+
+@dataclasses.dataclass
+class PerfCounters:
+    """CPU cache and execution counters from perf stat."""
+    cache_misses: int
+    cache_references: int
+    instructions: int
+    cycles: int
+
+    def miss_rate(self) -> float:
+        """Cache miss rate (misses / references)."""
+        if self.cache_references == 0:
+            return 0.0
+        return self.cache_misses / self.cache_references
+
+    def ipc(self) -> float:
+        """Instructions per cycle."""
+        if self.cycles == 0:
+            return 0.0
+        return self.instructions / self.cycles
+
+    def to_dict(self) -> dict:
+        """Serialize to JSON."""
+        return {
+            "cache_misses": self.cache_misses,
+            "cache_references": self.cache_references,
+            "instructions": self.instructions,
+            "cycles": self.cycles,
+            "miss_rate": self.miss_rate(),
+            "ipc": self.ipc(),
+        }
+
+    @staticmethod
+    def from_dict(d: dict) -> PerfCounters:
+        """Deserialize from JSON."""
+        return PerfCounters(
+            cache_misses=d["cache_misses"],
+            cache_references=d["cache_references"],
+            instructions=d["instructions"],
+            cycles=d["cycles"],
+        )
+
+
+def detect_hybrid_cores() -> tuple[str, str, int]:
+    """Detect P-core and E-core CPU ranges on hybrid x86 CPU.
+
+    Returns
+    -------
+    (pcore_range: str, ecore_range: str, pcore_id: int)
+        pcore_range: space-separated CPU ids
+            (e.g. "0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15")
+        ecore_range: space-separated CPU ids
+            (e.g. "16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31")
+        pcore_id: first P-core id (0 on this host)
+
+    Raises
+    ------
+    RuntimeError if hybrid CPU detection fails
+    """
+    try:
+        with open("/sys/devices/cpu_core/cpus", encoding="utf-8") as f:
+            pcore_str = f.read().strip()
+        with open("/sys/devices/cpu_atom/cpus", encoding="utf-8") as f:
+            ecore_str = f.read().strip()
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            f"Hybrid CPU detection failed: {exc}. "
+            "This recipe requires /sys/devices/cpu_core/cpus and "
+            "/sys/devices/cpu_atom/cpus. Non-hybrid CPUs are not supported."
+        ) from exc
+
+    # Parse ranges like "0-15" into space-separated "0 1 2 3 ..."
+    def expand_range(range_str: str) -> str:
+        """Convert '0-15' to '0 1 2 3 ... 15'."""
+        parts: list[str] = []
+        for part in range_str.split(","):
+            part = part.strip()
+            if "-" in part:
+                start, end = part.split("-")
+                parts.extend(str(i) for i in range(int(start), int(end) + 1))
+            else:
+                parts.append(part)
+        return " ".join(parts)
+
+    pcore_ids = expand_range(pcore_str)
+    ecore_ids = expand_range(ecore_str)
+    pcore_id = int(pcore_str.split("-")[0].split(",")[0])
+
+    return pcore_ids, ecore_ids, pcore_id
+
+
+def parse_perf_output(
+    perf_output: str,
+    core_type: str,
+) -> dict[str, int]:
+    """Parse perf stat output for cache and execution counters.
+
+    Parameters
+    ----------
+    perf_output : str
+        perf stat stderr output
+    core_type : str
+        P or E, for error messaging
+
+    Returns
+    -------
+    dict[str, int]
+        Counters: cache_misses, cache_references, instructions, cycles
+
+    Raises
+    ------
+    RuntimeError if output is invalid or <not counted>
+    """
+    counters = {}
+    lines = perf_output.split("\n")
+
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#") or "time elapsed" in line:
+            continue
+
+        # Extract number and event name
+        match = re.match(
+            r"^([\d,]+|<not counted>)\s+(cpu_\w+/[\w\-]+/)",
+            line,
+        )
+        if not match:
+            continue
+
+        count_str, event = match.groups()
+
+        # Skip <not counted> entries
+        if count_str == "<not counted>":
+            raise RuntimeError(
+                f"perf stat returned <not counted> for {event} on {core_type}"
+                f"-cores. Workload pinned to wrong core type. "
+                f"Output:\n{perf_output}"
+            )
+
+        # Convert "7,614" to 7614
+        count = int(count_str.replace(",", ""))
+
+        # Map event name to counter key
+        if "cache-misses" in event:
+            counters["cache_misses"] = count
+        elif "cache-references" in event:
+            counters["cache_references"] = count
+        elif "instructions" in event:
+            counters["instructions"] = count
+        elif "cycles" in event:
+            counters["cycles"] = count
+
+    # Validate we got all four counters
+    required = {"cache_misses", "cache_references", "instructions", "cycles"}
+    if not required.issubset(counters.keys()):
+        missing = required - counters.keys()
+        raise RuntimeError(
+            f"perf stat output missing counters: {missing}.\n"
+            f"Output:\n{perf_output}"
+        )
+
+    return counters
+
+
+def run_perf_stat(
+    command: list[str],
+    cpu_mask: str,
+    core_type: str,
+) -> PerfCounters:
+    """Run perf stat on a command pinned to one core type.
+
+    Parameters
+    ----------
+    command : list[str]
+        Command to run
+    cpu_mask : str
+        Space-separated CPU ids
+    core_type : str
+        P or E, for log messaging
+
+    Returns
+    -------
+    PerfCounters
+        Parsed cache and execution counters
+
+    Raises
+    ------
+    RuntimeError if perf stat fails or returns no counts
+    """
+    # Use taskset to pin to the CPU mask
+    full_cmd = ["taskset", "-c", cpu_mask.replace(" ", ",")] + command
+
+    # Run perf stat with explicit cpu_core/* or cpu_atom/* PMU events.
+    pmu = "cpu_core" if core_type == "P" else "cpu_atom"
+    perf_events = [
+        f"{pmu}/cache-misses/",
+        f"{pmu}/cache-references/",
+        f"{pmu}/instructions/",
+        f"{pmu}/cycles/",
+    ]
+
+    perf_cmd = ["/usr/bin/perf", "stat", "-e", ",".join(perf_events)] + full_cmd
+
+    print(f"[{core_type}-core] Running: {' '.join(perf_cmd)}", file=sys.stderr)
+
+    try:
+        result = subprocess.run(
+            perf_cmd,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"perf stat timed out after 600s. Command: {' '.join(perf_cmd)}"
+        ) from exc
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "/usr/bin/perf not found. Install linux-tools or perf package."
+        ) from exc
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"perf stat failed with exit code {result.returncode}.\n"
+            f"stderr: {result.stderr}\n"
+            f"stdout: {result.stdout}"
+        )
+
+    counters_dict = parse_perf_output(result.stderr, core_type)
+
+    print(
+        f"[{core_type}-core] counters: cache_misses={counters_dict['cache_misses']}, "
+        f"cache_references={counters_dict['cache_references']}, "
+        f"instructions={counters_dict['instructions']}, "
+        f"cycles={counters_dict['cycles']}"
+    )
+
+    return PerfCounters(**counters_dict)
+
+
+def measure_baseline(
+    nginx_path: str | pathlib.Path,
+    output_json: str | None = None,
+    core_type: str = "P",
+) -> PerfCounters:
+    """Measure cache counters for ab_bench.py release pass.
+
+    Parameters
+    ----------
+    nginx_path : str or Path
+        Path to nginx binary
+    output_json : str | None
+        If provided, save result to this JSON file
+    core_type : str
+        'P' (P-cores, default) or 'E' (E-cores)
+
+    Returns
+    -------
+    PerfCounters
+        Measured counters
+    """
+    nginx_path_obj = pathlib.Path(nginx_path).resolve()
+    if not nginx_path_obj.exists():
+        raise RuntimeError(f"nginx binary not found: {nginx_path_obj}")
+
+    # Run ab_bench.py release pass under perf stat
+    # Use 1 round and 5s duration for a quick baseline (faster than 3x10s default)
+    bench_cmd = [
+        "python3",
+        str(TOOLS_DIR / "ab_bench.py"),
+        "--arm-a",
+        f"{nginx_path_obj}:baseline",
+        "--rounds",
+        "1",
+        "--duration",
+        "5s",  # Short measurement window
+    ]
+
+    # Detect hybrid CPU ranges
+    pcore_ids, ecore_ids, _ = detect_hybrid_cores()
+    cpu_mask = pcore_ids if core_type == "P" else ecore_ids
+
+    # Run the benchmark under perf stat
+    counters = run_perf_stat(bench_cmd, cpu_mask, core_type)
+
+    # Save to JSON if requested
+    if output_json:
+        result = {
+            "core_type": core_type,
+            "cpu_mask": cpu_mask,
+            "command": " ".join(bench_cmd),
+            "counters": counters.to_dict(),
+        }
+        with open(output_json, "w", encoding="utf-8") as f:
+            json.dump(result, f, indent=2)
+        print(f"Saved to {output_json}")
+
+    return counters
+
+
+def print_counters(
+    label: str,
+    counters: PerfCounters,
+) -> None:
+    """Print a set of counter values."""
+    print(f"\n{label}:")
+    print(f"  cache_misses:      {counters.cache_misses:>12,}")
+    print(f"  cache_references:  {counters.cache_references:>12,}")
+    print(f"  instructions:      {counters.instructions:>12,}")
+    print(f"  cycles:            {counters.cycles:>12,}")
+    print(f"  miss_rate:         {counters.miss_rate():>12.2%}")
+    print(f"  IPC:               {counters.ipc():>12.2f}")
+
+
+@dataclasses.dataclass
+class CounterDelta:
+    """Delta between two measurements."""
+    cache_misses: int
+    cache_references: int
+    instructions: int
+    cycles: int
+    miss_rate: float
+    ipc: float
+
+    @staticmethod
+    def compute(baseline: PerfCounters, optimized: PerfCounters) -> CounterDelta:
+        """Compute delta between baseline and optimized."""
+        return CounterDelta(
+            cache_misses=optimized.cache_misses - baseline.cache_misses,
+            cache_references=optimized.cache_references - baseline.cache_references,
+            instructions=optimized.instructions - baseline.instructions,
+            cycles=optimized.cycles - baseline.cycles,
+            miss_rate=optimized.miss_rate() - baseline.miss_rate(),
+            ipc=optimized.ipc() - baseline.ipc(),
+        )
+
+
+def compare_results(baseline_json: str, optimized_json: str) -> None:
+    """Compare two measurement runs.
+
+    Parameters
+    ----------
+    baseline_json : str
+        Path to baseline measurement result
+    optimized_json : str
+        Path to optimized measurement result
+    """
+    with open(baseline_json, encoding="utf-8") as f:
+        baseline_result = json.load(f)
+    with open(optimized_json, encoding="utf-8") as f:
+        optimized_result = json.load(f)
+
+    baseline = PerfCounters.from_dict(baseline_result["counters"])
+    optimized = PerfCounters.from_dict(optimized_result["counters"])
+
+    print("\n" + "=" * 70)
+    print("COUNTER DELTA ANALYSIS")
+    print("=" * 70)
+
+    print_counters("BASELINE (current code)", baseline)
+    print_counters("OPTIMIZED (with repack)", optimized)
+
+    delta = CounterDelta.compute(baseline, optimized)
+
+    print("\nDELTA:")
+    miss_pct = delta.cache_misses / baseline.cache_misses
+    refs_pct = delta.cache_references / baseline.cache_references
+    insns_pct = delta.instructions / baseline.instructions
+    cycles_pct = delta.cycles / baseline.cycles
+    print(f"  cache_misses:      {delta.cache_misses:>+12,} ({miss_pct:>+6.1%})")
+    print(f"  cache_references:  {delta.cache_references:>+12,} ({refs_pct:>+6.1%})")
+    print(f"  instructions:      {delta.instructions:>+12,} ({insns_pct:>+6.1%})")
+    print(f"  cycles:            {delta.cycles:>+12,} ({cycles_pct:>+6.1%})")
+    print(f"  miss_rate:         {delta.miss_rate:>+12.2%}")
+    print(f"  IPC:               {delta.ipc:>+12.3f}")
+
+    # Verdict
+    print("\n" + "=" * 70)
+    if delta.cache_misses < 0:
+        claim_pct = delta.cache_misses / baseline.cache_misses
+        print(f"✓ SUPPORTS CLAIM: {abs(delta.cache_misses):,} fewer "
+              f"cache misses ({claim_pct:.1%})")
+        print("  Repack row retained.")
+    else:
+        support_pct = delta.cache_misses / baseline.cache_misses
+        print(f"✗ DOES NOT SUPPORT: {delta.cache_misses:+,} cache misses "
+              f"({support_pct:+.1%})")
+        print("  Repack row should be REFUTED.")
+    print("=" * 70 + "\n")
+
+
+def main() -> int:
+    """Entry point."""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    # "measure" subcommand
+    measure_parser = subparsers.add_parser(
+        "measure",
+        help="Measure baseline or optimized code",
+        aliases=["baseline"],
+    )
+    measure_parser.add_argument(
+        "--nginx",
+        required=True,
+        help="Path to nginx binary",
+    )
+    measure_parser.add_argument(
+        "--json",
+        help="Save result to JSON file",
+    )
+    measure_parser.add_argument(
+        "--core-type",
+        choices=["P", "E"],
+        default="P",
+        help="Pin to P-cores (default) or E-cores",
+    )
+
+    # "compare" subcommand
+    compare_parser = subparsers.add_parser(
+        "compare",
+        help="Compare baseline and optimized measurements",
+    )
+    compare_parser.add_argument(
+        "baseline",
+        help="Baseline measurement JSON file",
+    )
+    compare_parser.add_argument(
+        "optimized",
+        help="Optimized measurement JSON file",
+    )
+
+    args = parser.parse_args()
+
+    if args.command in ("measure", "baseline", None):
+        if not args.nginx:
+            parser.print_help()
+            return 1
+        try:
+            measure_baseline(
+                args.nginx,
+                output_json=args.json,
+                core_type=args.core_type,
+            )
+            return 0
+        except (RuntimeError, FileNotFoundError, subprocess.TimeoutExpired) as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 1
+    elif args.command == "compare":
+        try:
+            compare_results(args.baseline, args.optimized)
+            return 0
+        except (FileNotFoundError, json.JSONDecodeError) as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 1
+    else:
+        parser.print_help()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Implements the [TOOL] task: perf stat counter-delta recipe for measuring cache behavior around the proposed data-layout optimization (split 104-byte dictionary lookup struct into compact 40-byte index + pointer).

## Key Features

- **Hybrid CPU pinning**: Detects P-core/E-core split from `/sys/devices/cpu_core/cpus` and `/sys/devices/cpu_atom/cpus`; pins workload to one core type to avoid split-PMU `<not counted>` artifacts. P-cores 0-15, E-cores 16-31 on this host.
- **Baseline measurement**: Runs ab_bench.py release pass (1 round, 5s) under `perf stat` with explicit `cpu_core/*` PMU-qualified events. Records cache_misses, cache_references, instructions, cycles.
- **A/B comparison**: `compare` subcommand computes deltas and prints verdict: supports the "third-cacheline" claim (fewer cache misses) or REFUTES it with evidence.
- **Documented recipe**: Follows ab_bench.py convention—full usage and pinning strategy in module docstring.

## Baseline Numbers (Release nginx, P-cores)

cache_misses:      808,591,284
cache_references:  6,173,526,162 (miss_rate=13.1%)
instructions:      344,119,258,416 (IPC=1.052)
cycles:            326,981,351,847

Workload: 5s ab_bench release pass (1 round) with 8KB body size, paced backend for real contention simulation.

## Usage

python3 ci/tools/perf_stat_recipe.py measure --nginx .build/baseline/objs/nginx --json baseline.json
python3 ci/tools/perf_stat_recipe.py measure --nginx .build/optimized/objs/nginx --json optimized.json
python3 ci/tools/perf_stat_recipe.py compare baseline.json optimized.json

## Test Plan

- Hybrid CPU detection verified on this host (P: 0-15, E: 16-31)
- perf stat with taskset pinning works; no <not counted> with explicit PMU selection
- Baseline measurement completes; counters are non-zero and match re-run within noise
- Lint clean (ruff, mypy, bandit, pylint, vulture, semgrep, ast-grep)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line performance measurement tool for comparing baseline and optimized nginx benchmark runs.
  * Reports cache misses, cache references, instructions, cycles, miss rates, IPC, and result deltas.
  * Supports processor core selection, JSON result export, timeout handling, and validation of performance data.
  * Indicates whether cache-miss results support retaining the optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->