### PR TITLE
fix(perf): measure the dcz lookup workload

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -186,7 +186,10 @@ jobs:
       - name: Python unit tests (test harness self-checks)
         run: |
           cd "$GITHUB_WORKSPACE/ci/tools"
-          python3 -m unittest -v test_test_encoding test_test_package_artifact
+          python3 -m unittest -v \
+            test_test_encoding \
+            test_test_package_artifact \
+            test_perf_stat_recipe
 
       # Cheapest test layer over the real pure decision functions -- the
       # Accept-Encoding parser and the .zst frame-header probe: no nginx

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,13 @@
 Changes with http-zstd
 
+    *) Feature: the request benchmark now has an opt-in dcz workload with
+       canonical dictionary negotiation headers, deterministic hit/miss
+       fixtures, and a response-encoding preflight. perf_stat_recipe.py
+       drives the required 1, 4, and 16 configured-dictionary matrix and
+       attaches counters only to nginx workers and compares them per measured
+       successful request, while the
+       existing ab_bench.py default remains the plain-zstd workload.
+
     *) Feature: "zstd_static_dict_bypass on" makes the precompressed
        static handler stand aside when a main request carries
        Available-Dictionary and explicitly accepts dcz, allowing the

--- a/README.md
+++ b/README.md
@@ -1353,6 +1353,16 @@ CLIs linked against the same libzstd/zlib, so ratio is machine-stable;
 throughput scales with CPU). Figures below: **libzstd 1.5.5**, single
 core, `--repeat 3`, best wall-time.
 
+For nginx request-path measurements, `ci/tools/ab_bench.py` keeps its existing
+plain-zstd workload by default and accepts `--workload dcz` for a focused RFC
+9842 dictionary hit or miss. `ci/tools/perf_stat_recipe.py` runs the fixed 1,
+4, and 16 configured-dictionary hit/miss matrix, records the response-encoding
+preflight and every successful measured request in JSON. Hardware counters
+attach only to the pinned nginx worker during measured release runs, excluding
+the Python harness, backend, wrk, startup, fixture creation, and cleanup; the
+comparison reports cache misses, references, instructions, and cycles per
+measured request.
+
 | Payload | Codec | Ratio | MB/s |
 |---|---|---:|---:|
 | HTML, 58 KB (test fixture) | gzip-6 | 15.5 | 29 |

--- a/ci/tools/ab_bench.py
+++ b/ci/tools/ab_bench.py
@@ -637,7 +637,21 @@ def start_nginx(arm: Arm, conf: pathlib.Path, root: pathlib.Path) -> subprocess.
         [str(arm.binary), "-p", str(root), "-c", str(conf)],
         stdout=log,
         stderr=subprocess.STDOUT,
+        start_new_session=True,
     )
+
+
+def stop_nginx(proc: subprocess.Popen) -> None:
+    """Gracefully stop nginx, then kill and reap its private process group."""
+    proc.terminate()
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.wait(timeout=5)
 
 
 def nginx_worker_pids(master_pid: int, expected: int) -> list[int]:
