### PR TITLE
ci: give the smoke-tests leak check a positive control

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -317,6 +317,33 @@ jobs:
           # ptrace-only fixture. No nginx, no libzstd -- pure Bash.
           bash "$GITHUB_WORKSPACE"/ci/tools/test_soak_asan_verdict_unit.sh
 
+      - name: LSan positive control unit fixture (smoke-tests clean-vs-could-not-run)
+        run: |
+          # The "Run smoke tests under ASAN+UBSAN" step's leak verdict
+          # already told a real finding from a ptrace-blocked log (the
+          # soak_asan_verdict() shape, A27-F9), but a log with NEITHER
+          # signature only means "no finding was written" -- it does not
+          # prove LSan's exit-time check ran at all. Observed in CI: run
+          # 33084048220 ("Tests ASAN+UBSAN" job) printed "All smoke tests
+          # clean under ASAN+UBSAN" from a /tmp/lsan-smoke.* log with
+          # neither shape, and SECONDS later in the SAME job the
+          # zstd_dict_file reload-leak step hit the ptrace-blocked
+          # signature 4/4 -- same runner, same environment. That "clean"
+          # was indistinguishable from "never ran".
+          # ci/tools/lsan_positive_control.sh (extracted from the canary
+          # test_reload_leak.sh already used) now gates the smoke step's
+          # "clean" branch on independently proving a deliberate leak IS
+          # caught here; if the control fails, the step demotes to a
+          # loud, distinct "INDETERMINATE (could not run)" instead of a
+          # silent green. This fixture drives the real if/elif/else +
+          # control shape against finding / ptrace-signature /
+          # clean-but-control-fails / clean-and-control-passes fixtures,
+          # runs the control function for real, and ends with a negative
+          # control proving the pre-fix (no control) shape would have
+          # reported the run-33084048220 case as clean. Needs a working
+          # `cc`; skips (does not fail) if none is on PATH.
+          bash "$GITHUB_WORKSPACE"/ci/tools/test_lsan_positive_control_unit.sh
+
       - name: static pread retry/accumulate unit fixture (EINTR, short read, O_DIRECT alignment)
         run: |
           # ngx_http_zstd_static_pread(): the static probe's retry/accumulate
@@ -2019,8 +2046,52 @@ jobs:
                  "to restore coverage."
             echo "⚠ smoke tests passed; leak check INDETERMINATE"
           else
-            echo "✓ no unsuppressed leaks under the smoke tests"
-            echo "✓ All smoke tests clean under ASAN+UBSAN"
+            # A clean log here is NOT proof LSan ran: run 33084048220 printed
+            # this exact "clean" verdict, and seconds later in the SAME job
+            # the reload-leak step's ptrace-blocked signature fired 4/4 --
+            # same runner, same environment. A log with neither a finding
+            # nor the ptrace signature is indistinguishable from "LSan never
+            # attempted its exit-time check at all", so a bare grep miss is
+            # not enough to call this clean. Prove the detector actually
+            # works here first, with the SAME positive control
+            # test_reload_leak.sh uses (ci/tools/lsan_positive_control.sh),
+            # before trusting the "no finding" reading above.
+            #
+            # Three outcomes, not two: rc=2 ("could not even attempt the
+            # control" -- no cc, or the ASan compile failed) is a
+            # different, honest fact from rc=1 ("attempted, LSan failed to
+            # catch the canary" -- ptrace is the known cause here). Only
+            # rc=1 is the run-33084048220 ambiguity this fix closes; rc=2
+            # gets its own loud, distinct label rather than being folded
+            # into either "clean" or the ptrace-specific warning.
+            . "$GITHUB_WORKSPACE/ci/tools/lsan_positive_control.sh"
+            set +e
+            lsan_positive_control
+            control_rc=$?
+            set -e
+            if [ "$control_rc" -eq 0 ]; then
+              echo "✓ no unsuppressed leaks under the smoke tests"
+              echo "✓ positive control confirmed LSan can detect a deliberate leak here"
+              echo "✓ All smoke tests clean under ASAN+UBSAN"
+            elif [ "$control_rc" -eq 2 ]; then
+              echo "::warning::LeakSanitizer's positive control could not even" \
+                   "be attempted (no ASan-capable cc on this runner) --" \
+                   "cannot confirm the clean smoke log above means no leaks." \
+                   "Smoke leak check INDETERMINATE (could not attempt control)."
+              echo "⚠ smoke tests passed; leak check INDETERMINATE (control could not run)"
+            else
+              echo "::warning::LeakSanitizer's positive control failed here" \
+                   "(a deliberate canary leak was not caught, so LSan's" \
+                   "exit-time check is not provably working). The most" \
+                   "likely cause on this runner pool is ptrace being" \
+                   "blocked (LXC seccomp / yama), same as run 33084048220's" \
+                   "reload-leak step; if that is ruled out, check the ASan" \
+                   "toolchain install instead. The clean smoke log above" \
+                   "does NOT mean no leaks; it means the leak check could" \
+                   "not run. Smoke leak check INDETERMINATE, not clean;" \
+                   "fix the runner profile to restore coverage."
+              echo "⚠ smoke tests passed; leak check INDETERMINATE (could not run)"
+            fi
           fi
 
       - name: zstd_dict_file reload leak check (CDict lifecycle)

