### PR TITLE
feat(static): let dcz bypass precompressed sidecars

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,17 @@
 Changes with http-zstd
 
+    *) Feature: "zstd_static_dict_bypass on" makes the precompressed
+       static handler stand aside when a main request carries
+       Available-Dictionary and explicitly accepts dcz, allowing the
+       filter module to negotiate the dictionary response first. The
+       opt-in applies to both "zstd_static on" and "always", inherits
+       across http/server/location configuration, and emits the complete
+       Accept-Encoding / Available-Dictionary / Sec-Fetch-Site Vary key
+       before declining. The default remains off; when a later dcz policy
+       or dictionary match fails, the skipped sidecar is not revisited and
+       the filter falls back to ordinary zstd or identity without allowing
+       a shared cache to cross that routing decision.
+
     *) Feature: "zstd_dcz_dict_trust_hashes on" opts out of verifying a
        supplied dictionary hash literal against the file's bytes: the
        literal is trusted verbatim as the negotiation key and the

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This is a hardened fork: every push/PR is exercised against **nginx mainline**, 
     * [zstd_dcz_assume_secure_transport](#zstd_dcz_assume_secure_transport)
   * [ngx_http_zstd_static_module](#ngx_http_zstd_static_module)
     * [zstd_static](#zstd_static)
+    * [zstd_static_dict_bypass](#zstd_static_dict_bypass)
 * [Variables](#variables)
   * [$zstd_ratio](#zstd_ratio)
   * [$zstd_bytes_in](#zstd_bytes_in)
@@ -236,7 +237,11 @@ This filter module compresses responses on the fly using zstd. It runs after the
 >
 > This used to be a deployment prerequisite backed only by a config-load warning: with the default `gzip_vary off`, nginx *suppresses* the header entirely, so a single overlooked location shipped zstd bodies that a shared cache would then hand to clients unable to decode them. Correctness now belongs to the module rather than to an operator directive, and the warning is gone with it. `gzip_vary on` remains perfectly fine to set (it also covers other encoders such as `gzip`); it is simply no longer load-bearing for zstd.
 >
-> `zstd_static always` is deliberately excluded: it ignores `Accept-Encoding` entirely, so its response is not a negotiated variant and correctly carries no `Vary: Accept-Encoding`.
+> `zstd_static always` is deliberately excluded when
+> [`zstd_static_dict_bypass`](#zstd_static_dict_bypass) is off: it then ignores
+> `Accept-Encoding` entirely, so its response is not a negotiated variant and
+> correctly carries no `Vary: Accept-Encoding`. The opt-in bypass is the stated
+> exception because it routes dictionary-aware requests by that field.
 >
 > Interoperating with [ngx_http_compression_vary_filter_module](https://github.com/HanadaLee/ngx_http_compression_vary_filter_module) is safe in every combination. That module emits and *flattens* `Vary` from `r->gzip_vary`, which this module still sets; because it folds the fields it finds rather than appending blindly, the header this module emits is merged rather than doubled. With `compression_vary off` (its default) this module's own emission still covers you — previously that exact combination produced no `Vary` at all, which is the residual risk the old summary warning existed to describe. CI asserts the single-`Vary` contract against the real module in both of its states.
 
@@ -1112,11 +1117,19 @@ Controls how pre-compressed `.zst` files are served.
 |---|---|
 | `off` | Disabled. Always serve the original file. |
 | `on` | Check whether the client supports zstd (`Accept-Encoding: zstd`). If yes and a `.zst` file exists, serve it. Otherwise fall back to the original. Emits `Vary: Accept-Encoding` automatically on both outcomes. |
-| `always` | Always serve the `.zst` file if it exists, regardless of `Accept-Encoding`. Use this when you know all clients support zstd (e.g. internal services). |
+| `always` | Serve the `.zst` file if it exists regardless of `Accept-Encoding`, except for dictionary-aware requests when [`zstd_static_dict_bypass`](#zstd_static_dict_bypass) is enabled. Use this when you know all other clients support zstd (e.g. internal services). |
 
-When set to `on`, the module emits a `Vary: Accept-Encoding` response header itself as soon as a `.zst` sibling makes the URI depend on `Accept-Encoding` — including on the fallback path where the client does not accept zstd and the original file is served. Correct caching by proxies and CDNs therefore does not require [`gzip_vary`](https://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_vary); setting `gzip_vary on` is compatible and never produces a duplicate header. `zstd_static always` ignores `Accept-Encoding` and emits no `Vary`.
+When set to `on`, the module emits a `Vary: Accept-Encoding` response header itself as soon as a `.zst` sibling makes the URI depend on `Accept-Encoding` — including on the fallback path where the client does not accept zstd and the original file is served. Correct caching by proxies and CDNs therefore does not require [`gzip_vary`](https://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_vary); setting `gzip_vary on` is compatible and never produces a duplicate header. With [`zstd_static_dict_bypass`](#zstd_static_dict_bypass) off, `zstd_static always` ignores `Accept-Encoding` and emits no `Vary`; the opt-in bypass is the exception described below.
 
-> **Warning (`always` mode):** When `zstd_static always` is set, `.zst` files are served to every client regardless of whether they advertise `Accept-Encoding: zstd`. No `Vary` header is emitted and no `Content-Encoding` negotiation occurs. Any client that does not support zstd will receive a compressed body it cannot decode. Only use `always` on locations where every client is guaranteed to support zstd — for example, internal service-to-service calls where you control both ends.
+> **Warning (`always` mode):** When `zstd_static always` is set and
+> `zstd_static_dict_bypass` is off, `.zst` files are served to every client
+> regardless of whether they advertise `Accept-Encoding: zstd`. No `Vary`
+> header is emitted and no `Content-Encoding` negotiation occurs. With the
+> bypass on, matching dictionary-aware requests stand aside with the complete
+> cache key instead. Any remaining client that does not support zstd will
+> receive a compressed body it cannot decode. Only use `always` on locations
+> where every non-bypassed client is guaranteed to support zstd — for example,
+> internal service-to-service calls where you control both ends.
 
 > **Magic-number validation.** Before serving a `.zst`, the module reads the first bytes of the file (one `pread(2)` at offset 0) and verifies they are the zstd frame magic (`ZSTD_MAGICNUMBER` `0xFD2FB528`) or a skippable-frame magic (`ZSTD_MAGIC_SKIPPABLE_*`). On mismatch — a truncated download, mistaken rename (`cp foo.txt foo.zst`), or any other non-zstd content — the handler logs `zstd static: "..." is not a zstd frame (leading bytes 0x...)` and **declines**; nginx then falls back to serving the uncompressed original, or returns 404 if no original is present. Without this, the client would receive a body labelled `Content-Encoding: zstd` that it cannot decode. The read is offset-explicit so it never disturbs the file position of the `open_file_cache` descriptor shared with other in-flight requests: `pread(2)` on POSIX, `ngx_read_file()` (a `ReadFile()` with an `OVERLAPPED` offset) on Win32. The verdict logic is a single shared function, so both platforms accept and reject exactly the same files. The probe is compiled out only on a POSIX build whose `configure` found no `pread(2)`, rather than degraded to a `read`+`lseek` pair that would corrupt those concurrent requests.
 >
@@ -1138,6 +1151,29 @@ Pre-compress files with a matching level to your workload:
 ```bash
 zstd -3 -k /var/www/static/app.js   # creates app.js.zst alongside app.js
 ```
+
+### zstd_static_dict_bypass
+
+**Syntax:** `zstd_static_dict_bypass on | off;`
+**Default:** `zstd_static_dict_bypass off;`
+**Context:** `http, server, location`
+
+When enabled, `zstd_static` stands aside for a main request that carries any
+`Available-Dictionary` header and explicitly accepts `dcz` with a non-zero
+weight. This lets [`zstd_dcz_dict_file`](#zstd_dcz_dict_file) negotiate a
+dictionary response instead of having the content-phase static handler serve
+the plain `.zst` sidecar first. The check applies in both `zstd_static on` and
+`zstd_static always` modes. Before declining it emits the complete
+`Vary: Accept-Encoding, Available-Dictionary, Sec-Fetch-Site` cache key; the
+filter reuses those idempotent fields when it runs, while an identity fallback
+remains partitioned correctly when the filter is disabled or ineligible.
+
+The directive is deliberately off by default. It is only a routing hint: the
+static module does not validate the advertised digest, dictionary store match,
+secure context, or origin policy. If any later dcz gate rejects the request,
+the filter produces an ordinary zstd or identity response instead of returning
+to the skipped sidecar. Enable it only on locations whose dictionary-aware
+clients should prefer runtime dcz negotiation over a precompressed sidecar.
 
 ---
 

--- a/ci/t/01-static.t
+++ b/ci/t/01-static.t
@@ -1345,3 +1345,228 @@ Content-Encoding: zstd
 --- error_code: 200
 --- no_error_log
 [error]
+
+
+
+=== TEST 47: dictionary bypass defaults off and the sidecar still wins
+# This is the default-value negative control. A dictionary-carrying client
+# explicitly accepts dcz, but without zstd_static_dict_bypass the static
+# handler keeps its historical first claim on the response.
+--- config
+    location /test {
+        zstd_static on;
+        root ../suite;
+    }
+--- request
+GET /test
+--- more_headers
+Accept-Encoding: zstd, dcz
+Available-Dictionary: :AA==:
+--- response_headers
+Content-Length: 3717
+ETag: "5be17d33-e85"
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 48: dictionary bypass requires Available-Dictionary
+# Explicit dcz alone must not forfeit a usable sidecar.
+--- config
+    location /test {
+        zstd_static on;
+        zstd_static_dict_bypass on;
+        root ../suite;
+    }
+--- request
+GET /test
+--- more_headers
+Accept-Encoding: zstd, dcz
+--- response_headers
+Content-Length: 3717
+ETag: "5be17d33-e85"
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 49: dictionary bypass does not treat wildcard as dcz
+# RFC 9842 requires an explicit dcz token; '*' cannot prove the client can
+# decode a dictionary response.
+--- config
+    location /test {
+        zstd_static on;
+        zstd_static_dict_bypass on;
+        root ../suite;
+    }
+--- request
+GET /test
+--- more_headers
+Accept-Encoding: zstd, *
+Available-Dictionary: :AA==:
+--- response_headers
+Content-Length: 3717
+ETag: "5be17d33-e85"
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 50: dictionary bypass honors dcz q=0 across duplicate fields
+# Repeated Accept-Encoding lines are one list. An explicit refusal on either
+# line wins, so this stays on the sidecar path.
+--- config
+    location /test {
+        zstd_static on;
+        zstd_static_dict_bypass on;
+        root ../suite;
+    }
+--- request
+GET /test
+--- more_headers
+Accept-Encoding: zstd, dcz
+Accept-Encoding: dcz;q=0
+Available-Dictionary: :AA==:
+--- response_headers
+Content-Length: 3717
+ETag: "5be17d33-e85"
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 51: dictionary bypass also applies to zstd_static always
+# The bypass is a preference for the filter path, so it must precede the
+# always-mode shortcut. With no filter configured here, core serves identity;
+# the complete Vary key keeps that fallback separate from the sidecar.
+--- config
+    location /test {
+        zstd_static always;
+        zstd_static_dict_bypass on;
+        root ../suite;
+    }
+--- request
+GET /test
+--- more_headers
+Accept-Encoding: zstd, dcz
+Available-Dictionary: :AA==:
+--- response_headers
+Content-Length: 59738
+ETag: "5be17d33-e95a"
+! Content-Encoding
+Vary: Accept-Encoding, Available-Dictionary, Sec-Fetch-Site
+--- no_error_log
+[error]
+
+
+
+=== TEST 52: dictionary bypass inherits into a location
+--- config
+    zstd_static on;
+    zstd_static_dict_bypass on;
+
+    location /test {
+        root ../suite;
+    }
+--- request
+GET /test
+--- more_headers
+Accept-Encoding: zstd, dcz
+Available-Dictionary: :AA==:
+--- response_headers
+Content-Length: 59738
+ETag: "5be17d33-e95a"
+! Content-Encoding
+Vary: Accept-Encoding, Available-Dictionary, Sec-Fetch-Site
+--- no_error_log
+[error]
+
+
+
+=== TEST 53: location off overrides inherited dictionary bypass
+--- config
+    zstd_static on;
+    zstd_static_dict_bypass on;
+
+    location /test {
+        zstd_static_dict_bypass off;
+        root ../suite;
+    }
+--- request
+GET /test
+--- more_headers
+Accept-Encoding: zstd, dcz
+Available-Dictionary: :AA==:
+--- response_headers
+Content-Length: 3717
+ETag: "5be17d33-e85"
+Content-Encoding: zstd
+--- no_error_log
+[error]
+
+
+
+=== TEST 54: HEAD dictionary bypass keeps the cache partition
+# The response filter deliberately does not encode header-only responses, so
+# the static handler must emit the complete Vary key before declining.
+--- config
+    location /test {
+        zstd_static on;
+        zstd_static_dict_bypass on;
+        root ../suite;
+    }
+--- request
+HEAD /test
+--- more_headers
+Accept-Encoding: zstd, dcz
+Available-Dictionary: :AA==:
+--- response_headers
+Content-Length: 59738
+ETag: "5be17d33-e95a"
+! Content-Encoding
+Vary: Accept-Encoding, Available-Dictionary, Sec-Fetch-Site
+--- no_error_log
+[error]
+
+
+
+=== TEST 55: dictionary bypass preserves a subrequest sidecar
+# auth_request drives /only/test as a real subrequest. The response filter
+# refuses every subrequest, so the static handler must ignore dictionary
+# bypass there. Only the .zst sidecar exists: removing the r == r->main guard
+# makes the subrequest fall through to a 404 and the parent return 500.
+--- config
+    location = /main {
+        auth_request /only/test;
+        root html;
+    }
+
+    location = /only/test {
+        internal;
+        zstd_static always;
+        zstd_static_dict_bypass on;
+        root html;
+    }
+--- user_files eval
+open my $fixture, '<:raw', 'ci/t/suite/test.zst'
+    or die "open zstd fixture: $!";
+local $/;
+my $zst = <$fixture>;
+close $fixture or die "close zstd fixture: $!";
+[
+    [ 'main' => "main response\n" ],
+    [ 'only/test.zst' => $zst ],
+]
+--- request
+GET /main
+--- more_headers
+Accept-Encoding: zstd, dcz
+Available-Dictionary: :AA==:
+--- response_body
+main response
+--- no_error_log
+[error]

--- a/ci/t/03-dcz.t
+++ b/ci/t/03-dcz.t
@@ -1128,3 +1128,57 @@ hashed=1
 invalid dcz dictionary hash
 --- no_error_log
 [alert]
+
+
+
+=== TEST 45: static sidecar keeps priority when dictionary bypass is absent
+# Default-off compatibility control. Both dictionary negotiation inputs are
+# present, but the existing sidecar remains the selected representation.
+--- config
+    location /test {
+        zstd on;
+        zstd_types *;
+        zstd_min_length 1;
+        zstd_static on;
+        zstd_dcz_dict_file $TEST_NGINX_PERL_PATH/suite/dcz-dict;
+        root $TEST_NGINX_PERL_PATH/suite;
+    }
+--- request
+GET /test
+--- more_headers eval
+"Accept-Encoding: zstd, dcz\nAvailable-Dictionary: :$::dict_b64:"
+--- response_headers
+Content-Length: 3717
+ETag: "5be17d33-e85"
+Content-Encoding: zstd
+Vary: Accept-Encoding
+--- no_error_log
+[error]
+
+
+
+=== TEST 46: static dictionary bypass lets the filter negotiate dcz
+# The weak origin ETag and missing sidecar Content-Length distinguish this
+# response from TEST 45's precompressed representation, while the combined
+# Vary proves the static handler declined before emitting its own header.
+--- config
+    location /test {
+        zstd on;
+        zstd_types *;
+        zstd_min_length 1;
+        zstd_static on;
+        zstd_static_dict_bypass on;
+        zstd_dcz_dict_file $TEST_NGINX_PERL_PATH/suite/dcz-dict;
+        root $TEST_NGINX_PERL_PATH/suite;
+    }
+--- request
+GET /test
+--- more_headers eval
+"Accept-Encoding: zstd, dcz\nAvailable-Dictionary: :$::dict_b64:"
+--- response_headers
+! Content-Length
+ETag: W/"5be17d33-e95a"
+Content-Encoding: dcz
+Vary: Accept-Encoding, Available-Dictionary, Sec-Fetch-Site
+--- no_error_log
+[error]

--- a/src/ngx_http_zstd_common.h
+++ b/src/ngx_http_zstd_common.h
@@ -709,6 +709,108 @@ ngx_http_zstd_push_header(ngx_http_request_t *r, const char *key,
 }
 
 
+static ngx_inline ngx_uint_t
+ngx_http_zstd_vary_has_token(ngx_http_request_t *r, const char *token,
+    size_t token_len)
+{
+    ngx_uint_t        i;
+    ngx_list_part_t  *part;
+    ngx_table_elt_t  *h;
+
+    for (part = &r->headers_out.headers.part, h = part->elts, i = 0;
+         /* void */;
+         i++)
+    {
+        if (i >= part->nelts) {
+            if (part->next == NULL) {
+                break;
+            }
+
+            part = part->next;
+            h = part->elts;
+            i = 0;
+        }
+
+        if (h[i].hash == 0
+            || h[i].key.len != sizeof("Vary") - 1
+            || ngx_strncasecmp(h[i].key.data, (u_char *) "Vary",
+                               sizeof("Vary") - 1) != 0)
+        {
+            continue;
+        }
+
+        {
+            u_char  *end, *p, *start;
+
+            p = h[i].value.data;
+            end = p + h[i].value.len;
+
+            while (p < end) {
+                while (p < end && (*p == ' ' || *p == '\t' || *p == ',')) {
+                    p++;
+                }
+
+                start = p;
+                while (p < end && *p != ',') {
+                    p++;
+                }
+
+                while (p > start && (p[-1] == ' ' || p[-1] == '\t')) {
+                    p--;
+                }
+
+                if ((size_t) (p - start) == token_len
+                    && ngx_strncasecmp(start, (u_char *) token,
+                                       token_len) == 0)
+                {
+                    return 1;
+                }
+
+                while (p < end && *p != ',') {
+                    p++;
+                }
+            }
+        }
+    }
+
+    return 0;
+}
+
+
+/*
+ * Add the two request-header dimensions that can select a dcz response.
+ * The static content handler and the response filter can both reach this
+ * helper on one request. Detect tokens across every active Vary field, so
+ * repeated calls and fields flattened or reordered by another filter remain
+ * duplicate-free.
+ */
+static ngx_inline ngx_int_t
+ngx_http_zstd_vary_dcz(ngx_http_request_t *r)
+{
+    ngx_uint_t  has_available_dictionary, has_sec_fetch_site;
+
+    has_available_dictionary = ngx_http_zstd_vary_has_token(
+        r, "Available-Dictionary", sizeof("Available-Dictionary") - 1);
+    has_sec_fetch_site = ngx_http_zstd_vary_has_token(
+        r, "Sec-Fetch-Site", sizeof("Sec-Fetch-Site") - 1);
+
+    if (has_available_dictionary && has_sec_fetch_site) {
+        return NGX_OK;
+    }
+
+    if (has_available_dictionary) {
+        return ngx_http_zstd_push_header(r, "Vary", "Sec-Fetch-Site");
+    }
+
+    if (has_sec_fetch_site) {
+        return ngx_http_zstd_push_header(r, "Vary", "Available-Dictionary");
+    }
+
+    return ngx_http_zstd_push_header(
+        r, "Vary", "Available-Dictionary, Sec-Fetch-Site");
+}
+
+
 /*
  * ngx_http_zstd_vary_accept_encoding()
  *
@@ -749,11 +851,11 @@ ngx_http_zstd_push_header(ngx_http_request_t *r, const char *key,
  * compatible with that module where relying on its default-off
  * directive was not.
  *
- * Callers must invoke this at most once per response, and only on a
- * path that is genuinely Accept-Encoding-dependent. "zstd_static
- * always" deliberately does NOT call it: it ignores Accept-Encoding,
- * so its response is not a negotiated variant and must not claim to
- * vary on one.
+ * Repeated calls are safe because the response-header scan above makes
+ * this helper idempotent. Call it only on a path that is genuinely
+ * Accept-Encoding-dependent. "zstd_static always" normally does not call
+ * it because that mode ignores Accept-Encoding; the explicit dictionary
+ * bypass is the exception, since its routing predicate reads that field.
  *
  * Returns NGX_OK, or NGX_ERROR when the header-list allocation fails.
  *
@@ -764,9 +866,6 @@ ngx_http_zstd_push_header(ngx_http_request_t *r, const char *key,
 static ngx_inline ngx_int_t
 ngx_http_zstd_vary_accept_encoding(ngx_http_request_t *r)
 {
-    ngx_uint_t                 i;
-    ngx_table_elt_t           *h;
-    ngx_list_part_t           *part;
     ngx_http_core_loc_conf_t  *clcf;
 
     r->gzip_vary = 1;
@@ -778,102 +877,10 @@ ngx_http_zstd_vary_accept_encoding(ngx_http_request_t *r)
         return NGX_OK;
     }
 
-    /*
-     * Idempotence, and it is NOT theoretical: the filter and the static
-     * handler are separate modules that both reach this helper on one
-     * request. With "zstd_static on" + "zstd on" + "gzip_vary off", a
-     * non-accepting client makes the static handler emit the field and
-     * DECLINE, after which the filter emits it again on the identity
-     * response it then also declines to encode -- two identical Vary
-     * lines, breaking the exactly-one contract this function exists to
-     * keep. (Observed on PR #163 before this guard: `curl -H
-     * "Accept-Encoding: gzip"` returned two "Vary: Accept-Encoding"
-     * fields.)
-     *
-     * A request-local flag would need a ctx that the static handler
-     * does not own, so scan the response header list instead. It is
-     * short at this point (the modules run before most header-emitting
-     * filters) and this runs at most twice per response. Scanning also
-     * makes the helper safe against a Vary: Accept-Encoding pushed by
-     * any OTHER module, not just our own second call.
-     *
-     * The token compare is case-insensitive on both field name and
-     * value, per RFC 9110: field names are case-insensitive, and the
-     * field values here are header NAMES, which are too.
-     */
-    for (part = &r->headers_out.headers.part, h = part->elts, i = 0;
-         /* void */;
-         i++)
+    if (ngx_http_zstd_vary_has_token(
+            r, "Accept-Encoding", sizeof("Accept-Encoding") - 1))
     {
-        if (i >= part->nelts) {
-            if (part->next == NULL) {
-                break;
-            }
-            part = part->next;
-            h = part->elts;
-            i = 0;
-        }
-
-        if (h[i].hash == 0) {
-            continue;
-        }
-
-        if (h[i].key.len == sizeof("Vary") - 1
-            && ngx_strncasecmp(h[i].key.data, (u_char *) "Vary",
-                               sizeof("Vary") - 1) == 0)
-        {
-            /*
-             * Check if "Accept-Encoding" is among the comma-separated tokens
-             * in the Vary value. Parse as comma-separated tokens, trim
-             * whitespace, and compare case-insensitively.
-             */
-            u_char  *p = h[i].value.data;
-            u_char  *end = h[i].value.data + h[i].value.len;
-
-            while (p < end) {
-                u_char  *token_start, *token_end;
-
-                /* Skip leading whitespace */
-                while (p < end && (*p == ' ' || *p == '\t')) {
-                    p++;
-                }
-
-                if (p >= end) {
-                    break;
-                }
-
-                token_start = p;
-
-                /* Find end of token (comma or end of string) */
-                while (p < end && *p != ',') {
-                    p++;
-                }
-
-                token_end = p;
-
-                /* Trim trailing whitespace from token */
-                while (token_end > token_start
-                       && (*(token_end - 1) == ' '
-                           || *(token_end - 1) == '\t'))
-                {
-                    token_end--;
-                }
-
-                /* Check if this token is "Accept-Encoding" */
-                if (token_end - token_start == sizeof("Accept-Encoding") - 1
-                    && ngx_strncasecmp(token_start,
-                                       (u_char *) "Accept-Encoding",
-                                       sizeof("Accept-Encoding") - 1) == 0)
-                {
-                    return NGX_OK;
-                }
-
-                /* Skip past the comma */
-                if (p < end && *p == ',') {
-                    p++;
-                }
-            }
-        }
+        return NGX_OK;
     }
 
     return ngx_http_zstd_push_header(r, "Vary", "Accept-Encoding");

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -1531,10 +1531,7 @@ ngx_http_zstd_header_filter(ngx_http_request_t *r)
      * Available-Dictionary token must not drop this one.
      */
     if (zlcf->dcz_dicts != NULL && zlcf->dcz_dicts->nelts > 0) {
-        if (ngx_http_zstd_push_header(r, "Vary",
-                                       "Available-Dictionary, Sec-Fetch-Site")
-            != NGX_OK)
-        {
+        if (ngx_http_zstd_vary_dcz(r) != NGX_OK) {
             return NGX_ERROR;
         }
     }

--- a/src/ngx_http_zstd_static_module.c
+++ b/src/ngx_http_zstd_static_module.c
@@ -138,6 +138,7 @@
 
 typedef struct {
     ngx_uint_t  enable;
+    ngx_flag_t  dict_bypass;
 } ngx_http_zstd_static_conf_t;
 
 
@@ -202,11 +203,19 @@ static ngx_command_t  ngx_http_zstd_static_commands[] = {
       offsetof(ngx_http_zstd_static_conf_t, enable),
       &ngx_http_zstd_static },
 
+    { ngx_string("zstd_static_dict_bypass"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_zstd_static_conf_t, dict_bypass),
+      NULL },
+
     ngx_null_command
 };
 
 
 static ngx_int_t ngx_http_zstd_static_handler(ngx_http_request_t *r);
+static ngx_uint_t ngx_http_zstd_static_should_bypass(ngx_http_request_t *r);
 static void * ngx_http_zstd_static_create_main_conf(ngx_conf_t *cf);
 static void * ngx_http_zstd_static_create_loc_conf(ngx_conf_t *cf);
 static char * ngx_http_zstd_static_merge_loc_conf(ngx_conf_t *cf, void *parent,
@@ -770,6 +779,45 @@ ngx_http_zstd_static_dio_buf_release(void)
 #endif /* NGX_HTTP_ZSTD_STATIC_HAVE_PROBE */
 
 
+static ngx_uint_t
+ngx_http_zstd_static_should_bypass(ngx_http_request_t *r)
+{
+    /*
+     * Do not validate Available-Dictionary or consult the configured
+     * dictionary store here: those are filter-owned policy.  This cheap
+     * routing predicate only asks whether the filter should get the request.
+     */
+    ngx_uint_t        i;
+    ngx_list_part_t  *part;
+    ngx_table_elt_t  *headers;
+
+    part = &r->headers_in.headers.part;
+    headers = part->elts;
+
+    for (i = 0; /* void */; i++) {
+        if (i >= part->nelts) {
+            if (part->next == NULL) {
+                return 0;
+            }
+
+            part = part->next;
+            headers = part->elts;
+            i = 0;
+        }
+
+        if (headers[i].key.len == sizeof("Available-Dictionary") - 1
+            && ngx_strncasecmp(headers[i].key.data,
+                               (u_char *) "Available-Dictionary",
+                               sizeof("Available-Dictionary") - 1) == 0)
+        {
+            return ngx_http_zstd_chain_coding_weight(
+                       r->headers_in.accept_encoding, "dcz",
+                       sizeof("dcz") - 1, 0) > 0;
+        }
+    }
+}
+
+
 static ngx_int_t
 ngx_http_zstd_static_handler(ngx_http_request_t *r)
 {
@@ -800,6 +848,30 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
     zscf = ngx_http_get_module_loc_conf(r, ngx_http_zstd_static_module);
 
     if (zscf->enable == NGX_HTTP_ZSTD_STATIC_OFF) {
+        return NGX_DECLINED;
+    }
+
+    /*
+     * The static content handler runs before the response filter can
+     * negotiate RFC 9842 dcz.  With this opt-in, stand aside when the
+     * client both presents a dictionary and explicitly accepts dcz, so
+     * the ordinary content handler and zstd filter get that opportunity.
+     * This deliberately precedes every static Vary/probe side effect,
+     * applies to "always" as well as "on", and stays limited to main
+     * requests because the dcz filter rejects subrequests.
+     */
+    if (zscf->dict_bypass && r == r->main
+        && ngx_http_zstd_static_should_bypass(r))
+    {
+        if (ngx_http_zstd_vary_accept_encoding(r) != NGX_OK
+            || ngx_http_zstd_vary_dcz(r) != NGX_OK)
+        {
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
+
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "zstd static: standing aside for dcz dictionary "
+                       "negotiation");
         return NGX_DECLINED;
     }
 
@@ -1472,10 +1544,9 @@ ngx_http_zstd_static_create_loc_conf(ngx_conf_t *cf)
     ngx_http_zstd_static_conf_t  *conf;
 
     /*
-     * ngx_palloc(), not ngx_pcalloc(): the struct's one field is
-     * unconditionally overwritten two lines below, before anything can
-     * read it, so zero-filling it first is dead work. Do NOT copy this
-     * substitution to a conf struct with more than one field, or one
+     * ngx_palloc(), not ngx_pcalloc(): both fields are unconditionally
+     * overwritten below before anything can read them, so zero-filling
+     * first is dead work. Do NOT copy this substitution to a conf struct
      * whose fields are conditionally written — the main conf
      * (ngx_http_zstd_static_main_conf_t.any_enabled) deliberately
      * depends on zero-init and must stay ngx_pcalloc().
@@ -1486,6 +1557,7 @@ ngx_http_zstd_static_create_loc_conf(ngx_conf_t *cf)
     }
 
     conf->enable = NGX_CONF_UNSET_UINT;
+    conf->dict_bypass = NGX_CONF_UNSET;
 
     return conf;
 }
@@ -1499,6 +1571,7 @@ ngx_http_zstd_static_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_uint_value(conf->enable, prev->enable,
                               NGX_HTTP_ZSTD_STATIC_OFF);
+    ngx_conf_merge_value(conf->dict_bypass, prev->dict_bypass, 0);
 
     /*
      * G5: there is no longer a gzip_vary-off warning here. The content
@@ -1506,9 +1579,10 @@ ngx_http_zstd_static_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
      * variant makes this URI Accept-Encoding-dependent (see
      * ngx_http_zstd_vary_accept_encoding()), so the header no longer
      * depends on the operator setting "gzip_vary on", and warning
-     * about that directive would be misleading. "always" still never
+     * about that directive would be misleading. "always" normally never
      * varies, by construction rather than by warning: it ignores
-     * Accept-Encoding and the handler does not emit the field for it.
+     * Accept-Encoding. zstd_static_dict_bypass is the explicit exception,
+     * because its routing decision consumes that request field.
      */
 
     return NGX_CONF_OK;


### PR DESCRIPTION
## TL;DR

Sites that keep ready-made compressed files currently serve those before the response code can choose a client-specific dictionary. This adds an opt-in switch that gives dictionary-aware requests first chance while keeping cache variants separate.

`zstd_static_dict_bypass on` makes the static handler decline main requests carrying `Available-Dictionary` plus an explicit positive `dcz` weight, after emitting the complete `Vary` key.

**Severity:** `None` (feature; existing defaults remain unchanged)

## Behavior

- The directive defaults to `off`, inherits through `http`, `server`, and `location`, and applies to both `zstd_static on` and `always`.
- Matching main requests stand aside before the sidecar probe. Subrequests keep the static path because the dictionary filter does not encode them.
- The static and filter modules share token-aware, idempotent `Vary` helpers for `Accept-Encoding`, `Available-Dictionary`, and `Sec-Fetch-Site`.
- The static module only routes the request. Dictionary validation, store matching, transport policy, and origin policy remain filter-owned; a later rejection does not revisit the skipped sidecar.

## Testing

- Built nginx 1.31.4 dynamic modules with `-Werror`.
- `ci/t/01-static.t`: 756 assertions passed twice, plus a post-review pass. New cases cover default-off behavior, the dictionary-header gate, explicit weights, duplicate fields, wildcard rejection, `always`, inheritance, a child override, `HEAD`, and subrequests.
- `ci/t/03-dcz.t`: 163 assertions passed twice, plus a post-review pass. New cases distinguish the default sidecar from the enabled dictionary response by encoding, length, ETag, and `Vary`.
- Seven fail-first mutations went red: bypass disabled, default enabled, dictionary-header gate removed, wildcard accepted, zero weight accepted, early `Vary` removed, and the main-request guard removed.
- Project linters passed. The shared review roster found no leaks, SAST, formatting, or copy/paste issues; Vale was not available because the repository has no `.vale.ini`.
- Independent review approved the final diff. The official pre-commit CodeRabbit review completed with zero findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `zstd_static_dict_bypass` setting to enable dictionary-aware compression negotiation for static responses.
  * Supports configuration inheritance and location-level overrides.
  * Preserves complete cache variation headers when deferring static compression.

* **Bug Fixes**
  * Improved handling of wildcard, disabled, and explicitly accepted dictionary compression preferences.
  * Added reliable fallback to regular zstd or identity responses when dictionary compression is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->