@@ -1026,12 +1040,7 @@ def run_release_pass(
             perf_proc.kill()
             perf_proc.wait(timeout=5)
         for proc, _root, _port in procs.values():
-            proc.terminate()
-            try:
-                proc.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.wait(timeout=5)
+            stop_nginx(proc)
         for backend in backends:
             backend.stop()
         for root in workdirs:
@@ -1191,11 +1200,7 @@ def run_debug_pass(
                 prev_created, prev_reused = total_created, total_reused
                 results[conc] = WitnessSample(created=created, reused=reused)
         finally:
-            proc.terminate()
-            try:
-                proc.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                proc.kill()
+            stop_nginx(proc)
     finally:
         backend.stop()
         shutil.rmtree(root, ignore_errors=True)

--- a/ci/tools/ab_bench.py
+++ b/ci/tools/ab_bench.py
@@ -105,13 +105,21 @@ Usage
         --arm-a .build/nginx-1.31.4/objs/nginx:release \\
         --debug-binary .build/nginx-1.31.4/objs/nginx
 
+    # Focus one RFC 9842 lookup cell: 16 configured dictionaries, miss path
+    python3 ci/tools/ab_bench.py \\
+        --arm-a .build/nginx-1.31.4/objs/nginx \\
+        --workload dcz --dcz-dictionaries 16 --dcz-case miss
+
 Exit non-zero only on harness error, never on a "slow" result.
 """
 
 from __future__ import annotations
 
 import argparse
+import base64
 import dataclasses
+import hashlib
+import http.client
 import json
 import os
 import pathlib
@@ -151,6 +159,9 @@ BODY_SIZES: dict[str, int] = {
     "8kb": 8 * 1024,
     "64kb": 64 * 1024,
 }
+
+DCZ_DICTIONARY_COUNTS = (1, 4, 16)
+DCZ_CASES = ("hit", "miss")
 
 # The debug pass drives ONE body-size class (the smaller one, where the
 # cache win is largest -- see the block above) rather than the full mix,
@@ -257,6 +268,101 @@ class WitnessSample:
         if total == 0:
             return None
         return self.reused / total
+
+
+@dataclasses.dataclass(frozen=True)
+class Workload:
+    """Request/config contract for one benchmark run."""
+
+    mode: str
+    headers: tuple[tuple[str, str], ...]
+    expected_encoding: str
+    config: str = ""
+    dictionary_count: int = 0
+    dcz_case: str | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class PerfAttachment:
+    """perf stat output contract for nginx workers during measured runs."""
+
+    output: pathlib.Path
+    events: str
+
+
+def _available_dictionary(data: bytes) -> str:
+    digest = hashlib.sha256(data).digest()
+    return f":{base64.b64encode(digest).decode('ascii')}:"
+
+
+def _dcz_dictionary(index: int) -> bytes:
+    marker = f"dictionary-{index:02d}".encode()
+    unit = marker + body_bytes(8 * 1024)
+    return unit[: 8 * 1024]
+
+
+def prepare_workload(
+    root: pathlib.Path,
+    mode: str,
+    dictionary_count: int,
+    dcz_case: str,
+) -> Workload:
+    """Create deterministic dcz fixtures and the matching request contract."""
+    if mode == "zstd":
+        return Workload(
+            mode="zstd",
+            headers=(("Accept-Encoding", "zstd"),),
+            expected_encoding="zstd",
+        )
+    if mode != "dcz":
+        raise ValueError(f"unsupported workload: {mode!r}")
+    if dictionary_count not in DCZ_DICTIONARY_COUNTS:
+        raise ValueError(
+            f"dcz dictionary count must be one of {DCZ_DICTIONARY_COUNTS}, "
+            f"got {dictionary_count}"
+        )
+    if dcz_case not in DCZ_CASES:
+        raise ValueError(f"dcz case must be one of {DCZ_CASES}, got {dcz_case!r}")
+
+    dictionary_dir = root / "dictionaries"
+    dictionary_dir.mkdir()
+    configured: list[str] = []
+    directives: list[str] = [
+        "    zstd_dcz_assume_secure_transport on;",
+    ]
+    for index in range(dictionary_count):
+        data = _dcz_dictionary(index)
+        path = dictionary_dir / f"dict-{index:02d}.bin"
+        path.write_bytes(data)
+        configured.append(_available_dictionary(data))
+        digest_hex = hashlib.sha256(data).hexdigest()
+        directives.append(f"    zstd_dcz_dict_file {path} {digest_hex};")
+
+    if dcz_case == "hit":
+        # The lookup walks configuration order, so the last entry exercises
+        # the full configured table just like a miss does.
+        advertised = configured[-1]
+        expected_encoding = "dcz"
+    else:
+        advertised = _available_dictionary(b"unconfigured dcz benchmark dictionary")
+        if advertised in configured:
+            raise RuntimeError(
+                "dcz miss fixture unexpectedly matches a configured hash"
+            )
+        expected_encoding = "zstd"
+
+    return Workload(
+        mode="dcz",
+        headers=(
+            ("Accept-Encoding", "zstd, dcz"),
+            ("Available-Dictionary", advertised),
+            ("Sec-Fetch-Site", "same-origin"),
+        ),
+        expected_encoding=expected_encoding,
+        config="\n".join(directives),
+        dictionary_count=dictionary_count,
+        dcz_case=dcz_case,
+    )
 
 
 def parse_arm(spec: str) -> tuple[str, str]:
@@ -471,6 +577,7 @@ def write_conf(
     workers: int,
     log_level: str,
     comp_level: int,
+    workload: Workload,
 ) -> pathlib.Path:
     load = ""
     filt = arm.filter_module or detect_module(
@@ -503,6 +610,7 @@ http {{
     zstd_comp_level {comp_level};
     zstd_min_length 1;
     zstd_types application/octet-stream;
+{workload.config}
     server {{
         listen 127.0.0.1:{port};
         default_type application/octet-stream;
@@ -530,6 +638,74 @@ def start_nginx(arm: Arm, conf: pathlib.Path, root: pathlib.Path) -> subprocess.
         stdout=log,
         stderr=subprocess.STDOUT,
     )
+
+
+def nginx_worker_pids(master_pid: int, expected: int) -> list[int]:
+    """Wait for and return the exact worker child set of an nginx master."""
+    children_path = pathlib.Path(f"/proc/{master_pid}/task/{master_pid}/children")
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        try:
+            children = [int(pid) for pid in children_path.read_text().split()]
+        except (FileNotFoundError, ProcessLookupError):
+            children = []
+        if len(children) == expected:
+            return children
+        time.sleep(0.05)
+    raise RuntimeError(
+        f"expected {expected} nginx worker pid(s), found {len(children)}"
+    )
+
+
+def start_worker_perf(
+    master_pid: int, workers: int, attachment: PerfAttachment
+) -> subprocess.Popen:
+    """Attach perf only to nginx workers, excluding harness/backend work."""
+    if workers != 1:
+        raise RuntimeError("worker perf attachment requires --workers 1")
+    pids = nginx_worker_pids(master_pid, workers)
+    proc = subprocess.Popen(
+        [
+            "/usr/bin/perf",
+            "stat",
+            "-p",
+            ",".join(str(pid) for pid in pids),
+            "-e",
+            attachment.events,
+            "-o",
+            str(attachment.output),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    time.sleep(0.1)
+    if proc.poll() is not None:
+        stderr = proc.stderr.read() if proc.stderr else ""
+        raise RuntimeError(f"perf stat failed to attach to nginx workers: {stderr}")
+    return proc
+
+
+def stop_worker_perf(proc: subprocess.Popen) -> None:
+    """Stop an attached perf process and require a usable exit."""
+    if proc.poll() is not None:
+        stderr = proc.stderr.read() if proc.stderr else ""
+        raise RuntimeError(
+            f"perf stat exited before the measured pass completed: {stderr}"
+        )
+    try:
+        proc.send_signal(signal.SIGINT)
+    except ProcessLookupError as exc:
+        raise RuntimeError("perf stat exited before it could be stopped") from exc
+    try:
+        returncode = proc.wait(timeout=10)
+    except subprocess.TimeoutExpired as exc:
+        proc.kill()
+        proc.wait(timeout=5)
+        raise RuntimeError("perf stat did not stop after the measured pass") from exc
+    if returncode not in (0, 128 + signal.SIGINT, -signal.SIGINT):
+        stderr = proc.stderr.read() if proc.stderr else ""
+        raise RuntimeError(f"perf stat failed with exit code {returncode}: {stderr}")
 
 
 def rss_monitor_start(master_pid: int, stop_path: pathlib.Path) -> subprocess.Popen:
@@ -621,8 +797,31 @@ def parse_wrk_duration_s(duration: str) -> float:
     return value * {"s": 1, "m": 60, "h": 3600}[unit]
 
 
+def verify_workload(port: int, workload: Workload) -> str:
+    """Fail before measurement unless the configured request path engages."""
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
+    try:
+        conn.request("GET", "/8kb", headers=dict(workload.headers))
+        response = conn.getresponse()
+        response.read()
+    finally:
+        conn.close()
+    encoding = response.getheader("Content-Encoding", "")
+    if response.status != 200 or encoding != workload.expected_encoding:
+        raise RuntimeError(
+            f"{workload.mode} workload preflight failed: status={response.status}, "
+            f"Content-Encoding={encoding!r}, expected "
+            f"{workload.expected_encoding!r}"
+        )
+    return encoding
+
+
 def run_wrk(
-    url: str, connections: int, duration: str, threads: int
+    url: str,
+    connections: int,
+    duration: str,
+    threads: int,
+    headers: tuple[tuple[str, str], ...],
 ) -> tuple[float, float, float, int, int]:
     wrk_bin = shutil.which("wrk")
     assert wrk_bin
@@ -634,20 +833,21 @@ def run_wrk(
     # documented harness-error path. The margin covers wrk's own
     # connect/warmup/report overhead on top of the measured window.
     timeout_s = parse_wrk_duration_s(duration) + 30
+    command = [
+        wrk_bin,
+        "-t",
+        str(threads),
+        "-c",
+        str(connections),
+        "-d",
+        duration,
+        "--latency",
+    ]
+    for name, value in headers:
+        command.extend(("-H", f"{name}: {value}"))
+    command.append(url)
     proc = subprocess.run(
-        [
-            wrk_bin,
-            "-t",
-            str(threads),
-            "-c",
-            str(connections),
-            "-d",
-            duration,
-            "--latency",
-            "-H",
-            "Accept-Encoding: zstd",
-            url,
-        ],
+        command,
         capture_output=True,
         text=True,
         check=False,
@@ -674,6 +874,7 @@ def bench_one(
     body: str,
     conc: int,
     duration: str,
+    workload: Workload,
 ) -> BenchSample:
     # The config sets `daemon off; master_process on;`, so the Popen
     # object's own pid already IS the master -- no need to re-derive it
@@ -686,7 +887,9 @@ def bench_one(
 
     url = f"http://127.0.0.1:{port}/{body}"
     threads = min(conc, os.cpu_count() or 4)
-    rps, p50, p99, requests, errors = run_wrk(url, conc, duration, threads)
+    rps, p50, p99, requests, errors = run_wrk(
+        url, conc, duration, threads, workload.headers
+    )
 
     peak_rss = 0
     monitor.send_signal(signal.SIGTERM)
@@ -718,8 +921,12 @@ def run_release_pass(
     workers: int,
     base_port: int,
     comp_level: int,
-) -> dict:
-    """Interleaved A/B rounds. Returns {arm_label: {conc: {body: [samples]}}}."""
+    workload_mode: str,
+    dictionary_count: int,
+    dcz_case: str,
+    perf_attachment: PerfAttachment | None = None,
+) -> tuple[dict, dict[str, str], int]:
+    """Run interleaved rounds and return samples, engagement, and setup count."""
     samples: dict[str, dict[int, dict[str, list[BenchSample]]]] = {
         arm.label: {c: {b: [] for b in BODY_SIZES} for c in concurrencies}
         for arm in arms
@@ -727,8 +934,12 @@ def run_release_pass(
 
     bodies = {name: body_bytes(size) for name, size in BODY_SIZES.items()}
     procs: dict[str, tuple[subprocess.Popen, pathlib.Path, int]] = {}
+    workloads: dict[str, Workload] = {}
+    engagement: dict[str, str] = {}
+    setup_successful_requests = 0
     backends: list[PacedBackend] = []
     workdirs: list[pathlib.Path] = []
+    perf_proc: subprocess.Popen | None = None
     try:
         for i, arm in enumerate(arms):
             root = pathlib.Path(tempfile.mkdtemp(prefix=f"ab-bench-{arm.label}-"))
@@ -745,12 +956,23 @@ def run_release_pass(
             backend = PacedBackend(backend_port, bodies, pace=False)
             backend.start()
             backends.append(backend)
+            workload = prepare_workload(root, workload_mode, dictionary_count, dcz_case)
+            workloads[arm.label] = workload
             conf = write_conf(
-                root, port, backend_port, arm, workers, "warn", comp_level
+                root,
+                port,
+                backend_port,
+                arm,
+                workers,
+                "warn",
+                comp_level,
+                workload,
             )
             proc = start_nginx(arm, conf, root)
             require_own_nginx_ready(proc, port, root, f"arm {arm.label!r}")
             procs[arm.label] = (proc, root, port)
+            engagement[arm.label] = verify_workload(port, workload)
+            setup_successful_requests += 1
 
         # Warmup: one short untimed-ish run per arm/body so the cache is
         # warm before the FIRST measured round -- otherwise round 1 is
@@ -759,7 +981,21 @@ def run_release_pass(
         for arm in arms:
             _proc, root, port = procs[arm.label]
             for body in BODY_SIZES:
-                run_wrk(f"http://127.0.0.1:{port}/{body}", 8, WARMUP_DURATION, 4)
+                _rps, _p50, _p99, requests, errors = run_wrk(
+                    f"http://127.0.0.1:{port}/{body}",
+                    8,
+                    WARMUP_DURATION,
+                    4,
+                    workloads[arm.label].headers,
+                )
+                setup_successful_requests += max(requests - errors, 0)
+
+        if perf_attachment is not None:
+            if len(arms) != 1:
+                raise RuntimeError("worker perf attachment requires exactly one arm")
+            perf_proc = start_worker_perf(
+                procs[arms[0].label][0].pid, workers, perf_attachment
+            )
 
         for _rnd in range(rounds):
             for conc in concurrencies:
@@ -772,10 +1008,23 @@ def run_release_pass(
                     for arm in arms:
                         proc, root, port = procs[arm.label]
                         sample = bench_one(
-                            arm, proc.pid, root, port, body, conc, duration
+                            arm,
+                            proc.pid,
+                            root,
+                            port,
+                            body,
+                            conc,
+                            duration,
+                            workloads[arm.label],
                         )
                         samples[arm.label][conc][body].append(sample)
+        if perf_proc is not None:
+            stop_worker_perf(perf_proc)
+            perf_proc = None
     finally:
+        if perf_proc is not None:
+            perf_proc.kill()
+            perf_proc.wait(timeout=5)
         for proc, _root, _port in procs.values():
             proc.terminate()
             try:
@@ -787,7 +1036,7 @@ def run_release_pass(
         for root in workdirs:
             shutil.rmtree(root, ignore_errors=True)
 
-    return samples
+    return samples, engagement, setup_successful_requests
 
 
 def evaluate_contention_self_check(
@@ -860,6 +1109,9 @@ def run_debug_pass(
     workers: int,
     base_port: int,
     comp_level: int,
+    workload_mode: str,
+    dictionary_count: int,
+    dcz_case: str,
 ) -> dict[int, WitnessSample]:
     """Separate pass, debug-level logging, only for engagement witnesses.
     Its own throughput is NOT reported -- see module docstring.
@@ -899,10 +1151,21 @@ def run_debug_pass(
     try:
         backend.start()
         port = base_port
-        conf = write_conf(root, port, backend_port, arm, workers, "debug", comp_level)
+        workload = prepare_workload(root, workload_mode, dictionary_count, dcz_case)
+        conf = write_conf(
+            root,
+            port,
+            backend_port,
+            arm,
+            workers,
+            "debug",
+            comp_level,
+            workload,
+        )
         proc = start_nginx(arm, conf, root)
         try:
             require_own_nginx_ready(proc, port, root, "debug pass")
+            verify_workload(port, workload)
             elog_path = root / "error.log"
             prev_created = 0
             prev_reused = 0
@@ -914,6 +1177,7 @@ def run_debug_pass(
                     conc,
                     duration,
                     min(conc, 4),
+                    workload.headers,
                 )
                 time.sleep(0.3)  # let the debug log flush
                 elog = elog_path.read_text("utf-8", "replace")
@@ -1209,8 +1473,35 @@ def main() -> int:
         "default so an A/B between two different binaries never mixes a "
         "level change into the change actually under measurement.",
     )
+    ap.add_argument(
+        "--workload",
+        choices=("zstd", "dcz"),
+        default="zstd",
+        help="request workload (default zstd preserves the existing harness)",
+    )
+    ap.add_argument(
+        "--dcz-dictionaries",
+        type=int,
+        choices=DCZ_DICTIONARY_COUNTS,
+        default=1,
+        help="configured dictionary count for --workload dcz",
+    )
+    ap.add_argument(
+        "--dcz-case",
+        choices=DCZ_CASES,
+        default="hit",
+        help="advertise the last configured dictionary or an absent one",
+    )
     ap.add_argument("--base-port", type=int, default=18400)
     ap.add_argument("--json", help="write machine-readable results here")
+    ap.add_argument(
+        "--perf-stat-output",
+        help="attach perf only to nginx workers during measured release runs",
+    )
+    ap.add_argument(
+        "--perf-events",
+        help="comma-separated perf events (required with --perf-stat-output)",
+    )
     args = ap.parse_args()
 
     if args.self_test:
@@ -1218,6 +1509,15 @@ def main() -> int:
 
     if not args.arm_a:
         print("error: --arm-a is required unless --self-test is given", file=sys.stderr)
+        return 2
+    if bool(args.perf_stat_output) != bool(args.perf_events):
+        print(
+            "error: --perf-stat-output and --perf-events must be used together",
+            file=sys.stderr,
+        )
+        return 2
+    if args.perf_stat_output and args.workers != 1:
+        print("error: worker perf attachment requires --workers 1", file=sys.stderr)
         return 2
 
     # Everything the scratch roots below create must stay readable by the
@@ -1254,12 +1554,21 @@ def main() -> int:
         print("error: arm labels must be distinct", file=sys.stderr)
         return 2
 
+    workload_label = args.workload
+    if args.workload == "dcz":
+        workload_label += f"/{args.dcz_dictionaries}/{args.dcz_case}"
     print(
         f"=== RELEASE PASS: rps/p50/p99/RSS, {args.rounds} interleaved "
-        f"round(s), NO cache witnesses in this section ==="
+        f"round(s), workload={workload_label}, "
+        "NO cache witnesses in this section ==="
     )
     try:
-        samples = run_release_pass(
+        perf_attachment = None
+        if args.perf_stat_output:
+            perf_attachment = PerfAttachment(
+                pathlib.Path(args.perf_stat_output).resolve(), args.perf_events
+            )
+        samples, engagement, setup_successful_requests = run_release_pass(
             arms,
             concurrencies,
             args.rounds,
@@ -1267,8 +1576,12 @@ def main() -> int:
             args.workers,
             args.base_port,
             args.comp_level,
+            args.workload,
+            args.dcz_dictionaries,
+            args.dcz_case,
+            perf_attachment,
         )
-    except RuntimeError as exc:
+    except (RuntimeError, ValueError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
@@ -1289,6 +1602,7 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
+    completed_successful_requests = total_successful + setup_successful_requests
 
     print_release_table(arms, concurrencies, samples)
 
@@ -1312,6 +1626,9 @@ def main() -> int:
                 args.workers,
                 args.base_port + len(arms) * 2 + 2,
                 args.comp_level,
+                args.workload,
+                args.dcz_dictionaries,
+                args.dcz_case,
             )
         except RuntimeError as exc:
             print(f"error: {exc}", file=sys.stderr)
@@ -1332,6 +1649,17 @@ def main() -> int:
                 "duration": args.duration,
                 "workers": args.workers,
                 "arms": [a.label for a in arms],
+                "workload": args.workload,
+                "dcz_dictionaries": args.dcz_dictionaries
+                if args.workload == "dcz"
+                else None,
+                "dcz_case": args.dcz_case if args.workload == "dcz" else None,
+                "engagement": engagement,
+                "successful_requests": total_successful,
+                "completed_successful_requests": completed_successful_requests,
+                "perf_scope": "nginx-workers-measured-release"
+                if perf_attachment is not None
+                else None,
                 "commit": subprocess.run(
                     ["git", "-C", str(REPO), "rev-parse", "--short", "HEAD"],
                     capture_output=True,

--- a/ci/tools/ab_bench.py
+++ b/ci/tools/ab_bench.py
@@ -969,8 +969,8 @@ def run_release_pass(
                 workload,
             )
             proc = start_nginx(arm, conf, root)
-            require_own_nginx_ready(proc, port, root, f"arm {arm.label!r}")
             procs[arm.label] = (proc, root, port)
+            require_own_nginx_ready(proc, port, root, f"arm {arm.label!r}")
             engagement[arm.label] = verify_workload(port, workload)
             setup_successful_requests += 1
 
@@ -1031,6 +1031,7 @@ def run_release_pass(
                 proc.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 proc.kill()
+                proc.wait(timeout=5)
         for backend in backends:
             backend.stop()
         for root in workdirs:

--- a/ci/tools/perf_stat_recipe.py
+++ b/ci/tools/perf_stat_recipe.py
@@ -73,6 +73,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import time
 
 TOOLS_DIR = pathlib.Path(__file__).resolve().parent
 DCZ_DICTIONARY_COUNTS = (1, 4, 16)
@@ -423,34 +424,58 @@ def kill_process_group(process: subprocess.Popen) -> None:
         os.killpg(process.pid, signal.SIGKILL)
     except ProcessLookupError:
         pass
-    process.communicate()
+    process.wait(timeout=10)
+
+
+def wait_process_without_reaping(process: subprocess.Popen, timeout: float) -> bool:
+    """Wait for exit while retaining the leader PID for group cleanup."""
+    deadline = time.monotonic() + timeout
+    while True:
+        status = os.waitid(
+            os.P_PID,
+            process.pid,
+            os.WEXITED | os.WNOHANG | os.WNOWAIT,
+        )
+        if status is not None:
+            return status.si_code == os.CLD_EXITED and status.si_status == 0
+        if time.monotonic() >= deadline:
+            raise subprocess.TimeoutExpired(process.args, timeout)
+        time.sleep(0.05)
 
 
 def run_pinned_bench(command: list[str], cpu_mask: str) -> None:
     """Run a benchmark pinned to one core set; perf attaches inside it."""
     full_command = ["taskset", "-c", cpu_mask.replace(" ", ","), *command]
-    process = subprocess.Popen(
-        full_command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        start_new_session=True,
-    )
-    try:
-        stdout, stderr = process.communicate(timeout=600)
-    except subprocess.TimeoutExpired as exc:
-        kill_process_group(process)
-        raise RuntimeError(
-            "benchmark timed out after 600s; process group killed"
-        ) from exc
-    except BaseException:
-        kill_process_group(process)
-        raise
-    if process.returncode != 0:
-        raise RuntimeError(
-            f"benchmark failed with exit code {process.returncode}.\n"
-            f"stderr: {stderr}\nstdout: {stdout}"
+    with (
+        tempfile.TemporaryFile(mode="w+", encoding="utf-8") as stdout_file,
+        tempfile.TemporaryFile(mode="w+", encoding="utf-8") as stderr_file,
+    ):
+        process = subprocess.Popen(
+            full_command,
+            stdout=stdout_file,
+            stderr=stderr_file,
+            text=True,
+            start_new_session=True,
         )
+        try:
+            succeeded = wait_process_without_reaping(process, 600)
+        except subprocess.TimeoutExpired as exc:
+            kill_process_group(process)
+            raise RuntimeError(
+                "benchmark timed out after 600s; process group killed"
+            ) from exc
+        except BaseException:
+            kill_process_group(process)
+            raise
+        if not succeeded:
+            kill_process_group(process)
+            stdout_file.seek(0)
+            stderr_file.seek(0)
+            raise RuntimeError(
+                f"benchmark failed with exit code {process.returncode}.\n"
+                f"stderr: {stderr_file.read()}\nstdout: {stdout_file.read()}"
+            )
+        process.wait(timeout=10)
 
 
 def measure_baseline(

--- a/ci/tools/perf_stat_recipe.py
+++ b/ci/tools/perf_stat_recipe.py
@@ -525,6 +525,7 @@ def measure_dcz_matrix(
 
     pcore_ids, ecore_ids, _ = detect_hybrid_cores()
     cpu_mask = pcore_ids if core_type == "P" else ecore_ids
+    identity = cpu_identity()
     scenarios: dict[str, dict] = {}
 
     with tempfile.TemporaryDirectory(prefix="zstd-perf-stat-") as temp_dir:
@@ -580,7 +581,7 @@ def measure_dcz_matrix(
         "workload": "dcz",
         "core_type": core_type,
         "cpu_mask": cpu_mask,
-        "cpu_identity": cpu_identity(),
+        "cpu_identity": identity,
         "normalization": "measured_successful_requests",
         "scenarios": scenarios,
     }

--- a/ci/tools/perf_stat_recipe.py
+++ b/ci/tools/perf_stat_recipe.py
@@ -23,8 +23,11 @@ struct-of-arrays lookup into two arrays (a 40-byte index + pointer indirection)
 to reduce cache misses on negotiation. This recipe establishes:
 
 1. A baseline of cache-misses, cache-references, instructions, and cycles for
-   the current (unmodified) code running ab_bench.py release pass
-2. An A/B delta when the optimization is applied
+   the current code across 1, 4, and 16 configured dictionaries, with a hit
+   and full-scan miss at each size
+2. An A/B delta normalized by successful measured requests. perf attaches only
+   to the pinned nginx worker after preflight and warmup, so harness, backend,
+   wrk, startup, fixture, and cleanup work cannot contaminate the counters
 
 The repack row is retained ONLY if the counter delta supports the "third-cacheline"
 claim (fewer cache misses). Struct size reduction alone (pahole) does not retain
@@ -40,6 +43,10 @@ USAGE
 
     # Compare
     python3 ci/tools/perf_stat_recipe.py --compare baseline.json optimized.json
+
+    # Preserve the original plain-zstd single measurement when needed
+    python3 ci/tools/perf_stat_recipe.py --nginx /path/to/nginx \
+        --workload zstd --json zstd.json
 
 Environment: requires
   - perf (installed at /usr/bin/perf)
@@ -59,12 +66,32 @@ from __future__ import annotations
 import argparse
 import dataclasses
 import json
+import os
 import pathlib
 import re
+import signal
 import subprocess
 import sys
+import tempfile
 
 TOOLS_DIR = pathlib.Path(__file__).resolve().parent
+DCZ_DICTIONARY_COUNTS = (1, 4, 16)
+DCZ_CASES = ("hit", "miss")
+
+
+def cpu_identity() -> str:
+    """Return stable CPU/PMU identity fields for cross-run compatibility."""
+    wanted = ("vendor_id", "cpu family", "model", "stepping", "model name")
+    fields: dict[str, str] = {}
+    for line in pathlib.Path("/proc/cpuinfo").read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            break
+        key, separator, value = line.partition(":")
+        if separator and key.strip() in wanted:
+            fields[key.strip()] = value.strip()
+    if not all(field in fields for field in wanted):
+        raise RuntimeError("could not determine CPU identity from /proc/cpuinfo")
+    return "; ".join(f"{field}={fields[field]}" for field in wanted)
 
 
 @dataclasses.dataclass
@@ -108,6 +135,80 @@ class PerfCounters:
             instructions=d["instructions"],
             cycles=d["cycles"],
         )
+
+
+def normalize_counters(
+    counters: PerfCounters, successful_requests: int
+) -> dict[str, float]:
+    """Return raw hardware counts per successful measured request."""
+    if successful_requests <= 0:
+        raise RuntimeError("cannot normalize perf counters without successful requests")
+    return {
+        "cache_misses": counters.cache_misses / successful_requests,
+        "cache_references": counters.cache_references / successful_requests,
+        "instructions": counters.instructions / successful_requests,
+        "cycles": counters.cycles / successful_requests,
+    }
+
+
+def successful_requests_from_bench(result: dict) -> int:
+    """Read successful requests from the measured release-pass window."""
+    meta = result.get("meta", {})
+    meta_total = meta.get("successful_requests")
+    if isinstance(meta_total, int):
+        return meta_total
+
+    total = 0
+    for arm in result.get("release", {}).values():
+        for concurrency in arm.values():
+            for samples in concurrency.values():
+                for sample in samples:
+                    total += max(sample["requests"] - sample["errors"], 0)
+    return total
+
+
+def dcz_scenarios() -> tuple[tuple[int, str], ...]:
+    """Fixed lookup-depth matrix used by the repack measurement."""
+    return tuple(
+        (dictionary_count, case)
+        for dictionary_count in DCZ_DICTIONARY_COUNTS
+        for case in DCZ_CASES
+    )
+
+
+def build_dcz_bench_command(
+    nginx_path: pathlib.Path,
+    dictionary_count: int,
+    case: str,
+    result_path: pathlib.Path,
+    perf_path: pathlib.Path,
+    perf_events: str,
+) -> list[str]:
+    """Build one deterministic dcz hit/miss ab_bench invocation."""
+    return [
+        "python3",
+        str(TOOLS_DIR / "ab_bench.py"),
+        "--arm-a",
+        f"{nginx_path}:baseline",
+        "--rounds",
+        "1",
+        "--workers",
+        "1",
+        "--duration",
+        "5s",
+        "--workload",
+        "dcz",
+        "--dcz-dictionaries",
+        str(dictionary_count),
+        "--dcz-case",
+        case,
+        "--json",
+        str(result_path),
+        "--perf-stat-output",
+        str(perf_path),
+        "--perf-events",
+        perf_events,
+    ]
 
 
 def detect_hybrid_cores() -> tuple[str, str, int]:
@@ -307,6 +408,51 @@ def run_perf_stat(
     return PerfCounters(**counters_dict)
 
 
+def qualified_perf_events(core_type: str) -> str:
+    """Return the four PMU-qualified events for one hybrid core type."""
+    pmu = "cpu_core" if core_type == "P" else "cpu_atom"
+    return ",".join(
+        f"{pmu}/{event}/"
+        for event in ("cache-misses", "cache-references", "instructions", "cycles")
+    )
+
+
+def kill_process_group(process: subprocess.Popen) -> None:
+    """Kill and reap a detached benchmark process group."""
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    process.communicate()
+
+
+def run_pinned_bench(command: list[str], cpu_mask: str) -> None:
+    """Run a benchmark pinned to one core set; perf attaches inside it."""
+    full_command = ["taskset", "-c", cpu_mask.replace(" ", ","), *command]
+    process = subprocess.Popen(
+        full_command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=600)
+    except subprocess.TimeoutExpired as exc:
+        kill_process_group(process)
+        raise RuntimeError(
+            "benchmark timed out after 600s; process group killed"
+        ) from exc
+    except BaseException:
+        kill_process_group(process)
+        raise
+    if process.returncode != 0:
+        raise RuntimeError(
+            f"benchmark failed with exit code {process.returncode}.\n"
+            f"stderr: {stderr}\nstdout: {stdout}"
+        )
+
+
 def measure_baseline(
     nginx_path: str | pathlib.Path,
     output_json: str | None = None,
@@ -367,6 +513,85 @@ def measure_baseline(
     return counters
 
 
+def measure_dcz_matrix(
+    nginx_path: str | pathlib.Path,
+    output_json: str | None = None,
+    core_type: str = "P",
+) -> dict[str, dict]:
+    """Measure the fixed 1/4/16-dictionary hit/miss matrix."""
+    nginx_path_obj = pathlib.Path(nginx_path).resolve()
+    if not nginx_path_obj.exists():
+        raise RuntimeError(f"nginx binary not found: {nginx_path_obj}")
+
+    pcore_ids, ecore_ids, _ = detect_hybrid_cores()
+    cpu_mask = pcore_ids if core_type == "P" else ecore_ids
+    scenarios: dict[str, dict] = {}
+
+    with tempfile.TemporaryDirectory(prefix="zstd-perf-stat-") as temp_dir:
+        temp_root = pathlib.Path(temp_dir)
+        for dictionary_count, case in dcz_scenarios():
+            name = f"dicts-{dictionary_count}-{case}"
+            bench_json = temp_root / f"{name}.json"
+            perf_output = temp_root / f"{name}.perf"
+            command = build_dcz_bench_command(
+                nginx_path_obj,
+                dictionary_count,
+                case,
+                bench_json,
+                perf_output,
+                qualified_perf_events(core_type),
+            )
+            run_pinned_bench(command, cpu_mask)
+            try:
+                bench_result = json.loads(bench_json.read_text(encoding="utf-8"))
+            except (FileNotFoundError, json.JSONDecodeError) as exc:
+                raise RuntimeError(
+                    f"ab_bench produced no usable JSON for {name}: {exc}"
+                ) from exc
+            try:
+                counters = PerfCounters(
+                    **parse_perf_output(
+                        perf_output.read_text(encoding="utf-8"), core_type
+                    )
+                )
+            except FileNotFoundError as exc:
+                raise RuntimeError(f"perf produced no output for {name}") from exc
+            if bench_result.get("meta", {}).get("perf_scope") != (
+                "nginx-workers-measured-release"
+            ):
+                raise RuntimeError(
+                    f"ab_bench did not prove worker-only perf for {name}"
+                )
+
+            successful_requests = successful_requests_from_bench(bench_result)
+            per_request = normalize_counters(counters, successful_requests)
+            scenarios[name] = {
+                "dictionary_count": dictionary_count,
+                "case": case,
+                "command": command,
+                "measured_successful_requests": successful_requests,
+                "engagement": bench_result.get("meta", {}).get("engagement"),
+                "counters": counters.to_dict(),
+                "per_successful_request": per_request,
+            }
+
+    result = {
+        "schema_version": 2,
+        "workload": "dcz",
+        "core_type": core_type,
+        "cpu_mask": cpu_mask,
+        "cpu_identity": cpu_identity(),
+        "normalization": "measured_successful_requests",
+        "scenarios": scenarios,
+    }
+    if output_json:
+        pathlib.Path(output_json).write_text(
+            json.dumps(result, indent=2), encoding="utf-8"
+        )
+        print(f"Saved to {output_json}")
+    return scenarios
+
+
 def print_counters(
     label: str,
     counters: PerfCounters,
@@ -405,6 +630,108 @@ class CounterDelta:
         )
 
 
+def _percent_delta(baseline: float, optimized: float) -> float:
+    if baseline == 0:
+        raise RuntimeError("cannot compare against a zero normalized counter")
+    return (optimized - baseline) / baseline
+
+
+def compare_dcz_results(baseline_result: dict, optimized_result: dict) -> None:
+    """Compare dcz matrix cells using counters per successful request."""
+    identity_fields = (
+        "schema_version",
+        "workload",
+        "core_type",
+        "cpu_mask",
+        "cpu_identity",
+        "normalization",
+    )
+    expected_identity = {
+        "schema_version": 2,
+        "workload": "dcz",
+        "normalization": "measured_successful_requests",
+    }
+    for field, value in expected_identity.items():
+        if baseline_result.get(field) != value or optimized_result.get(field) != value:
+            raise RuntimeError(f"dcz comparison requires {field}={value!r}")
+    for field in identity_fields:
+        if baseline_result.get(field) != optimized_result.get(field):
+            raise RuntimeError(f"dcz comparison requires matching {field}")
+    for result in (baseline_result, optimized_result):
+        if result.get("core_type") not in ("P", "E"):
+            raise RuntimeError("dcz comparison requires core_type P or E")
+        if not isinstance(result.get("cpu_mask"), str) or not result["cpu_mask"]:
+            raise RuntimeError("dcz comparison requires a non-empty cpu_mask")
+        if (
+            not isinstance(result.get("cpu_identity"), str)
+            or not result["cpu_identity"]
+        ):
+            raise RuntimeError("dcz comparison requires a non-empty cpu_identity")
+
+    baseline_cells = baseline_result.get("scenarios", {})
+    optimized_cells = optimized_result.get("scenarios", {})
+    expected = {f"dicts-{count}-{case}" for count, case in dcz_scenarios()}
+    if set(baseline_cells) != expected or set(optimized_cells) != expected:
+        raise RuntimeError(
+            "dcz comparison requires matching 1/4/16 dictionary hit/miss matrices"
+        )
+
+    for dictionary_count, case in dcz_scenarios():
+        name = f"dicts-{dictionary_count}-{case}"
+        for cell in (baseline_cells[name], optimized_cells[name]):
+            if (
+                cell.get("dictionary_count") != dictionary_count
+                or cell.get("case") != case
+            ):
+                raise RuntimeError(f"dcz scenario metadata does not match {name}")
+            expected_encoding = "dcz" if case == "hit" else "zstd"
+            engagement = cell.get("engagement")
+            if not isinstance(engagement, dict) or set(engagement.values()) != {
+                expected_encoding
+            }:
+                raise RuntimeError(
+                    f"dcz scenario {name} requires {expected_encoding} engagement"
+                )
+
+    print("\nDCZ COUNTERS PER SUCCESSFUL REQUEST")
+    header = (
+        f"{'scenario':<16}{'base req':>11}{'opt req':>11}"
+        f"{'miss delta':>13}{'ref delta':>12}{'insn delta':>13}"
+        f"{'cycle delta':>14}"
+    )
+    print(header)
+    print("-" * len(header))
+    for dictionary_count, case in dcz_scenarios():
+        name = f"dicts-{dictionary_count}-{case}"
+        baseline = baseline_cells[name]
+        optimized = optimized_cells[name]
+        baseline_norm = normalize_counters(
+            PerfCounters.from_dict(baseline["counters"]),
+            baseline["measured_successful_requests"],
+        )
+        optimized_norm = normalize_counters(
+            PerfCounters.from_dict(optimized["counters"]),
+            optimized["measured_successful_requests"],
+        )
+        miss_delta = _percent_delta(
+            baseline_norm["cache_misses"], optimized_norm["cache_misses"]
+        )
+        reference_delta = _percent_delta(
+            baseline_norm["cache_references"],
+            optimized_norm["cache_references"],
+        )
+        instruction_delta = _percent_delta(
+            baseline_norm["instructions"], optimized_norm["instructions"]
+        )
+        cycle_delta = _percent_delta(baseline_norm["cycles"], optimized_norm["cycles"])
+        print(
+            f"{name:<16}{baseline['measured_successful_requests']:>11}"
+            f"{optimized['measured_successful_requests']:>11}{miss_delta:>+12.1%}"
+            f"{reference_delta:>+12.1%}{instruction_delta:>+13.1%}"
+            f"{cycle_delta:>+14.1%}"
+        )
+
+
 def compare_results(baseline_json: str, optimized_json: str) -> None:
     """Compare two measurement runs.
 
@@ -419,6 +746,10 @@ def compare_results(baseline_json: str, optimized_json: str) -> None:
         baseline_result = json.load(f)
     with open(optimized_json, encoding="utf-8") as f:
         optimized_result = json.load(f)
+
+    if "scenarios" in baseline_result or "scenarios" in optimized_result:
+        compare_dcz_results(baseline_result, optimized_result)
+        return
 
     baseline = PerfCounters.from_dict(baseline_result["counters"])
     optimized = PerfCounters.from_dict(optimized_result["counters"])
@@ -463,6 +794,17 @@ def compare_results(baseline_json: str, optimized_json: str) -> None:
     print("=" * 70 + "\n")
 
 
+def normalize_cli_argv(argv: list[str]) -> list[str]:
+    """Map documented flag-first spellings onto the argparse subcommands."""
+    if argv[:1] in (["-h"], ["--help"]):
+        return argv
+    if argv and argv[0] == "--compare":
+        return ["compare", *argv[1:]]
+    if argv and argv[0].startswith("-"):
+        return ["measure", *argv]
+    return argv
+
+
 def main() -> int:
     """Entry point."""
     parser = argparse.ArgumentParser(
@@ -492,6 +834,12 @@ def main() -> int:
         default="P",
         help="Pin to P-cores (default) or E-cores",
     )
+    measure_parser.add_argument(
+        "--workload",
+        choices=("dcz", "zstd"),
+        default="dcz",
+        help="measure the dcz lookup matrix (default) or legacy zstd workload",
+    )
 
     # "compare" subcommand
     compare_parser = subparsers.add_parser(
@@ -507,18 +855,26 @@ def main() -> int:
         help="Optimized measurement JSON file",
     )
 
-    args = parser.parse_args()
+    argv = normalize_cli_argv(sys.argv[1:])
+    args = parser.parse_args(argv)
 
-    if args.command in ("measure", "baseline", None):
+    if args.command in ("measure", "baseline"):
         if not args.nginx:
             parser.print_help()
             return 1
         try:
-            measure_baseline(
-                args.nginx,
-                output_json=args.json,
-                core_type=args.core_type,
-            )
+            if args.workload == "dcz":
+                measure_dcz_matrix(
+                    args.nginx,
+                    output_json=args.json,
+                    core_type=args.core_type,
+                )
+            else:
+                measure_baseline(
+                    args.nginx,
+                    output_json=args.json,
+                    core_type=args.core_type,
+                )
             return 0
         except (RuntimeError, FileNotFoundError, subprocess.TimeoutExpired) as e:
             print(f"ERROR: {e}", file=sys.stderr)
@@ -527,7 +883,7 @@ def main() -> int:
         try:
             compare_results(args.baseline, args.optimized)
             return 0
-        except (FileNotFoundError, json.JSONDecodeError) as e:
+        except (FileNotFoundError, json.JSONDecodeError, KeyError, RuntimeError) as e:
             print(f"ERROR: {e}", file=sys.stderr)
             return 1
     else:

--- a/ci/tools/test_perf_stat_recipe.py
+++ b/ci/tools/test_perf_stat_recipe.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+import importlib.util
+import io
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+from typing import Any
+from unittest import mock
+
+TOOLS_DIR = pathlib.Path(__file__).resolve().parent
+
+
+def load_tool(name: str) -> Any:
+    path = TOOLS_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load test module {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ab_bench = load_tool("ab_bench")
+perf_recipe = load_tool("perf_stat_recipe")
+
+
+class DczWorkloadTests(unittest.TestCase):
+    def test_hit_configures_requested_dictionaries_and_canonical_headers(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            workload = ab_bench.prepare_workload(root, "dcz", 4, "hit")
+
+            self.assertEqual(workload.config.count("zstd_dcz_dict_file "), 4)
+            self.assertIn("zstd_dcz_assume_secure_transport on;", workload.config)
+            self.assertNotIn("zstd_dcz_dict_trust_hashes", workload.config)
+            self.assertEqual(dict(workload.headers)["Accept-Encoding"], "zstd, dcz")
+            self.assertEqual(dict(workload.headers)["Sec-Fetch-Site"], "same-origin")
+            self.assertRegex(
+                dict(workload.headers)["Available-Dictionary"],
+                r"^:[A-Za-z0-9+/]{43}=:$",
+            )
+            self.assertEqual(workload.expected_encoding, "dcz")
+            self.assertEqual(len(list((root / "dictionaries").iterdir())), 4)
+
+    def test_miss_advertises_no_configured_dictionary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            workload = ab_bench.prepare_workload(root, "dcz", 16, "miss")
+            advertised = dict(workload.headers)["Available-Dictionary"]
+            configured = {
+                ab_bench._available_dictionary(path.read_bytes())
+                for path in (root / "dictionaries").iterdir()
+            }
+
+            self.assertNotIn(advertised, configured)
+            self.assertEqual(workload.expected_encoding, "zstd")
+            self.assertEqual(len(configured), 16)
+
+    def test_default_zstd_workload_stays_dictionary_free(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workload = ab_bench.prepare_workload(
+                pathlib.Path(temp_dir), "zstd", 1, "hit"
+            )
+
+            self.assertEqual(workload.headers, (("Accept-Encoding", "zstd"),))
+            self.assertEqual(workload.config, "")
+            self.assertEqual(workload.expected_encoding, "zstd")
+
+    def test_rejects_unsupported_dictionary_count(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            self.assertRaisesRegex(ValueError, "must be one of"),
+        ):
+            ab_bench.prepare_workload(pathlib.Path(temp_dir), "dcz", 2, "hit")
+
+    def test_preflight_requires_the_expected_content_encoding(self) -> None:
+        response = mock.Mock(status=200)
+        response.getheader.return_value = "zstd"
+        connection = mock.Mock()
+        connection.getresponse.return_value = response
+        workload = ab_bench.Workload(
+            mode="dcz",
+            headers=(("Accept-Encoding", "zstd, dcz"),),
+            expected_encoding="dcz",
+        )
+
+        with (
+            mock.patch.object(
+                ab_bench.http.client, "HTTPConnection", return_value=connection
+            ),
+            self.assertRaisesRegex(RuntimeError, "Content-Encoding='zstd'"),
+        ):
+            ab_bench.verify_workload(18400, workload)
+
+        connection.request.assert_called_once_with(
+            "GET", "/8kb", headers={"Accept-Encoding": "zstd, dcz"}
+        )
+        response.read.assert_called_once_with()
+
+    def test_perf_attaches_only_to_resolved_nginx_workers(self) -> None:
+        process = mock.Mock()
+        process.poll.return_value = None
+        attachment = ab_bench.PerfAttachment(
+            pathlib.Path("/result.perf"), "cpu_core/cache-misses/"
+        )
+
+        with (
+            mock.patch.object(ab_bench, "nginx_worker_pids", return_value=[1234]),
+            mock.patch.object(
+                ab_bench.subprocess, "Popen", return_value=process
+            ) as popen,
+            mock.patch.object(ab_bench.time, "sleep"),
+        ):
+            self.assertIs(ab_bench.start_worker_perf(99, 1, attachment), process)
+
+        command = popen.call_args.args[0]
+        self.assertEqual(command[command.index("-p") + 1], "1234")
+        self.assertNotIn("99", command)
+
+    def test_perf_attachment_rejects_multiple_workers(self) -> None:
+        attachment = ab_bench.PerfAttachment(
+            pathlib.Path("/result.perf"), "cpu_core/cache-misses/"
+        )
+        with (
+            mock.patch.object(ab_bench.subprocess, "Popen") as popen,
+            self.assertRaisesRegex(RuntimeError, "requires --workers 1"),
+        ):
+            ab_bench.start_worker_perf(99, 2, attachment)
+
+        popen.assert_not_called()
+
+    def test_perf_stop_accepts_the_expected_sigint_exit(self) -> None:
+        for returncode in (-ab_bench.signal.SIGINT, 128 + ab_bench.signal.SIGINT):
+            with self.subTest(returncode=returncode):
+                process = mock.Mock()
+                process.poll.return_value = None
+                process.wait.return_value = returncode
+
+                ab_bench.stop_worker_perf(process)
+
+                process.send_signal.assert_called_once_with(ab_bench.signal.SIGINT)
+
+    def test_perf_stop_rejects_an_early_clean_exit(self) -> None:
+        process = mock.Mock()
+        process.poll.return_value = 0
+
+        with self.assertRaisesRegex(RuntimeError, "exited before"):
+            ab_bench.stop_worker_perf(process)
+
+        process.send_signal.assert_not_called()
+
+
+class PerfRecipeTests(unittest.TestCase):
+    @staticmethod
+    def _matrix_result(
+        counters: Any,
+        successful_requests: int,
+        *,
+        core_type: str = "P",
+        cpu_mask: str = "0-7",
+        cpu_identity: str = "vendor/model/stepping",
+    ) -> dict:
+        scenarios = {}
+        for dictionary_count, case in perf_recipe.dcz_scenarios():
+            scenarios[f"dicts-{dictionary_count}-{case}"] = {
+                "dictionary_count": dictionary_count,
+                "case": case,
+                "measured_successful_requests": successful_requests,
+                "counters": counters.to_dict(),
+                "engagement": {"baseline": "dcz" if case == "hit" else "zstd"},
+            }
+        return {
+            "schema_version": 2,
+            "workload": "dcz",
+            "core_type": core_type,
+            "cpu_mask": cpu_mask,
+            "cpu_identity": cpu_identity,
+            "normalization": "measured_successful_requests",
+            "scenarios": scenarios,
+        }
+
+    def test_documented_flag_first_cli_spellings_remain_supported(self) -> None:
+        self.assertEqual(
+            perf_recipe.normalize_cli_argv(["--nginx", "/nginx"]),
+            ["measure", "--nginx", "/nginx"],
+        )
+        self.assertEqual(
+            perf_recipe.normalize_cli_argv(["--compare", "base.json", "opt.json"]),
+            ["compare", "base.json", "opt.json"],
+        )
+        self.assertEqual(perf_recipe.normalize_cli_argv(["--help"]), ["--help"])
+
+    def test_matrix_contains_required_hit_and_miss_cells(self) -> None:
+        self.assertEqual(
+            perf_recipe.dcz_scenarios(),
+            (
+                (1, "hit"),
+                (1, "miss"),
+                (4, "hit"),
+                (4, "miss"),
+                (16, "hit"),
+                (16, "miss"),
+            ),
+        )
+
+    def test_matrix_measure_orchestrates_every_worker_only_scenario(self) -> None:
+        perf_text = "\n".join(
+            f"100 cpu_core/{event}/"
+            for event in (
+                "cache-misses",
+                "cache-references",
+                "instructions",
+                "cycles",
+            )
+        )
+
+        def fake_run(command: list[str], cpu_mask: str) -> None:
+            self.assertEqual(cpu_mask, "0 1")
+            count = command[command.index("--dcz-dictionaries") + 1]
+            case = command[command.index("--dcz-case") + 1]
+            json_path = pathlib.Path(command[command.index("--json") + 1])
+            perf_path = pathlib.Path(command[command.index("--perf-stat-output") + 1])
+            json_path.write_text(
+                json.dumps(
+                    {
+                        "meta": {
+                            "successful_requests": 10,
+                            "perf_scope": "nginx-workers-measured-release",
+                            "engagement": {
+                                "baseline": "dcz" if case == "hit" else "zstd"
+                            },
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            perf_path.write_text(perf_text, encoding="utf-8")
+            self.assertIn(count, {"1", "4", "16"})
+
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            mock.patch.object(
+                perf_recipe, "detect_hybrid_cores", return_value=("0 1", "2 3", 0)
+            ),
+            mock.patch.object(perf_recipe, "cpu_identity", return_value="test-cpu"),
+            mock.patch.object(
+                perf_recipe, "run_pinned_bench", side_effect=fake_run
+            ) as run,
+        ):
+            result_path = pathlib.Path(temp_dir) / "matrix.json"
+            scenarios = perf_recipe.measure_dcz_matrix(
+                pathlib.Path(sys.executable), str(result_path), "P"
+            )
+            saved = json.loads(result_path.read_text())
+
+        self.assertEqual(run.call_count, 6)
+        self.assertEqual(
+            set(scenarios),
+            {f"dicts-{n}-{c}" for n, c in perf_recipe.dcz_scenarios()},
+        )
+        self.assertEqual(saved["normalization"], "measured_successful_requests")
+
+    def test_pinned_bench_timeout_kills_the_process_group(self) -> None:
+        process = mock.Mock(pid=4321)
+        process.communicate.side_effect = [
+            perf_recipe.subprocess.TimeoutExpired(["taskset"], 600),
+            ("", ""),
+        ]
+        with (
+            mock.patch.object(perf_recipe.subprocess, "Popen", return_value=process),
+            mock.patch.object(perf_recipe.os, "killpg") as killpg,
+            self.assertRaisesRegex(RuntimeError, "process group killed"),
+        ):
+            perf_recipe.run_pinned_bench(["bench"], "0 1")
+
+        killpg.assert_called_once_with(4321, perf_recipe.signal.SIGKILL)
+        self.assertEqual(process.communicate.call_count, 2)
+
+    def test_pinned_bench_interrupt_kills_the_process_group(self) -> None:
+        process = mock.Mock(pid=4321)
+        process.communicate.side_effect = [KeyboardInterrupt, ("", "")]
+        with (
+            mock.patch.object(perf_recipe.subprocess, "Popen", return_value=process),
+            mock.patch.object(perf_recipe.os, "killpg") as killpg,
+            self.assertRaises(KeyboardInterrupt),
+        ):
+            perf_recipe.run_pinned_bench(["bench"], "0 1")
+
+        killpg.assert_called_once_with(4321, perf_recipe.signal.SIGKILL)
+        self.assertEqual(process.communicate.call_count, 2)
+
+    def test_dcz_command_selects_workload_and_evidence_json(self) -> None:
+        command = perf_recipe.build_dcz_bench_command(
+            pathlib.Path("/nginx"),
+            16,
+            "miss",
+            pathlib.Path("/result.json"),
+            pathlib.Path("/result.perf"),
+            "cpu_core/cache-misses/",
+        )
+
+        self.assertEqual(
+            command,
+            [
+                "python3",
+                str(perf_recipe.TOOLS_DIR / "ab_bench.py"),
+                "--arm-a",
+                "/nginx:baseline",
+                "--rounds",
+                "1",
+                "--workers",
+                "1",
+                "--duration",
+                "5s",
+                "--workload",
+                "dcz",
+                "--dcz-dictionaries",
+                "16",
+                "--dcz-case",
+                "miss",
+                "--json",
+                "/result.json",
+                "--perf-stat-output",
+                "/result.perf",
+                "--perf-events",
+                "cpu_core/cache-misses/",
+            ],
+        )
+
+    def test_successful_request_denominator_excludes_errors(self) -> None:
+        result = {
+            "release": {
+                "baseline": {
+                    "8": {
+                        "8kb": [
+                            {"requests": 120, "errors": 20},
+                            {"requests": 80, "errors": 0},
+                        ]
+                    }
+                }
+            }
+        }
+
+        self.assertEqual(perf_recipe.successful_requests_from_bench(result), 180)
+
+    def test_measured_request_denominator_excludes_setup_traffic(self) -> None:
+        result = {
+            "meta": {
+                "successful_requests": 100,
+                "completed_successful_requests": 141,
+            }
+        }
+
+        self.assertEqual(perf_recipe.successful_requests_from_bench(result), 100)
+
+    def test_normalization_reverses_misleading_raw_counter_delta(self) -> None:
+        baseline = perf_recipe.PerfCounters(1000, 2000, 3000, 4000)
+        optimized = perf_recipe.PerfCounters(1500, 3000, 4500, 6000)
+
+        self.assertGreater(optimized.cache_misses, baseline.cache_misses)
+        baseline_norm = perf_recipe.normalize_counters(baseline, 100)
+        optimized_norm = perf_recipe.normalize_counters(optimized, 300)
+        self.assertLess(optimized_norm["cache_misses"], baseline_norm["cache_misses"])
+
+    def test_matrix_compare_uses_normalized_counts_and_prints_all_deltas(self) -> None:
+        baseline = self._matrix_result(
+            perf_recipe.PerfCounters(1000, 2000, 3000, 4000), 100
+        )
+        optimized = self._matrix_result(
+            perf_recipe.PerfCounters(1500, 3000, 4500, 6000), 300
+        )
+
+        output = io.StringIO()
+        with mock.patch("sys.stdout", output):
+            perf_recipe.compare_dcz_results(baseline, optimized)
+
+        rendered = output.getvalue()
+        self.assertIn("dicts-16-miss", rendered)
+        self.assertIn("miss delta", rendered)
+        self.assertIn("ref delta", rendered)
+        self.assertIn("insn delta", rendered)
+        self.assertIn("cycle delta", rendered)
+        self.assertEqual(rendered.count("-50.0%"), 24)
+
+    def test_matrix_compare_rejects_incompatible_measurements(self) -> None:
+        baseline = self._matrix_result(perf_recipe.PerfCounters(1, 2, 3, 4), 1)
+        optimized = self._matrix_result(
+            perf_recipe.PerfCounters(1, 2, 3, 4),
+            1,
+            core_type="E",
+            cpu_mask="8-15",
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "matching core_type"):
+            perf_recipe.compare_dcz_results(baseline, optimized)
+
+        optimized = self._matrix_result(
+            perf_recipe.PerfCounters(1, 2, 3, 4),
+            1,
+            cpu_identity="different-cpu",
+        )
+        with self.assertRaisesRegex(RuntimeError, "matching cpu_identity"):
+            perf_recipe.compare_dcz_results(baseline, optimized)
+
+    def test_matrix_compare_rejects_missing_identity_and_wrong_engagement(self) -> None:
+        baseline = self._matrix_result(perf_recipe.PerfCounters(1, 2, 3, 4), 1)
+        optimized = self._matrix_result(perf_recipe.PerfCounters(1, 2, 3, 4), 1)
+        del baseline["core_type"]
+        del optimized["core_type"]
+        with self.assertRaisesRegex(RuntimeError, "core_type P or E"):
+            perf_recipe.compare_dcz_results(baseline, optimized)
+
+        baseline = self._matrix_result(perf_recipe.PerfCounters(1, 2, 3, 4), 1)
+        optimized = self._matrix_result(perf_recipe.PerfCounters(1, 2, 3, 4), 1)
+        optimized["scenarios"]["dicts-16-hit"]["engagement"] = {"baseline": "zstd"}
+        with self.assertRaisesRegex(RuntimeError, "requires dcz engagement"):
+            perf_recipe.compare_dcz_results(baseline, optimized)
+
+    def test_normalization_rejects_zero_successful_requests(self) -> None:
+        counters = perf_recipe.PerfCounters(1, 2, 3, 4)
+        with self.assertRaisesRegex(RuntimeError, "without successful requests"):
+            perf_recipe.normalize_counters(counters, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/tools/test_perf_stat_recipe.py
+++ b/ci/tools/test_perf_stat_recipe.py
@@ -32,7 +32,7 @@ class DczWorkloadTests(unittest.TestCase):
         arm = ab_bench.Arm("baseline", pathlib.Path("/nginx"))
         with (
             tempfile.TemporaryDirectory() as temp_dir,
-            mock.patch.object(ab_bench, "open", mock.mock_open()),
+            mock.patch("builtins.open", mock.mock_open()),
             mock.patch.object(ab_bench.subprocess, "Popen") as popen,
         ):
             ab_bench.start_nginx(

--- a/ci/tools/test_perf_stat_recipe.py
+++ b/ci/tools/test_perf_stat_recipe.py
@@ -100,6 +100,46 @@ class DczWorkloadTests(unittest.TestCase):
         )
         response.read.assert_called_once_with()
 
+    def test_readiness_failure_reaps_the_spawned_nginx_process(self) -> None:
+        process = mock.Mock()
+        process.wait.side_effect = [
+            ab_bench.subprocess.TimeoutExpired(["nginx"], 10),
+            0,
+        ]
+        backend = mock.Mock()
+        workload = ab_bench.Workload(
+            mode="zstd",
+            headers=(("Accept-Encoding", "zstd"),),
+            expected_encoding="zstd",
+        )
+        arm = ab_bench.Arm("baseline", pathlib.Path("/nginx"))
+
+        with (
+            mock.patch.object(ab_bench, "PacedBackend", return_value=backend),
+            mock.patch.object(ab_bench, "prepare_workload", return_value=workload),
+            mock.patch.object(
+                ab_bench, "write_conf", return_value=pathlib.Path("/nginx.conf")
+            ),
+            mock.patch.object(ab_bench, "start_nginx", return_value=process),
+            mock.patch.object(
+                ab_bench,
+                "require_own_nginx_ready",
+                side_effect=RuntimeError("readiness failed"),
+            ),
+            self.assertRaisesRegex(RuntimeError, "readiness failed"),
+        ):
+            ab_bench.run_release_pass(
+                [arm], [1], 1, "1s", 1, 18400, 6, "zstd", 1, "hit"
+            )
+
+        process.terminate.assert_called_once_with()
+        self.assertEqual(
+            process.wait.call_args_list,
+            [mock.call(timeout=10), mock.call(timeout=5)],
+        )
+        process.kill.assert_called_once_with()
+        backend.stop.assert_called_once_with()
+
     def test_perf_attaches_only_to_resolved_nginx_workers(self) -> None:
         process = mock.Mock()
         process.poll.return_value = None
@@ -282,32 +322,84 @@ class PerfRecipeTests(unittest.TestCase):
 
     def test_pinned_bench_timeout_kills_the_process_group(self) -> None:
         process = mock.Mock(pid=4321)
-        process.communicate.side_effect = [
-            perf_recipe.subprocess.TimeoutExpired(["taskset"], 600),
-            ("", ""),
-        ]
         with (
             mock.patch.object(perf_recipe.subprocess, "Popen", return_value=process),
-            mock.patch.object(perf_recipe.os, "killpg") as killpg,
+            mock.patch.object(
+                perf_recipe,
+                "wait_process_without_reaping",
+                side_effect=perf_recipe.subprocess.TimeoutExpired(["taskset"], 600),
+            ),
+            mock.patch.object(perf_recipe, "kill_process_group") as kill_group,
             self.assertRaisesRegex(RuntimeError, "process group killed"),
         ):
             perf_recipe.run_pinned_bench(["bench"], "0 1")
 
-        killpg.assert_called_once_with(4321, perf_recipe.signal.SIGKILL)
-        self.assertEqual(process.communicate.call_count, 2)
+        kill_group.assert_called_once_with(process)
 
     def test_pinned_bench_interrupt_kills_the_process_group(self) -> None:
         process = mock.Mock(pid=4321)
-        process.communicate.side_effect = [KeyboardInterrupt, ("", "")]
         with (
             mock.patch.object(perf_recipe.subprocess, "Popen", return_value=process),
-            mock.patch.object(perf_recipe.os, "killpg") as killpg,
+            mock.patch.object(
+                perf_recipe,
+                "wait_process_without_reaping",
+                side_effect=KeyboardInterrupt,
+            ),
+            mock.patch.object(perf_recipe, "kill_process_group") as kill_group,
             self.assertRaises(KeyboardInterrupt),
         ):
             perf_recipe.run_pinned_bench(["bench"], "0 1")
 
-        killpg.assert_called_once_with(4321, perf_recipe.signal.SIGKILL)
-        self.assertEqual(process.communicate.call_count, 2)
+        kill_group.assert_called_once_with(process)
+
+    def test_pinned_bench_nonzero_exit_kills_the_process_group(self) -> None:
+        process = mock.Mock(returncode=1)
+        with (
+            mock.patch.object(perf_recipe.subprocess, "Popen", return_value=process),
+            mock.patch.object(
+                perf_recipe, "wait_process_without_reaping", return_value=False
+            ),
+            mock.patch.object(perf_recipe, "kill_process_group") as kill_group,
+            self.assertRaisesRegex(RuntimeError, "exit code 1"),
+        ):
+            perf_recipe.run_pinned_bench(["bench"], "0 1")
+
+        kill_group.assert_called_once_with(process)
+
+    def test_failed_status_is_observed_without_reaping_the_group_leader(self) -> None:
+        process = mock.Mock(pid=4321, args=["bench"])
+        status = mock.Mock(si_code=perf_recipe.os.CLD_EXITED, si_status=1)
+        with mock.patch.object(perf_recipe.os, "waitid", return_value=status) as waitid:
+            self.assertFalse(perf_recipe.wait_process_without_reaping(process, 1))
+
+        waitid.assert_called_once_with(
+            perf_recipe.os.P_PID,
+            4321,
+            perf_recipe.os.WEXITED | perf_recipe.os.WNOHANG | perf_recipe.os.WNOWAIT,
+        )
+        process.wait.assert_not_called()
+
+    def test_clean_status_is_observed_without_reaping_the_group_leader(self) -> None:
+        process = mock.Mock(pid=4321, args=["bench"])
+        status = mock.Mock(si_code=perf_recipe.os.CLD_EXITED, si_status=0)
+        with mock.patch.object(perf_recipe.os, "waitid", return_value=status):
+            self.assertTrue(perf_recipe.wait_process_without_reaping(process, 1))
+
+        process.wait.assert_not_called()
+
+    def test_pinned_bench_success_reaps_without_group_kill(self) -> None:
+        process = mock.Mock(pid=4321)
+        with (
+            mock.patch.object(perf_recipe.subprocess, "Popen", return_value=process),
+            mock.patch.object(
+                perf_recipe, "wait_process_without_reaping", return_value=True
+            ),
+            mock.patch.object(perf_recipe, "kill_process_group") as kill_group,
+        ):
+            perf_recipe.run_pinned_bench(["bench"], "0 1")
+
+        process.wait.assert_called_once_with(timeout=10)
+        kill_group.assert_not_called()
 
     def test_dcz_command_selects_workload_and_evidence_json(self) -> None:
         command = perf_recipe.build_dcz_bench_command(
@@ -428,6 +520,13 @@ class PerfRecipeTests(unittest.TestCase):
         del baseline["core_type"]
         del optimized["core_type"]
         with self.assertRaisesRegex(RuntimeError, "core_type P or E"):
+            perf_recipe.compare_dcz_results(baseline, optimized)
+
+        baseline = self._matrix_result(perf_recipe.PerfCounters(1, 2, 3, 4), 1)
+        optimized = self._matrix_result(perf_recipe.PerfCounters(1, 2, 3, 4), 1)
+        del baseline["cpu_identity"]
+        del optimized["cpu_identity"]
+        with self.assertRaisesRegex(RuntimeError, "non-empty cpu_identity"):
             perf_recipe.compare_dcz_results(baseline, optimized)
 
         baseline = self._matrix_result(perf_recipe.PerfCounters(1, 2, 3, 4), 1)

--- a/ci/tools/test_perf_stat_recipe.py
+++ b/ci/tools/test_perf_stat_recipe.py
@@ -263,6 +263,23 @@ class PerfRecipeTests(unittest.TestCase):
         )
         self.assertEqual(saved["normalization"], "measured_successful_requests")
 
+    def test_matrix_identity_failure_prevents_scenario_execution(self) -> None:
+        with (
+            mock.patch.object(
+                perf_recipe, "detect_hybrid_cores", return_value=("0 1", "2 3", 0)
+            ),
+            mock.patch.object(
+                perf_recipe,
+                "cpu_identity",
+                side_effect=RuntimeError("missing CPU identity"),
+            ),
+            mock.patch.object(perf_recipe, "run_pinned_bench") as run,
+            self.assertRaisesRegex(RuntimeError, "missing CPU identity"),
+        ):
+            perf_recipe.measure_dcz_matrix(pathlib.Path(sys.executable))
+
+        run.assert_not_called()
+
     def test_pinned_bench_timeout_kills_the_process_group(self) -> None:
         process = mock.Mock(pid=4321)
         process.communicate.side_effect = [

--- a/ci/tools/test_perf_stat_recipe.py
+++ b/ci/tools/test_perf_stat_recipe.py
@@ -28,6 +28,19 @@ perf_recipe = load_tool("perf_stat_recipe")
 
 
 class DczWorkloadTests(unittest.TestCase):
+    def test_nginx_starts_in_its_own_process_group(self) -> None:
+        arm = ab_bench.Arm("baseline", pathlib.Path("/nginx"))
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            mock.patch.object(ab_bench, "open", mock.mock_open()),
+            mock.patch.object(ab_bench.subprocess, "Popen") as popen,
+        ):
+            ab_bench.start_nginx(
+                arm, pathlib.Path("nginx.conf"), pathlib.Path(temp_dir)
+            )
+
+        self.assertTrue(popen.call_args.kwargs["start_new_session"])
+
     def test_hit_configures_requested_dictionaries_and_canonical_headers(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = pathlib.Path(temp_dir)
@@ -102,6 +115,7 @@ class DczWorkloadTests(unittest.TestCase):
 
     def test_readiness_failure_reaps_the_spawned_nginx_process(self) -> None:
         process = mock.Mock()
+        process.pid = 4321
         process.wait.side_effect = [
             ab_bench.subprocess.TimeoutExpired(["nginx"], 10),
             0,
@@ -126,6 +140,7 @@ class DczWorkloadTests(unittest.TestCase):
                 "require_own_nginx_ready",
                 side_effect=RuntimeError("readiness failed"),
             ),
+            mock.patch.object(ab_bench.os, "killpg") as kill_group,
             self.assertRaisesRegex(RuntimeError, "readiness failed"),
         ):
             ab_bench.run_release_pass(
@@ -137,8 +152,19 @@ class DczWorkloadTests(unittest.TestCase):
             process.wait.call_args_list,
             [mock.call(timeout=10), mock.call(timeout=5)],
         )
-        process.kill.assert_called_once_with()
+        kill_group.assert_called_once_with(4321, ab_bench.signal.SIGKILL)
         backend.stop.assert_called_once_with()
+
+    def test_nginx_group_cleanup_reaps_when_group_is_already_gone(self) -> None:
+        process = mock.Mock(pid=4321)
+        process.wait.side_effect = [
+            ab_bench.subprocess.TimeoutExpired(["nginx"], 10),
+            0,
+        ]
+        with mock.patch.object(ab_bench.os, "killpg", side_effect=ProcessLookupError):
+            ab_bench.stop_nginx(process)
+
+        self.assertEqual(process.wait.call_args_list[-1], mock.call(timeout=5))
 
     def test_perf_attaches_only_to_resolved_nginx_workers(self) -> None:
         process = mock.Mock()


### PR DESCRIPTION
> Found while validating the data-layout repack benchmark TODO.

## TL;DR

The existing performance recipe recorded plenty of activity, but none of its requests exercised compression-dictionary selection and its counters also included setup and load-generator work. Those numbers could not tell us whether a lookup optimization helped the server itself.

`ab_bench.py` now provides a verified dcz workload, while `perf_stat_recipe.py` runs the fixed 1/4/16-dictionary hit/miss matrix and counts only measured nginx-worker activity.

**Severity:** `Medium` (`benchmark integrity — unrelated work could decide whether a lookup optimization is retained`)

## Behaviour

- `ab_bench.py` keeps its existing plain-zstd default. The opt-in dcz mode builds deterministic dictionaries, sends canonical negotiation headers, makes hits scan to the final configured entry, and requires the expected `Content-Encoding` before measurement.
- The recipe pins the benchmark tree but attaches `perf stat` only to one nginx worker after preflight and warmup. Early perf exit, multiple workers, timeout, and interruption fail with descendant cleanup instead of publishing partial counters.
- Schema v2 evidence records measured successful requests, response engagement, core type, CPU mask, and CPU identity. Comparison rejects mismatched hardware, malformed cells, and hit/miss results that did not negotiate `dcz`/`zstd` respectively.

## Testing

- `python3 -m unittest -v test_test_encoding test_test_package_artifact test_perf_stat_recipe` (32 tests)
- `python3 -m py_compile ab_bench.py perf_stat_recipe.py test_perf_stat_recipe.py`
- `python3 ab_bench.py --self-test`
- Ruff check/format, actionlint, the scoped project linter, and the shared branch-diff lint roster; Vale remains uncovered because the repository has no `.vale.ini`.
- Real nginx preflight: 16-dictionary hit returned `dcz`; the corresponding miss returned `zstd`.
- Bounded worker-only perf smoke: dcz engaged, measured requests were non-zero, and all four counters parsed. This was a plumbing check, not benchmark evidence.
- Mutation controls went red when dcz traffic, the 16-entry cells, per-request normalization, worker PID attachment, setup exclusion, or engagement validation was removed.
- Independent review approved the final measurement boundary and lifecycle. The final uncommitted CodeRabbit pass reviewed all six files with zero findings.

## Performance

No baseline/optimized A/B run is included. This PR repairs the workload and measurement boundary so a later run can produce evidence without counting Python, backend, wrk, startup, fixture, or cleanup work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional DCZ benchmark workloads covering dictionary hit and miss scenarios with 1, 4, and 16 configured dictionaries.
  - Added JSON benchmark metadata, successful-request normalization, and worker-scoped performance-counter measurements.
  - Added workload selection and performance-measurement options while preserving the existing plain-zstd default.

- **Documentation**
  - Expanded benchmark guidance for workload selection, result recording, and measurement scenarios.

- **Tests**
  - Added comprehensive validation for DCZ workloads, performance measurements, CLI behavior, and comparison results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->