--- a/ci/tools/lsan_positive_control.sh
+++ b/ci/tools/lsan_positive_control.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 Thijs Eilander
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# lsan_positive_control() -- prove LeakSanitizer's exit-time check can
+# actually detect a DELIBERATE leak in the current environment, before any
+# caller trusts a "no leak" verdict from it.
+#
+# Why this exists: this runner pool intermittently blocks ptrace (LXC
+# seccomp/yama on builder02), which is what LSan's exit-time tracer needs.
+# When blocked, LSan emits "ptrace appears to be blocked (is seccomp
+# enabled?)" and detects NOTHING -- the process just exits, and a caller
+# that only greps its log for that one signature string is trusting an
+# implementation detail of the warning message, not proving the detector
+# ran. Observed directly in build-test.yml run 33084048220 ("Tests
+# ASAN+UBSAN" job): the "Run smoke tests under ASAN+UBSAN" step printed
+# "All smoke tests clean under ASAN+UBSAN" (neither a finding nor the
+# ptrace signature in its log), and SECONDS later in the SAME job the
+# "zstd_dict_file reload leak check" step (ci/tools/test_reload_leak.sh)
+# hit the ptrace-blocked signature 4 times in a row. Same job, same
+# runner, same environment -- so the smoke step's "clean" almost
+# certainly meant "LSan's exit-time check never ran here either", not "no
+# leak found". A clean log and a never-ran log are bitwise
+# indistinguishable without an independent proof the detector fired.
+#
+# This function is that proof: it compiles a tiny known-leaking canary
+# (a bare `malloc` with no free) with the SAME sanitizer the caller is
+# using, runs it with detect_leaks=1 and a distinct exitcode, and requires
+# that exact exitcode back. Only then is "clean" from the caller's real
+# log trustworthy; anything else means the detector could not run here,
+# which is INDETERMINATE, not a pass.
+#
+# Originally inline in ci/tools/test_reload_leak.sh; extracted so the
+# smoke-tests step in .github/workflows/build-test.yml can share the
+# exact same proof instead of a second, divergent copy.
+#
+# Verdict (return code) -- THREE distinct codes, not two, because "the
+# control could not even be attempted" (no toolchain here) is a different
+# fact than "the control ran and LSan failed it" (ptrace is blocked here):
+# collapsing them would make a caller skip its real leak test on any
+# runner that simply lacks an ASan-capable `cc`, silently losing coverage
+# that runner always had before this function existed.
+#   0  -- positive control PASSED: LSan caught the deliberate leak here.
+#          The caller's own verdict for this run can be trusted.
+#   1  -- positive control ATTEMPTED and FAILED: the canary compiled and
+#          ran but its deliberate leak was not caught. LSan's exit-time
+#          check is provably not working in this environment right now
+#          (ptrace blocked is the known cause on this runner pool). Any
+#          "clean" reading from the caller's real log is INDETERMINATE,
+#          not a pass -- the caller should skip trusting its own leak
+#          check and report INDETERMINATE instead.
+#   2  -- control could NOT be attempted at all (no `cc` on PATH, or the
+#          ASan compile itself failed -- e.g. no ASan runtime installed).
+#          This says nothing about whether LSan's exit-time check works;
+#          it means this function has no evidence either way. A caller
+#          MUST NOT treat this as "indeterminate" and skip its real leak
+#          check -- fall back to running that check exactly as if this
+#          function did not exist (its historical behavior).
+#
+# Nothing is printed on success; failure paths are silent too -- the
+# caller decides how loudly to report each code for its own context (a
+# GitHub ::warning::, a distinct exit code, whatever fits the step).
+#
+# Usage (sourced):
+#   if lsan_positive_control; then trust_clean
+#   elif [ $? -eq 2 ]; then run_real_check_unverified   # could not attempt
+#   else report_indeterminate; fi                        # attempted, failed
+# Usage (direct):   ci/tools/lsan_positive_control.sh; echo $?
+lsan_positive_control() {
+    local work canary_c canary_bin crc
+
+    command -v cc >/dev/null 2>&1 || return 2
+
+    work="$(mktemp -d "${TMPDIR:-/tmp}/lsan-positive-control.XXXXXX")" || return 2
+    canary_c="$work/canary.c"
+    canary_bin="$work/canary"
+
+    cat >"$canary_c" <<'EOF'
+#include <stdlib.h>
+int main(void) { malloc(1234); return 0; }
+EOF
+
+    if ! cc -fsanitize=address -o "$canary_bin" "$canary_c" 2>/dev/null; then
+        rm -rf "$work"
+        return 2
+    fi
+
+    crc=0
+    ASAN_OPTIONS="detect_leaks=1:exitcode=23" \
+        timeout 30 "$canary_bin" >/dev/null 2>&1 || crc=$?
+
+    rm -rf "$work"
+
+    [ "$crc" -eq 23 ] && return 0
+    return 1
+}
+
+# Allow direct execution for ad hoc probing of the current environment:
+#   ci/tools/lsan_positive_control.sh; echo $?
+# Sourcing (as test_reload_leak.sh and the smoke-tests step do) must not
+# run this -- BASH_SOURCE differs from $0 only when sourced.
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    lsan_positive_control
+    exit $?
+fi

--- a/ci/tools/test_lsan_positive_control_unit.sh
+++ b/ci/tools/test_lsan_positive_control_unit.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+#
+# Unit fixture for lsan_positive_control() (ci/tools/lsan_positive_control.sh)
+# and for the three-outcome verdict shape it feeds in the smoke-tests step
+# of .github/workflows/build-test.yml.
+#
+# The bug this closes: the "Run smoke tests under ASAN+UBSAN" step's leak
+# verdict used to grep /tmp/lsan-smoke.* for a finding, then for the
+# ptrace-blocked signature, and otherwise print "clean" -- exactly the
+# soak_asan_verdict() shape (A27-F9, PR #216). But a log with NEITHER a
+# finding NOR the ptrace signature is not proof LSan's exit-time check ran
+# at all: it is equally consistent with the check never firing. Observed
+# directly in build-test.yml run 33084048220, job "Tests ASAN+UBSAN": the
+# smoke-tests step printed "All smoke tests clean under ASAN+UBSAN" (its
+# /tmp/lsan-smoke.* log held neither shape), and SECONDS later in the SAME
+# job the "zstd_dict_file reload leak check" step
+# (ci/tools/test_reload_leak.sh) hit the ptrace-blocked signature 4/4 --
+# same runner, same environment. A "clean" verdict that cannot be told
+# apart from "never ran" is vacuous.
+#
+# The fix does NOT touch detect_leaks or weaken the grep-based verdict --
+# it adds a POSITIVE CONTROL (lsan_positive_control(), extracted from the
+# canary this same shape already used in test_reload_leak.sh) that must
+# independently prove LSan can catch a deliberate leak in this environment
+# before the "clean" branch is trusted. If the control fails, the step
+# demotes to a loud, distinct "INDETERMINATE (could not run)" -- never a
+# silent green.
+#
+# This fixture proves five DIFFERENT observed outcomes from five DIFFERENT
+# inputs, driving the real verdict logic end to end (not just the
+# extracted function): a real LeakSanitizer finding, a ptrace-blocked log,
+# a clean log whose positive control ATTEMPTED and FAILED (control_rc=1,
+# the exact ambiguity in run 33084048220), a clean log with a PASSING
+# control (control_rc=0), and a clean log whose control could not even be
+# ATTEMPTED (control_rc=2, no cc -- a different fact from rc=1, so it gets
+# its own distinct label rather than folding into either "clean" or the
+# ptrace-specific warning). It ends with a negative control that actually
+# RUNS the pre-fix else-branch (no positive control at all) against the
+# same empty-log fixture and requires it to report "clean" -- proving this
+# fixture reproduces the real false-green from run 33084048220.
+#
+# No nginx, no libzstd, no network -- pure Bash, plus a working `cc`.
+#
+# Usage: ci/tools/test_lsan_positive_control_unit.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=ci/tools/lsan_positive_control.sh
+. "$SCRIPT_DIR/lsan_positive_control.sh"
+
+if ! command -v cc >/dev/null 2>&1; then
+    echo "SKIP: no cc on PATH -- lsan_positive_control unit fixture needs one" >&2
+    exit 0
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/lsan-positive-control-unit.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+# smoke_verdict <log-glob-file-or-none> <control_rc: 0|1|2> <expect>
+# Mirrors the ACTUAL if/elif/else + positive-control shape now in
+# build-test.yml's smoke-tests step verdict verbatim (including the
+# real three-way control_rc from lsan_positive_control() itself: 0 pass,
+# 1 attempted-and-failed, 2 could-not-attempt), so this fixture exercises
+# the real decision tree, not a paraphrase of it.
+smoke_verdict() {
+    local logfile="$1" control_rc="$2"
+    local verdict
+
+    if [ "$logfile" != "-" ] && grep -q 'ERROR: LeakSanitizer' "$logfile" 2>/dev/null; then
+        verdict="finding"
+    elif [ "$logfile" != "-" ] && grep -qE 'ptrace appears to be blocked|LeakSanitizer may hang' "$logfile" 2>/dev/null; then
+        verdict="ptrace-indeterminate"
+    elif [ "$control_rc" -eq 0 ]; then
+        verdict="clean"
+    elif [ "$control_rc" -eq 2 ]; then
+        verdict="control-could-not-attempt-indeterminate"
+    else
+        verdict="could-not-run-indeterminate"
+    fi
+    echo "$verdict"
+}
+
+# pre_fix_smoke_verdict <log-glob-file-or-none>
+# The ORIGINAL else-branch this fixture guards against regressing to: no
+# positive control at all, so any log with neither a finding nor the
+# ptrace signature is trusted as clean outright. Executable, not a
+# hardcoded literal -- so the negative control below actually runs the
+# old decision and can fail if that decision ever changes.
+pre_fix_smoke_verdict() {
+    local logfile="$1"
+
+    if [ "$logfile" != "-" ] && grep -q 'ERROR: LeakSanitizer' "$logfile" 2>/dev/null; then
+        echo "finding"
+    elif [ "$logfile" != "-" ] && grep -qE 'ptrace appears to be blocked|LeakSanitizer may hang' "$logfile" 2>/dev/null; then
+        echo "ptrace-indeterminate"
+    else
+        echo "clean"
+    fi
+}
+
+assert_eq() {
+    local got="$1" want="$2" label="$3"
+    if [ "$got" != "$want" ]; then
+        echo "FAIL: $label -- got '$got', want '$want'" >&2
+        fail=1
+        return
+    fi
+    echo "OK: $label (verdict=$got)"
+}
+
+# ── Case 1: a real LeakSanitizer finding -> fail, regardless of control
+#    status. This step's grep is deliberately narrow (ERROR: LeakSanitizer
+#    only) -- it is the leak gate, not the general ASan/UBSan gate the
+#    Perl-suite step above it already runs. ─────────────────────────────
+cat >"$WORK/asan.real" <<'EOF'
+==4712==ERROR: LeakSanitizer: detected memory leaks
+
+Direct leak of 1234 byte(s) in 1 object(s) allocated from:
+    #0 0x4a3b20 in malloc
+    #1 0x4a5c10 in ngx_http_zstd_body_filter
+SUMMARY: LeakSanitizer: 1234 byte(s) leaked in 1 allocation(s).
+EOF
+v="$(smoke_verdict "$WORK/asan.real" 0)"
+assert_eq "$v" "finding" "real LeakSanitizer finding => FAIL (finding checked first, ordering preserved, even with a passing control)"
+
+# ── Case 2: ptrace-blocked signature already in the log -> INDETERMINATE
+#    (this branch does not even need the positive control; the signature
+#    alone is enough, same as A27-F9/soak_asan_verdict) ─────────────────
+cat >"$WORK/asan.ptrace" <<'EOF'
+==1848==WARNING: ptrace appears to be blocked (is seccomp enabled?). LeakSanitizer may hang.
+EOF
+v="$(smoke_verdict "$WORK/asan.ptrace" 0)"
+assert_eq "$v" "ptrace-indeterminate" "ptrace signature in log => INDETERMINATE"
+
+# ── Case 3: THE BUG -- a clean log (no finding, no ptrace signature) but
+#    the positive control ATTEMPTED and FAILED (control_rc=1): LSan
+#    demonstrably cannot detect a leak here. This is run 33084048220's
+#    exact shape: smoke log had neither signature, yet the sibling
+#    reload-leak step proved ptrace was blocked seconds later in the same
+#    job. Must NOT read as clean. ───────────────────────────────────────
+: >"$WORK/asan.empty"
+v="$(smoke_verdict "$WORK/asan.empty" 1)"
+assert_eq "$v" "could-not-run-indeterminate" \
+    "clean log + control ATTEMPTED and FAILED (rc=1) => INDETERMINATE, not clean (the run 33084048220 case)"
+
+# ── Case 4: a genuinely clean log AND a working positive control (rc=0)
+#    -> the only input that may report clean. ──────────────────────────
+v="$(smoke_verdict "$WORK/asan.empty" 0)"
+assert_eq "$v" "clean" "clean log + PASSING control (rc=0) => clean"
+
+# ── Case 5: a clean log but the control could NOT even be attempted
+#    (rc=2 -- no cc, or the ASan compile failed). This is NOT the same
+#    fact as case 3: it says nothing about whether LSan works here, so it
+#    must get its OWN distinct label, never silently folded into either
+#    "clean" or the attempted-and-failed warning. ───────────────────────
+v="$(smoke_verdict "$WORK/asan.empty" 2)"
+assert_eq "$v" "control-could-not-attempt-indeterminate" \
+    "clean log + control COULD NOT ATTEMPT (rc=2) => its own distinct indeterminate label"
+
+# ── The positive control function itself, driven for real (not stubbed):
+#    on this dev/CI host ptrace is not blocked, so the deliberate canary
+#    leak (malloc(1234), no free) must be CAUGHT. This is the same
+#    lsan_positive_control() the smoke-tests step and test_reload_leak.sh
+#    both call -- one source of truth, not two copies. ─────────────────
+if lsan_positive_control; then
+    echo "OK: lsan_positive_control() caught the deliberate canary leak on this host"
+else
+    echo "FAIL: lsan_positive_control() did not catch its own deliberate leak" \
+         "on this host (unexpected here -- ptrace should not be blocked" \
+         "in this environment)" >&2
+    fail=1
+fi
+
+# ── Mandatory negative control ──────────────────────────────────────────
+# Actually RUN the pre-fix else-branch (pre_fix_smoke_verdict(), no
+# positive control at all -- not a hardcoded literal) against Case 3's
+# exact input: an empty/never-written log, the shape a ptrace-blocked LSan
+# leaves behind when it dies before writing anything. The pre-fix logic
+# must report "clean" here -- proving this fixture reproduces the real
+# false-green from run 33084048220, and that the positive control
+# (distinguishing control_rc 0/1/2 in smoke_verdict above) is what
+# actually closes it, not something incidental to this fixture.
+echo
+echo "-- negative control: reverting to the pre-fix (no positive control) shape --"
+old_verdict="$(pre_fix_smoke_verdict "$WORK/asan.empty")"
+if [ "$old_verdict" != "clean" ]; then
+    echo "FAIL: negative control did not reproduce the pre-fix false-clean verdict" \
+         "(pre_fix_smoke_verdict returned '$old_verdict', expected 'clean')" >&2
+    fail=1
+else
+    echo "OK: negative control reproduces the pre-fix bug" \
+         "(pre_fix_smoke_verdict on the empty/never-ran log returns 'clean'," \
+         "indistinguishable from a real clean run -- exactly run 33084048220;" \
+         "smoke_verdict above only differs because it also checks control_rc)"
+fi
+
+if [ "$fail" -ne 0 ]; then
+    echo "FAIL: lsan_positive_control unit fixture had failures" >&2
+    exit 1
+fi
+echo "OK: lsan_positive_control unit fixture -- all cases + negative control passed"

--- a/ci/tools/test_reload_leak.sh
+++ b/ci/tools/test_reload_leak.sh
@@ -31,6 +31,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=ci/tools/lsan_positive_control.sh
+. "$SCRIPT_DIR/lsan_positive_control.sh"
+
 NGINX="${1:?usage: test_reload_leak.sh <nginx-binary> [reloads]}"
 RELOADS="${2:-5}"
 
@@ -43,27 +47,29 @@ mkdir -p "$WORK/conf" "$WORK/logs" "$WORK/html"
 # ── Positive control ─────────────────────────────────────────────────
 # Prove LSan can detect a DELIBERATE leak in this environment before
 # trusting any verdict below; a broken detector must read as
-# indeterminate, never as "no leak".
-if command -v cc >/dev/null 2>&1; then
-    cat >"$WORK/canary.c" <<'EOF'
-#include <stdlib.h>
-int main(void) { malloc(1234); return 0; }
-EOF
-    if cc -fsanitize=address -o "$WORK/canary" "$WORK/canary.c" 2>/dev/null; then
-        set +e
-        ASAN_OPTIONS="detect_leaks=1:exitcode=23" \
-            timeout 30 "$WORK/canary" >/dev/null 2>&1
-        crc=$?
-        set -e
-        if [ "$crc" -ne 23 ]; then
-            echo "::warning::LeakSanitizer failed its positive control" \
-                 "(deliberate leak exited $crc, want 23) — ptrace is likely" \
-                 "blocked on this runner (LXC seccomp / yama). Leak check" \
-                 "INDETERMINATE, not failed; fix the runner profile to" \
-                 "restore coverage."
-            exit 0
-        fi
-    fi
+# indeterminate, never as "no leak". Shared with the smoke-tests step in
+# .github/workflows/build-test.yml via lsan_positive_control.sh so both
+# call sites prove the SAME thing the SAME way.
+#
+# rc=2 ("could not attempt": no cc, or the ASan compile itself failed) is
+# NOT the same fact as rc=1 ("attempted, LSan failed to catch it") -- only
+# rc=1 says anything about whether THIS runner's LSan works, so only rc=1
+# short-circuits here. rc=2 falls through and still runs the real
+# reload-leak test below, exactly as this script did before the positive
+# control existed.
+set +e
+lsan_positive_control
+control_rc=$?
+set -e
+if [ "$control_rc" -eq 1 ]; then
+    echo "::warning::LeakSanitizer failed its positive control" \
+         "(a deliberate canary leak was not caught, so LSan's exit-time" \
+         "check is not provably working here). The most likely cause on" \
+         "this runner pool is ptrace being blocked (LXC seccomp / yama);" \
+         "if that is ruled out, check the ASan toolchain install instead." \
+         "Leak check INDETERMINATE, not failed; fix the runner profile to" \
+         "restore coverage."
+    exit 0
 fi
 
 # A non-trivial dictionary so ZSTD_createCDict() actually allocates.


### PR DESCRIPTION
> Found while chasing why `test_reload_leak.sh`'s ptrace-blocked signature showed up in run 33084048220 seconds after the sibling smoke-tests step called itself clean.

## TL;DR

A leak checker only tells you something if it actually ran. This runner pool sometimes blocks the syscall LeakSanitizer needs to inspect a process on exit, and when that happens the checker silently does nothing instead of reporting a leak or a pass. The "Run smoke tests under ASAN+UBSAN" step's leak gate couldn't tell a real clean run from that silent nothing, so it printed the same green checkmark either way.

In code terms: the smoke-tests step in `.github/workflows/build-test.yml` now sources `ci/tools/lsan_positive_control.sh` (extracted from the canary already in `ci/tools/test_reload_leak.sh`) and requires it to catch a deliberate `malloc(1234)` leak before trusting a `/tmp/lsan-smoke.*` log with neither an `ERROR: LeakSanitizer` finding nor the ptrace-blocked signature.

**Severity:** `Medium` (test coverage — the leak lane can silently stop running while the job still reports success)

## What is going on

Run `33084048220` ("Tests ASAN+UBSAN" job) is the concrete case: the smoke-tests step printed `All smoke tests clean under ASAN+UBSAN` because `/tmp/lsan-smoke.*` held neither shape its `if`/`elif`/`else` verdict checks for. Seconds later, in the *same job*, the `zstd_dict_file reload leak check` step (`ci/tools/test_reload_leak.sh`) hit `ptrace appears to be blocked (is seccomp enabled?)` four times in a row — same runner, same environment. The smoke step's clean log is consistent with two very different facts: a genuinely leak-free run, or LSan's exit-time check never firing at all. The existing grep-based verdict cannot distinguish them.

`test_reload_leak.sh` already carried the fix for this ambiguity: before trusting its own verdict, it compiles a tiny leaking canary (`malloc(1234)`, no free) with the same sanitizer, runs it with `detect_leaks=1:exitcode=23`, and requires exitcode 23 back. That logic is now `lsan_positive_control()` in `ci/tools/lsan_positive_control.sh`, with three return codes instead of the original's two implicit outcomes:

* `0` — control passed, LSan caught the canary; the caller's real verdict can be trusted.
* `1` — control ran and failed (canary leak not caught); LSan's exit-time check is provably not working here right now.
* `2` — control could not even be attempted (no `cc`, or the ASan compile itself failed). This is a different fact from `1` and must not collapse into it: `test_reload_leak.sh`'s original code fell through to run the real leak test unconditionally when `cc` was absent, and `lsan_positive_control()` preserves that by giving "could not attempt" its own code.

Both `test_reload_leak.sh` and the smoke-tests step now branch on all three codes explicitly rather than treating "not 0" as one bucket.

## Proposed fix

* `ci/tools/lsan_positive_control.sh` — new shared function, sourced by both call sites instead of two copies drifting apart.
* `ci/tools/test_reload_leak.sh` — inline canary replaced by a call to the shared function; behavior preserved exactly (rc=2 still falls through to the real reload-leak test, rc=1 still exits 0 with a warning).
* `.github/workflows/build-test.yml` smoke-tests step — the `else` branch (no finding, no ptrace signature) no longer trusts "clean" outright. It now runs the same positive control and reports one of three outcomes: `✓ All smoke tests clean` (control passed), `⚠ ... INDETERMINATE (could not run)` (control ran and failed — the run 33084048220 case), or `⚠ ... INDETERMINATE (control could not run)` (no `cc` available — a different, honest label, not folded into the other two).
* `detect_leaks` stays `1` throughout; nothing about the actual leak gate was loosened. The finding-first ordering (`ERROR: LeakSanitizer` checked before the ptrace signature, checked before the new control) is unchanged, so a real leak still fails the job before either INDETERMINATE branch can fire.

## Testing

New unit fixture `ci/tools/test_lsan_positive_control_unit.sh` (added to the `validation` job alongside the existing `soak_asan_verdict`/`compressBound`/static-pread unit fixtures — pure Bash plus a working `cc`, no nginx or libzstd build). It drives the real if/elif/else + control shape end to end against five fixtures and asserts five distinct observed verdicts:

* a real `ERROR: LeakSanitizer` log → `finding` (checked first, ordering preserved even with a passing control)
* a ptrace-blocked-signature log → `ptrace-indeterminate`
* an empty log with control rc=1 (attempted, failed) → `could-not-run-indeterminate` — the exact run 33084048220 shape
* an empty log with control rc=0 (passed) → `clean` — the only input that may report clean
* an empty log with control rc=2 (could not attempt) → its own `control-could-not-attempt-indeterminate` label

It also runs `lsan_positive_control()` for real (not stubbed) and confirms it catches its own deliberate canary leak on the host running the fixture. The mandatory negative control calls `pre_fix_smoke_verdict()` — the actual pre-fix else-branch logic, not a hardcoded string — against the same empty-log fixture and requires it to report `clean`, proving the fixture reproduces the real false-green and that the positive control is what closes it. I mutated that function's `else` branch to a different label and re-ran the fixture: it failed with `FAIL: negative control did not reproduce the pre-fix false-clean verdict`, confirming the check is not vacuous; reverting brings it back to green.

I ran `bash ci/tools/test_lsan_positive_control_unit.sh` and `ci/tools/lsan_positive_control.sh` directly on this dev box (ptrace is not blocked here) — both pass, confirming `lsan_positive_control()` correctly returns 0 when LSan works and 2 when `cc` is hidden from `PATH`. I could not exercise rc=1 (control attempted and failed) against a real ptrace-blocked runner locally; that path is unit-tested via the fixture above and will additionally be exercised for real whenever this CI's runner pool hits its known intermittent ptrace block.

`.claude/skills/_shared/review-lint.sh --diff HEAD` is clean across shellcheck, yamllint (only pre-existing line-length warnings, none touching new lines' content), actionlint, zizmor, gitleaks/trufflehog, codespell, lizard, jscpd, semgrep, trivy, checkov, and ast-grep. `shfmt` reports style-only diffs (this repo's shell files use 4-space indent, matching `ci/tools/soak_asan_verdict.sh`; `shfmt`'s 2-space default disagrees with the same pre-existing file, so this is repo-wide advisory noise, not a regression).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved memory-leak validation in smoke tests to avoid incorrectly reporting clean results when leak detection cannot be verified.
  - Distinguishes successful detection, unavailable checks, and failed detection outcomes.
  - Emits warnings for indeterminate results instead of claiming validation succeeded.

- **Tests**
  - Added coverage for leak detection, blocked execution, missing compiler support, clean runs, and false-clean scenarios.
  - Added validation for configuration cleanup across successful and error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->