### PR TITLE
perf: skip superseded libzstd parameters per dictionary mode

### DIFF
--- a/.github/workflows/harness-fault-arms.yml
+++ b/.github/workflows/harness-fault-arms.yml
@@ -406,11 +406,11 @@ jobs:
             exit 1
           fi
 
-          # The count oracles specifically -- oracle 3 (cdict) and oracle 6
+          # The count oracles specifically -- oracle 3 (cdict) and oracle 7
           # (dcz). Same "[^#]*$" reasoning as codec-call-count's tail above:
           # without it a SKIP line would still match and bank a green that
           # asserted nothing.
-          for n in 3 6; do
+          for n in 3 7; do
             if ! grep -qE "^ok $n - [^#]*setParameter call count is [^#]*$" \
                  "$GITHUB_WORKSPACE/setparam-call-count-tap.log"; then
               echo "::error::oracle $n (a setParameter-call-count assertion)" \
@@ -419,6 +419,20 @@ jobs:
               exit 1
             fi
           done
+
+          # Oracle 4: the frame's own Window_Descriptor actually carries the
+          # operator's zstd_window_log cap under a CDict -- the direct check
+          # for the windowLog-not-superseded finding, independent of the
+          # call-count oracle above (a call count can coincidentally match
+          # while the frame itself still carries an uncapped, level-derived
+          # window).
+          if ! grep -qE '^ok 4 - [^#]*frame window size is [^#]*$' \
+               "$GITHUB_WORKSPACE/setparam-call-count-tap.log"; then
+            echo "::error::oracle 4 (the cdict frame window-cap assertion)" \
+              "did not pass -- without it a dropped windowLog set on the" \
+              "CDict path is invisible to this scenario"
+            exit 1
+          fi
 
       - name: Run setparam-call-count-nodict scenario
         env:
@@ -443,6 +457,14 @@ jobs:
             echo "::error::oracle 3 (the no-dict setParameter-call-count" \
               "assertion) did not pass -- without it there is no reference" \
               "count the dictionary-mode oracles above are measured against"
+            exit 1
+          fi
+
+          if ! grep -qE '^ok 4 - [^#]*frame window size is [^#]*$' \
+               "$GITHUB_WORKSPACE/setparam-call-count-nodict-tap.log"; then
+            echo "::error::oracle 4 (the no-dict frame window-cap" \
+              "assertion) did not pass -- without it there is no reference" \
+              "frame window the cdict oracle above is measured against"
             exit 1
           fi
 

--- a/.github/workflows/harness-fault-arms.yml
+++ b/.github/workflows/harness-fault-arms.yml
@@ -11,6 +11,21 @@ name: Harness Fault Arms
 #                                          (cycle-pool + fd deltas)
 #   ci/t/harness-scenarios/fault-palloc    pool-allocation failure handling
 #                                          (PALLOC fault site, issues.md m8)
+#   ci/t/harness-scenarios/codec-call-count
+#                                          per-response ZSTD_compressStream2
+#                                          call count, plain/tiny/empty/dcz/
+#                                          flush-last
+#   ci/t/harness-scenarios/setparam-call-count,
+#   ci/t/harness-scenarios/setparam-call-count-nodict
+#                                          per-mode ZSTD_CCtx_setParameter
+#                                          call count -- pins that a CDict
+#                                          compression skips the parameters
+#                                          refCDict supersedes (level,
+#                                          windowLog) while a dcz-negotiated
+#                                          one, which uses refPrefix instead,
+#                                          still sets them (TODO-archive.md
+#                                          2026-08 "skip superseded libzstd
+#                                          parameters per dictionary mode")
 #
 # See plan-testkit-integration.md Phase 4: this is the "real" gate for the
 # codec fault-injection surface Phase 3 wired up -- the testkit-side
@@ -361,6 +376,76 @@ jobs:
             fi
           done
 
+      - name: Run setparam-call-count scenario
+        env:
+          PROBER_ROOT: ${{ github.workspace }}
+          PROBER_BUILD: ${{ github.workspace }}/nginx-1.31.4
+          PROBER_MODULE: ngx_http_zstd_filter_module.so
+          PROBER_DIRECTIVE: zstd_probe
+          PROBER_PROBE: "zstd_probe;"
+          # No PROBER_ALLOW_LOG, deliberately: this scenario injects no
+          # faults either, same reasoning as codec-call-count above.
+        run: |
+          set -euo pipefail
+          cd ci/t/harness/ci/prober
+          ./run-scenario.sh "$GITHUB_WORKSPACE/ci/t/harness-scenarios/setparam-call-count" nginx 1.31.4 \
+            | tee "$GITHUB_WORKSPACE/setparam-call-count-tap.log"
+
+          if grep -q '^not ok' "$GITHUB_WORKSPACE/setparam-call-count-tap.log"; then
+            echo "::error::setparam-call-count scenario reported at least one 'not ok' line"
+            exit 1
+          fi
+
+          TOTAL_OK=$(grep -c '^ok ' "$GITHUB_WORKSPACE/setparam-call-count-tap.log" || true)
+          SKIPPED=$(grep -c '^ok .*# SKIP' "$GITHUB_WORKSPACE/setparam-call-count-tap.log" || true)
+          if [ "$TOTAL_OK" -gt 0 ] && [ "$TOTAL_OK" -eq "$SKIPPED" ]; then
+            echo "::error::every oracle in setparam-call-count SKIPped -- the" \
+              "scenario asserted nothing about the per-mode" \
+              "ZSTD_CCtx_setParameter call count; failing rather than" \
+              "banking a vacuous green"
+            exit 1
+          fi
+
+          # The count oracles specifically -- oracle 3 (cdict) and oracle 6
+          # (dcz). Same "[^#]*$" reasoning as codec-call-count's tail above:
+          # without it a SKIP line would still match and bank a green that
+          # asserted nothing.
+          for n in 3 6; do
+            if ! grep -qE "^ok $n - [^#]*setParameter call count is [^#]*$" \
+                 "$GITHUB_WORKSPACE/setparam-call-count-tap.log"; then
+              echo "::error::oracle $n (a setParameter-call-count assertion)" \
+                "did not pass -- without it this scenario cannot show a" \
+                "superseded-by-cdict parameter was actually skipped"
+              exit 1
+            fi
+          done
+
+      - name: Run setparam-call-count-nodict scenario
+        env:
+          PROBER_ROOT: ${{ github.workspace }}
+          PROBER_BUILD: ${{ github.workspace }}/nginx-1.31.4
+          PROBER_MODULE: ngx_http_zstd_filter_module.so
+          PROBER_DIRECTIVE: zstd_probe
+          PROBER_PROBE: "zstd_probe;"
+        run: |
+          set -euo pipefail
+          cd ci/t/harness/ci/prober
+          ./run-scenario.sh "$GITHUB_WORKSPACE/ci/t/harness-scenarios/setparam-call-count-nodict" nginx 1.31.4 \
+            | tee "$GITHUB_WORKSPACE/setparam-call-count-nodict-tap.log"
+
+          if grep -q '^not ok' "$GITHUB_WORKSPACE/setparam-call-count-nodict-tap.log"; then
+            echo "::error::setparam-call-count-nodict scenario reported at least one 'not ok' line"
+            exit 1
+          fi
+
+          if ! grep -qE '^ok 3 - [^#]*setParameter call count is [^#]*$' \
+               "$GITHUB_WORKSPACE/setparam-call-count-nodict-tap.log"; then
+            echo "::error::oracle 3 (the no-dict setParameter-call-count" \
+              "assertion) did not pass -- without it there is no reference" \
+              "count the dictionary-mode oracles above are measured against"
+            exit 1
+          fi
+
       - name: Upload TAP log
         if: always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
@@ -371,5 +456,7 @@ jobs:
             alloc-neutral-tap.log
             fault-palloc-tap.log
             codec-call-count-tap.log
+            setparam-call-count-tap.log
+            setparam-call-count-nodict-tap.log
           retention-days: 14
           if-no-files-found: ignore

--- a/ci/t/harness-scenarios/setparam-call-count-nodict/driver.sh
+++ b/ci/t/harness-scenarios/setparam-call-count-nodict/driver.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# Scenario: ZSTD_CCtx_setParameter() CALL COUNT, NO-DICTIONARY MODE.
+#
+# Pins the per-mode instrumentation this item's done criterion asks for. The
+# no-dict mode takes NEITHER the zlcf->dict (CDict) NOR the ctx->dcz_dict
+# (raw prefix) branch in ngx_http_zstd_filter_init_cctx(), so every
+# parameter the location configures is a live CCtx parameter and none of
+# them is superseded-by-cdict: level, windowLog, and (with zstd_long on)
+# enableLongDistanceMatching are all genuinely applied -> 3 calls.
+#
+# This is the reference count the dictionary-mode oracles in the sibling
+# setparam-call-count scenario are measured AGAINST: level and windowLog
+# drop out under a trained CDict specifically because refCDict supersedes
+# them (zstd.h), and this arm is what proves they were being set at all
+# when nothing supersedes them.
+set -euo pipefail
+
+# shellcheck source=lib.sh
+. "$PROBER_LIB"
+
+HOST=127.0.0.1
+PORT="$PROBER_RESOLVED_PORT"
+ELOG="$PROBER_PREFIX/logs/error.log"
+
+FAILED=0
+N=0
+
+ok()    { N=$((N + 1)); echo "ok $N - $1"; }
+notok() { N=$((N + 1)); echo "not ok $N - $1"; FAILED=1; }
+diag()  { echo "# $1"; }
+
+WWW="$PROBER_PREFIX/www"
+mkdir -p "$WWW"
+printf 'the quick brown fox jumps over the lazy dog, nodict setparam count fixture\n' \
+    >"$WWW/index.html"
+
+reset_counter() {
+    curl -fsS --max-time 5 "http://$HOST:$PORT/__probe?setparam_reset=1" \
+        -o /dev/null
+}
+
+read_counter() {
+    local body
+    body="$(prober_probe_body "$HOST" "$PORT")" || return 1
+    prober_probe_field "$body" "setparam_calls" || return 1
+}
+
+echo "1..3"
+
+if ! reset_counter; then
+    notok "reset: probe did not answer setparam_reset"
+    notok "response decodes byte-for-byte to the origin"
+    notok "setParameter call count is 3"
+    exit 1
+fi
+
+RAW="$PROBER_PREFIX/tmp"
+mkdir -p "$RAW"
+HDRS="$RAW/nodict.hdrs"
+BODY="$RAW/nodict.bin"
+
+if curl -sS --max-time 15 -D "$HDRS" -o "$BODY" \
+        -H 'Accept-Encoding: zstd' \
+        "http://$HOST:$PORT/index.html" 2>"$RAW/nodict.err"; then
+    ok "request succeeded"
+else
+    notok "request succeeded"
+    diag "curl stderr: $(cat "$RAW/nodict.err" 2>/dev/null || true)"
+fi
+
+if grep -qi '^content-encoding:[[:space:]]*zstd' "$HDRS" 2>/dev/null; then
+    :
+else
+    diag "headers: $(tr -d '\r' <"$HDRS" 2>/dev/null | tr '\n' ' ')"
+fi
+
+if zstd -d -q -f -o "$BODY.dec" "$BODY" 2>/dev/null \
+   && cmp -s "$BODY.dec" "$WWW/index.html"; then
+    ok "response decodes byte-for-byte to the origin"
+else
+    notok "response decodes byte-for-byte to the origin"
+fi
+
+GOT="$(read_counter || echo -1)"
+if [ "$GOT" -eq 3 ]; then
+    ok "setParameter call count is 3 (level, windowLog, LDM -- none superseded)"
+else
+    diag "setparam_calls=$GOT expected=3"
+    notok "setParameter call count is 3 (got $GOT)"
+fi
+
+if grep -qE '\[(crit|alert|emerg)\]' "$ELOG" 2>/dev/null; then
+    diag "$(grep -E '\[(crit|alert|emerg)\]' "$ELOG" | head -3)"
+fi
+
+exit "$FAILED"

--- a/ci/t/harness-scenarios/setparam-call-count-nodict/driver.sh
+++ b/ci/t/harness-scenarios/setparam-call-count-nodict/driver.sh
@@ -10,10 +10,16 @@
 # enableLongDistanceMatching are all genuinely applied -> 3 calls.
 #
 # This is the reference count the dictionary-mode oracles in the sibling
-# setparam-call-count scenario are measured AGAINST: level and windowLog
-# drop out under a trained CDict specifically because refCDict supersedes
-# them (zstd.h), and this arm is what proves they were being set at all
-# when nothing supersedes them.
+# setparam-call-count scenario are measured AGAINST. Under a trained CDict
+# only level drops out (ZSTD_CCtx_refCDict() supersedes compressionLevel
+# from the CDict's own baked-in ZSTD_compressionParameters -- zstd.h).
+# windowLog is NOT superseded: ZSTD_resetCCtx_byAttachingCDict()/
+# ZSTD_resetCCtx_byCopyingCDict() (zstd_compress.c) both restore windowLog
+# from the CCtx's own applied params right after copying the CDict's other
+# cParams, and assert it is nonzero -- so init_cctx must keep setting it
+# even in CDict mode, or the operator's zstd_window_log cap silently stops
+# applying. This arm is what proves level and windowLog are both genuinely
+# set when nothing supersedes either of them.
 set -euo pipefail
 
 # shellcheck source=lib.sh
@@ -32,8 +38,20 @@ diag()  { echo "# $1"; }
 
 WWW="$PROBER_PREFIX/www"
 mkdir -p "$WWW"
-printf 'the quick brown fox jumps over the lazy dog, nodict setparam count fixture\n' \
-    >"$WWW/index.html"
+
+# Larger than 2**20 (zstd_window_log 20 in nginx.conf): a body smaller than
+# the window cap lets zstd shrink the FRAME's encoded window to fit the
+# content regardless of what ZSTD_c_windowLog was set to, which would make
+# the window-cap assertion below pass whether or not the cap was actually
+# applied. Random bytes, same construction as the sibling
+# setparam-call-count scenario's fixture and for the same reason.
+awk 'BEGIN {
+    srand(43)
+    n = 1200000
+    for (i = 0; i < n; i++) {
+        printf "%c", 97 + int(rand() * 26)
+    }
+}' >"$WWW/index.html"
 
 reset_counter() {
     curl -fsS --max-time 5 "http://$HOST:$PORT/__probe?setparam_reset=1" \
@@ -46,12 +64,13 @@ read_counter() {
     prober_probe_field "$body" "setparam_calls" || return 1
 }
 
-echo "1..3"
+echo "1..4"
 
 if ! reset_counter; then
     notok "reset: probe did not answer setparam_reset"
     notok "response decodes byte-for-byte to the origin"
     notok "setParameter call count is 3"
+    notok "frame window size is 1048576 B"
     exit 1
 fi
 
@@ -88,6 +107,23 @@ if [ "$GOT" -eq 3 ]; then
 else
     diag "setparam_calls=$GOT expected=3"
     notok "setParameter call count is 3 (got $GOT)"
+fi
+
+# Direct frame-level check, same reasoning as the sibling
+# setparam-call-count scenario's assert_window_cap: the call count above
+# proves windowLog was SET on the CCtx, not that the resulting frame
+# carries the operator's actual cap. This arm establishes the reference
+# window (1 MiB, 2**20) the dictionary-mode oracles are compared against.
+WANT_WINDOW=$((1 << 20))
+GOT_WINDOW="$(zstd -l -v "$BODY" 2>/dev/null \
+    | grep -oP 'Window Size:.*\(\K[0-9]+(?= B\))' | head -1)"
+if [ -z "$GOT_WINDOW" ]; then
+    notok "frame window size is $WANT_WINDOW B (zstd -l -v produced no Window Size line)"
+elif [ "$GOT_WINDOW" -eq "$WANT_WINDOW" ]; then
+    ok "frame window size is $WANT_WINDOW B"
+else
+    diag "frame Window Size=$GOT_WINDOW B expected=$WANT_WINDOW B"
+    notok "frame window size is $WANT_WINDOW B (got $GOT_WINDOW B)"
 fi
 
 if grep -qE '\[(crit|alert|emerg)\]' "$ELOG" 2>/dev/null; then

--- a/ci/t/harness-scenarios/setparam-call-count-nodict/nginx.conf
+++ b/ci/t/harness-scenarios/setparam-call-count-nodict/nginx.conf
@@ -1,0 +1,36 @@
+@LOAD@
+# Sibling of setparam-call-count, isolated because zstd_dict_file is an
+# http{}-context directive: any conf that loads one gives every "zstd on"
+# location a non-NULL conf->dict (see the sibling scenario's comment), so a
+# genuinely dict-free arm needs its own conf with no such directive anywhere.
+daemon off;
+pid @PREFIX@/nginx.pid;
+error_log @PREFIX@/logs/error.log info;
+worker_processes 1;
+events { worker_connections 16; }
+http {
+    default_type text/plain;
+
+    server {
+        listen 127.0.0.1:@PORT@;
+        root @PREFIX@/www;
+
+        # No dictionary anywhere in this conf: init_cctx takes neither the
+        # zlcf->dict (CDict) nor the ctx->dcz_dict (raw prefix) branch, so
+        # every configured parameter is a live CCtx parameter, none
+        # superseded:
+        #   level     set
+        #   windowLog set
+        #   LDM       set (zstd_long on)
+        # -> 3 setParameter calls.
+        location / {
+            alias @PREFIX@/www/;
+            zstd on;
+            zstd_min_length 0;
+            zstd_window_log 20;
+            zstd_long on;
+        }
+
+        location /__probe { @PROBE@ }
+    }
+}

--- a/ci/t/harness-scenarios/setparam-call-count-nodict/requires
+++ b/ci/t/harness-scenarios/setparam-call-count-nodict/requires
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Gate: the tree run-scenario.sh is about to boot must be a TEST_HARNESS
+# build. This scenario reads the setparam_calls counter out of the probe
+# document, and without both TEST_HARNESS=1 and -DNGX_TEST_HARNESS the probe
+# endpoint compiles out entirely -- `nginx -t` would then reject the
+# `zstd_probe;` in nginx.conf and the scenario would red for a build reason
+# rather than a module one.
+#
+# No dictionary fixture to stage here -- this scenario's whole point is a
+# conf with no zstd_dict_file / zstd_dcz_dict_file anywhere in it, so the
+# dict-staging step the sibling setparam-call-count scenario needs does not
+# apply.
+#
+# Derived the same way run-scenario.sh/lib.sh resolve the build tree, so this
+# gate can never SKIP a tree the engine would boot fine or pass one it would
+# reject -- identical reasoning to fault-arms/requires and alloc-neutral's.
+set -euo pipefail
+
+FLAVOR="${2:-nginx}"
+VERSION="${3:-1.31.3}"
+BUILD="${PROBER_BUILD:-${PROBER_ROOT:-$(cd ../.. && pwd)}/.build/${FLAVOR}-${VERSION}}"
+SO="$BUILD/objs/ngx_http_zstd_filter_module.so"
+
+if [ ! -f "$SO" ]; then
+    echo "ngx_http_zstd_filter_module.so not found at $SO -- build it first"
+    exit 1
+fi
+
+if ! nm "$SO" 2>/dev/null | grep -q ' ngx_test_probe_'; then
+    echo "$SO carries no ngx_test_probe_* symbols -- this is a packaged (non-harness) build; configure with TEST_HARNESS=1 CFLAGS=\"\$CFLAGS -DNGX_TEST_HARNESS\" first"
+    exit 1
+fi
+
+if ! command -v zstd >/dev/null 2>&1; then
+    echo "zstd(1) not found -- the oracle decodes its response and compares it byte-for-byte with the origin file"
+    exit 1
+fi
+
+exit 0

--- a/ci/t/harness-scenarios/setparam-call-count/driver.sh
+++ b/ci/t/harness-scenarios/setparam-call-count/driver.sh
@@ -8,10 +8,14 @@
 # this conf) -- the no-dict reference count (3) is measured separately in
 # the sibling setparam-call-count-nodict scenario.
 #
-#   /cdict/  trained CDict (zlcf->dict, refCDict): compressionLevel and
-#            windowLog are in zstd.h's refCDict-superseded "compression
-#            parameters" block, so init_cctx now skips setting them --
-#            only enableLongDistanceMatching remains -> 1 call.
+#   /cdict/  trained CDict (zlcf->dict, refCDict): only compressionLevel is
+#            in zstd.h's refCDict-superseded "compression parameters" block
+#            (ZSTD_CCtx_refCDict() takes it from the CDict's own baked
+#            ZSTD_compressionParameters). windowLog is NOT superseded --
+#            ZSTD_resetCCtx_byAttachingCDict()/ZSTD_resetCCtx_byCopyingCDict()
+#            (zstd_compress.c) both restore it from the CCtx's own applied
+#            params right after copying the CDict's other cParams, so
+#            init_cctx keeps setting it here -> 2 calls (windowLog, LDM).
 #   /dcz/    negotiated raw prefix (ctx->dcz_dict, refPrefix): refPrefix
 #            does NOT override sticky parameters, so level, windowLog
 #            (the dcz-aware value, set once, not twice), LDM and
@@ -39,8 +43,20 @@ diag()  { echo "# $1"; }
 
 WWW="$PROBER_PREFIX/www"
 mkdir -p "$WWW" "$PROBER_PREFIX/tmp"
-printf 'the quick brown fox jumps over the lazy dog, dictionary setparam count fixture\n' \
-    >"$WWW/index.html"
+
+# Larger than 2**20 (zstd_window_log 20 in nginx.conf, both arms): a body
+# smaller than the window cap lets zstd shrink the FRAME's encoded window to
+# fit the content regardless of what ZSTD_c_windowLog was set to, which would
+# make the cap assertion below pass whether or not the cap was actually
+# applied. Random bytes so the compressor cannot fold the whole body into a
+# handful of long matches and shrink the decode/measure cost.
+awk 'BEGIN {
+    srand(42)
+    n = 1200000
+    for (i = 0; i < n; i++) {
+        printf "%c", 97 + int(rand() * 26)
+    }
+}' >"$WWW/index.html"
 
 DICT_FILE="$(dirname "$PROBER_SERVER_BIN")/setparam-call-count.dict"
 DICT_SHA_B64="$(openssl dgst -sha256 -binary "$DICT_FILE" 2>/dev/null \
@@ -107,11 +123,48 @@ measure() {
     fi
 }
 
-echo "1..7"
+# assert_window_cap LABEL FRAME_FILE WINDOW_LOG: parse the compressed
+# frame's own Window_Descriptor via `zstd -l -v` and require it to be
+# EXACTLY 2**WINDOW_LOG. This is the direct regression check for the
+# windowLog-is-NOT-superseded-by-cdict finding: the setParameter call
+# count above proves windowLog was SET on the CCtx, but not that the
+# resulting FRAME actually carries the operator's cap -- a build that
+# silently dropped the CCtx-side set (the exact bug ZSTD_resetCCtx_
+# byAttachingCDict()/ZSTD_resetCCtx_byCopyingCDict() would produce, see
+# nginx.conf's comment) still passes the call-count oracle if something
+# else pushes the count back to 2 by coincidence, but the frame itself
+# would then carry libzstd's level-derived window instead of 1 MiB. The
+# fixture is 1200000 bytes, larger than 2**20, specifically so the window
+# cannot shrink to fit content and mask an uncapped default.
+assert_window_cap() {
+    local label="$1" frame="$2" wlog="$3"
+    local want=$((1 << wlog))
+    local got
+
+    got="$(zstd -l -v "$frame" 2>/dev/null \
+        | grep -oP 'Window Size:.*\(\K[0-9]+(?= B\))' | head -1)"
+
+    if [ -z "$got" ]; then
+        notok "$label: frame window size is $want B (zstd -l -v produced no Window Size line)"
+        return
+    fi
+
+    if [ "$got" -eq "$want" ]; then
+        ok "$label: frame window size is $want B"
+    else
+        diag "$label: frame Window Size=$got B expected=$want B"
+        notok "$label: frame window size is $want B (got $got B)"
+    fi
+}
+
+echo "1..8"
 
 # /cdict/: no dcz negotiation header, so init_cctx takes the zlcf->dict
-# branch. level and windowLog superseded-by-cdict -> only LDM is set.
-measure "cdict" "/cdict/index.html" "zstd" 1
+# branch. level is superseded-by-cdict and skipped; windowLog is NOT
+# superseded (restored from the CCtx's own params by
+# ZSTD_resetCCtx_by{Attaching,Copying}CDict()) and stays set alongside LDM.
+measure "cdict" "/cdict/index.html" "zstd" 2
+assert_window_cap "cdict" "$PROBER_PREFIX/tmp/cdict.bin" 20
 
 if [ -n "$DICT_SHA_B64" ]; then
     measure "dcz" "/dcz/index.html" "dcz" 4 \

--- a/ci/t/harness-scenarios/setparam-call-count/driver.sh
+++ b/ci/t/harness-scenarios/setparam-call-count/driver.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Scenario: ZSTD_CCtx_setParameter() CALL COUNT, DICTIONARY MODES.
+#
+# Pins the per-mode instrumentation this item's done criterion asks for.
+# Both dictionary paths live here because zstd_dict_file is http{}-context
+# (see nginx.conf's comment for why a genuinely dict-free arm cannot share
+# this conf) -- the no-dict reference count (3) is measured separately in
+# the sibling setparam-call-count-nodict scenario.
+#
+#   /cdict/  trained CDict (zlcf->dict, refCDict): compressionLevel and
+#            windowLog are in zstd.h's refCDict-superseded "compression
+#            parameters" block, so init_cctx now skips setting them --
+#            only enableLongDistanceMatching remains -> 1 call.
+#   /dcz/    negotiated raw prefix (ctx->dcz_dict, refPrefix): refPrefix
+#            does NOT override sticky parameters, so level, windowLog
+#            (the dcz-aware value, set once, not twice), LDM and
+#            checksumFlag(dcz) all apply -> 4 calls.
+#
+# THE OUTPUT-IDENTITY HALF. A call count on its own is satisfied by a
+# response that is fast and wrong, so every oracle here is paired with a
+# byte-for-byte decode against the origin -- the same shape as
+# codec-call-count/driver.sh, and for the same reason (see its header).
+set -euo pipefail
+
+# shellcheck source=lib.sh
+. "$PROBER_LIB"
+
+HOST=127.0.0.1
+PORT="$PROBER_RESOLVED_PORT"
+ELOG="$PROBER_PREFIX/logs/error.log"
+
+FAILED=0
+N=0
+
+ok()    { N=$((N + 1)); echo "ok $N - $1"; }
+notok() { N=$((N + 1)); echo "not ok $N - $1"; FAILED=1; }
+diag()  { echo "# $1"; }
+
+WWW="$PROBER_PREFIX/www"
+mkdir -p "$WWW" "$PROBER_PREFIX/tmp"
+printf 'the quick brown fox jumps over the lazy dog, dictionary setparam count fixture\n' \
+    >"$WWW/index.html"
+
+DICT_FILE="$(dirname "$PROBER_SERVER_BIN")/setparam-call-count.dict"
+DICT_SHA_B64="$(openssl dgst -sha256 -binary "$DICT_FILE" 2>/dev/null \
+                | openssl base64 -A 2>/dev/null || true)"
+
+reset_counter() {
+    curl -fsS --max-time 5 "http://$HOST:$PORT/__probe?setparam_reset=1" \
+        -o /dev/null
+}
+
+read_counter() {
+    local body
+    body="$(prober_probe_body "$HOST" "$PORT")" || return 1
+    prober_probe_field "$body" "setparam_calls" || return 1
+}
+
+# measure LABEL PATH ENC EXPECT [EXTRA_HEADER...]
+measure() {
+    local label="$1" path="$2" enc="$3" expect="$4"; shift 4
+    local hdrs="$PROBER_PREFIX/tmp/${label}.hdrs"
+    local body="$PROBER_PREFIX/tmp/${label}.bin"
+    local -a extra=(-H 'Accept-Encoding: zstd')
+    local h
+    for h in "$@"; do extra+=(-H "$h"); done
+
+    if ! reset_counter; then
+        notok "$label: probe did not answer setparam_reset"
+        notok "$label: response decodes byte-for-byte to the origin"
+        notok "$label: setParameter call count is $expect"
+        return
+    fi
+
+    if ! curl -sS --max-time 15 -D "$hdrs" -o "$body" "${extra[@]}" \
+             "http://$HOST:$PORT$path" 2>"$body.err"; then
+        notok "$label: request failed or timed out"
+        notok "$label: response decodes byte-for-byte to the origin"
+        notok "$label: setParameter call count is $expect"
+        return
+    fi
+
+    if ! grep -qi "^content-encoding:[[:space:]]*$enc" "$hdrs"; then
+        diag "$label: headers were: $(tr -d '\r' <"$hdrs" | tr '\n' ' ')"
+        notok "$label: response carried Content-Encoding: $enc"
+        notok "$label: response decodes byte-for-byte to the origin"
+        notok "$label: setParameter call count is $expect"
+        return
+    fi
+    ok "$label: response carried Content-Encoding: $enc"
+
+    if zstd -d -q -f -o "$body.dec" "$body" -D "$DICT_FILE" 2>/dev/null \
+       && cmp -s "$body.dec" "$WWW/index.html"; then
+        ok "$label: response decodes byte-for-byte to the origin"
+    else
+        notok "$label: response decodes byte-for-byte to the origin"
+    fi
+
+    local got
+    got="$(read_counter || echo -1)"
+    if [ "$got" -eq "$expect" ]; then
+        ok "$label: setParameter call count is $expect"
+    else
+        diag "$label: setparam_calls=$got expected=$expect"
+        notok "$label: setParameter call count is $expect (got $got)"
+    fi
+}
+
+echo "1..7"
+
+# /cdict/: no dcz negotiation header, so init_cctx takes the zlcf->dict
+# branch. level and windowLog superseded-by-cdict -> only LDM is set.
+measure "cdict" "/cdict/index.html" "zstd" 1
+
+if [ -n "$DICT_SHA_B64" ]; then
+    measure "dcz" "/dcz/index.html" "dcz" 4 \
+        "Accept-Encoding: zstd, dcz" \
+        "Available-Dictionary: :$DICT_SHA_B64:"
+else
+    # NOT a SKIP -- see codec-call-count/driver.sh's identical reasoning:
+    # openssl(1) is a hard requires-gate, so reaching here means the hash
+    # derivation failed for some other reason (unreadable/truncated
+    # dictionary), and a SKIP would read as a pass to anything grepping
+    # for the oracle.
+    notok "dcz: response carried Content-Encoding: dcz (could not derive the dictionary hash from $DICT_FILE)"
+    notok "dcz: response decodes byte-for-byte to the origin (no dictionary hash)"
+    notok "dcz: setParameter call count is 4 (no dictionary hash)"
+fi
+
+# error log carries no crit/alert/emerg: this scenario injects no faults.
+if grep -qE '\[(crit|alert|emerg)\]' "$ELOG" 2>/dev/null; then
+    diag "$(grep -E '\[(crit|alert|emerg)\]' "$ELOG" | head -3)"
+    notok "error log carries no crit/alert/emerg lines"
+else
+    ok "error log carries no crit/alert/emerg lines"
+fi
+
+exit "$FAILED"

--- a/ci/t/harness-scenarios/setparam-call-count/nginx.conf
+++ b/ci/t/harness-scenarios/setparam-call-count/nginx.conf
@@ -23,13 +23,19 @@ http {
         root @PREFIX@/www;
 
         # No-dcz-negotiation arm: init_cctx takes the zlcf->dict (CDict)
-        # branch. compressionLevel and windowLog are superseded by the
-        # CDict's own baked parameters, so the fixed set is:
+        # branch. Only compressionLevel is superseded by the CDict's own
+        # baked ZSTD_compressionParameters (zstd.h). windowLog is NOT
+        # superseded -- ZSTD_resetCCtx_byAttachingCDict()/
+        # ZSTD_resetCCtx_byCopyingCDict() (zstd_compress.c) both restore it
+        # from the CCtx's own applied params right after copying the
+        # CDict's other cParams, and assert it nonzero, so init_cctx must
+        # keep setting it here or zstd_window_log's cap silently stops
+        # applying under a dictionary. The fixed set is:
         #   level        SKIPPED (superseded-by-cdict)
-        #   windowLog    SKIPPED (superseded-by-cdict)
+        #   windowLog    set (NOT superseded-by-cdict)
         #   LDM          set (zstd_long on; not superseded)
         #   checksumFlag NOT set (dcz-only)
-        # -> 1 setParameter call (enableLongDistanceMatching only).
+        # -> 2 setParameter calls (windowLog, enableLongDistanceMatching).
         location /cdict/ {
             alias @PREFIX@/www/;
             zstd on;

--- a/ci/t/harness-scenarios/setparam-call-count/nginx.conf
+++ b/ci/t/harness-scenarios/setparam-call-count/nginx.conf
@@ -1,0 +1,74 @@
+@LOAD@
+# Pins the per-mode ZSTD_CCtx_setParameter() call count init_cctx makes.
+# Same shape as codec-call-count: this repo IS the module under test, so
+# PROBER_MODULE is ngx_http_zstd_filter_module.so and @LOAD@ already
+# load_modules it, reaching setparam_calls through the same zoneless
+# module_render path.
+daemon off;
+pid @PREFIX@/nginx.pid;
+error_log @PREFIX@/logs/error.log info;
+worker_processes 1;
+events { worker_connections 16; }
+http {
+    default_type text/plain;
+
+    # Trained CDict, http{}-context only (NGX_HTTP_MAIN_CONF). Applies to
+    # EVERY location below unless a dcz negotiation on that request takes
+    # priority (dcz_dict != NULL wins in init_cctx -- see the else-if there).
+    zstd_dict_file_unsafe on;
+    zstd_dict_file @BUILD_OBJS@/setparam-call-count.dict;
+
+    server {
+        listen 127.0.0.1:@PORT@;
+        root @PREFIX@/www;
+
+        # No-dcz-negotiation arm: init_cctx takes the zlcf->dict (CDict)
+        # branch. compressionLevel and windowLog are superseded by the
+        # CDict's own baked parameters, so the fixed set is:
+        #   level        SKIPPED (superseded-by-cdict)
+        #   windowLog    SKIPPED (superseded-by-cdict)
+        #   LDM          set (zstd_long on; not superseded)
+        #   checksumFlag NOT set (dcz-only)
+        # -> 1 setParameter call (enableLongDistanceMatching only).
+        location /cdict/ {
+            alias @PREFIX@/www/;
+            zstd on;
+            zstd_min_length 0;
+            zstd_window_log 20;
+            zstd_long on;
+        }
+
+        # dcz negotiation arm: init_cctx takes the ctx->dcz_dict (raw
+        # prefix) branch. refPrefix does NOT supersede sticky parameters,
+        # so:
+        #   level          set
+        #   windowLog      set ONCE, with the dcz-aware value (not the
+        #                  generic zlcf->window_log -- see the skip
+        #                  condition in init_cctx)
+        #   LDM            set (zstd_long on)
+        #   checksumFlag   set (dcz-only)
+        # -> 4 setParameter calls.
+        location /dcz/ {
+            alias @PREFIX@/www/;
+            zstd on;
+            zstd_min_length 0;
+            zstd_window_log 20;
+            zstd_long on;
+            zstd_dcz_dict_file @BUILD_OBJS@/setparam-call-count.dict;
+            zstd_dcz_assume_secure_transport on;
+        }
+
+        # No-dictionary arm lives in the SEPARATE setparam-call-count-nodict
+        # scenario, not here: zstd_dict_file is an http{}-context
+        # (NGX_HTTP_MAIN_CONF) directive, and any "zstd on" location in an
+        # http{} block where it is set gets conf->dict populated from the
+        # shared registry (see the location-merge code around
+        # zmcf->dict_registry in ngx_http_zstd_merge_loc_conf) -- there is
+        # no per-location opt-out short of a second http{} block, which one
+        # nginx.conf cannot express. Splitting into two confs keeps each one
+        # a single, unambiguous arm rather than a location whose comment
+        # promises "no dict" while conf->dict is silently non-NULL.
+
+        location /__probe { @PROBE@ }
+    }
+}

--- a/ci/t/harness-scenarios/setparam-call-count/requires
+++ b/ci/t/harness-scenarios/setparam-call-count/requires
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Gate: the tree run-scenario.sh is about to boot must be a TEST_HARNESS build.
+# This scenario reads the setparam_calls counter out of the probe document,
+# and without both TEST_HARNESS=1 and -DNGX_TEST_HARNESS the probe endpoint
+# compiles out entirely -- `nginx -t` would then reject the `zstd_probe;` in
+# nginx.conf and the scenario would red for a build reason rather than a
+# module one.
+#
+# Derived the same way run-scenario.sh/lib.sh resolve the build tree, so this
+# gate can never SKIP a tree the engine would boot fine or pass one it would
+# reject -- identical reasoning to fault-arms/requires and alloc-neutral's.
+set -euo pipefail
+
+FLAVOR="${2:-nginx}"
+VERSION="${3:-1.31.3}"
+BUILD="${PROBER_BUILD:-${PROBER_ROOT:-$(cd ../.. && pwd)}/.build/${FLAVOR}-${VERSION}}"
+SO="$BUILD/objs/ngx_http_zstd_filter_module.so"
+
+if [ ! -f "$SO" ]; then
+    echo "ngx_http_zstd_filter_module.so not found at $SO -- build it first"
+    exit 1
+fi
+
+if ! nm "$SO" 2>/dev/null | grep -q ' ngx_test_probe_'; then
+    echo "$SO carries no ngx_test_probe_* symbols -- this is a packaged (non-harness) build; configure with TEST_HARNESS=1 CFLAGS=\"\$CFLAGS -DNGX_TEST_HARNESS\" first"
+    exit 1
+fi
+
+# Every call-count oracle here is PAIRED with a decode of the same response
+# against the origin bytes, because a call count on its own is satisfied by a
+# response that is fast and wrong. A missing decoder would silently weaken
+# every one of them to "200 and some bytes". Fail here instead: a gate that
+# cannot run its assertion is not a gate.
+if ! command -v zstd >/dev/null 2>&1; then
+    echo "zstd(1) not found -- every oracle decodes its response and compares it byte-for-byte with the origin file"
+    exit 1
+fi
+
+# openssl(1) is gated on exactly the same reasoning, and it is the CLI that is
+# required, not libssl: the driver shells out to `openssl dgst`/`openssl base64`
+# to derive the Available-Dictionary hash the dcz arm negotiates with. Without
+# it that arm cannot run.
+#
+# It is a hard gate rather than a driver-side SKIP deliberately. A SKIP prints
+# an "ok ... # SKIP" line, which reads as a pass to every consumer that greps
+# for the oracle -- so the dcz arm would assert nothing while the run stayed
+# green, which is the false green this scenario exists to remove. Failing the
+# whole scenario here is loud and impossible to misread.
+if ! command -v openssl >/dev/null 2>&1; then
+    echo "openssl(1) not found -- the dcz arm derives its Available-Dictionary hash with \"openssl dgst -sha256 | openssl base64\"; the CLI is required, not just libssl"
+    exit 1
+fi
+
+# Stage the dictionary fixture the dcz and trained-dict arms need.
+#
+# It has to exist before nginx runs its CONFIG TEST -- zstd_dcz_dict_file and
+# zstd_dict_file open their file at configuration time, so a driver-written
+# fixture is far too late (the prefix the driver writes into is not created
+# until prober_render_conf, immediately before that config test). This gate is
+# the only hook that runs earlier, so it stages the file and the conf
+# references it through @BUILD_OBJS@, the one absolute path the renderer
+# substitutes that exists this early.
+#
+# Copied from the repo's own checked-in ci/t/suite/dcz-dict rather than
+# generated, so the dcz arm here negotiates against exactly the dictionary
+# 03-dcz.t already pins the wire contract against.
+DICT_SRC="$(cd "$(dirname "$0")/../../suite" && pwd)/dcz-dict"
+if [ ! -f "$DICT_SRC" ]; then
+    echo "dictionary fixture not found at $DICT_SRC"
+    exit 1
+fi
+if ! cp -f "$DICT_SRC" "$BUILD/objs/setparam-call-count.dict"; then
+    echo "cannot stage the dictionary fixture into $BUILD/objs"
+    exit 1
+fi
+
+exit 0

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -3045,6 +3045,10 @@ ngx_http_zstd_set_param(ngx_http_request_t *r, ZSTD_CCtx *cctx,
 {
     size_t  rc;
 
+#ifdef NGX_TEST_HARNESS
+    ngx_http_zstd_probe_note_setparam();
+#endif
+
     rc = ZSTD_CCtx_setParameter(cctx, param, value);
     if (ZSTD_isError(rc)) {
         ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
@@ -3262,11 +3266,32 @@ ngx_http_zstd_filter_init_cctx(ngx_http_request_t *r,
         return NGX_ERROR;
     }
 
-    if (ngx_http_zstd_set_param(r, cctx, ZSTD_c_compressionLevel,
-                                (int) zlcf->level, "level")
-        != NGX_OK)
-    {
-        return NGX_ERROR;
+    /*
+     * ZSTD_c_compressionLevel is one of the "compression parameters"
+     * ZSTD_CCtx_refCDict() unconditionally overrides from the CDict's own
+     * baked-in ZSTD_compressionParameters (see the enum block comment in
+     * zstd.h: "When compressing with a ZSTD_CDict these parameters are
+     * superseded by the parameters used to construct the ZSTD_CDict" --
+     * ZSTD_c_compressionLevel is the first parameter in that block). Skip
+     * setting it only when refCDict is actually going to run below --
+     * i.e. zlcf->dict is set AND this request did NOT negotiate dcz,
+     * exactly the "else if (zlcf->dict)" condition the refCDict call site
+     * itself uses. zstd_dict_file is an http{}-context directive, so a
+     * dcz-negotiated request can have BOTH ctx->dcz_dict and zlcf->dict
+     * non-NULL at once; the dcz branch below always wins that mutual
+     * exclusion (ZSTD_CCtx_refPrefix() only, never refCDict), so gating on
+     * zlcf->dict alone would wrongly skip the level on such a request even
+     * though refCDict is never called for it. The dcz path uses
+     * ZSTD_CCtx_refPrefix(), which does NOT override sticky parameters, so
+     * level must still be set there.
+     */
+    if (zlcf->dict == NULL || ctx->dcz_dict != NULL) {
+        if (ngx_http_zstd_set_param(r, cctx, ZSTD_c_compressionLevel,
+                                    (int) zlcf->level, "level")
+            != NGX_OK)
+        {
+            return NGX_ERROR;
+        }
     }
 
     /*
@@ -3319,8 +3344,24 @@ ngx_http_zstd_filter_init_cctx(ngx_http_request_t *r,
      * windowLog gives operators a hard, predictable per-request memory
      * ceiling at a small ratio cost on inputs larger than the window.
      * Unset (0) keeps zstd's level-derived default.
+     *
+     * Skipped for both dictionary modes -- each sets its own windowLog
+     * with more specific knowledge than this generic block has:
+     *
+     *   - zlcf->dict (trained CDict): ZSTD_c_windowLog is in the same
+     *     refCDict-superseded "compression parameters" block as the level
+     *     above (zstd.h), and conf->dict was already built via
+     *     ZSTD_createCDict_advanced() seeded from this exact
+     *     zlcf->window_log (see the CDict construction site), so setting
+     *     it again here would only be immediately discarded.
+     *   - ctx->dcz_dict (RFC 9842 raw prefix): refPrefix does not override
+     *     sticky parameters, so windowLog here is NOT superseded, but the
+     *     dcz branch below computes a dictionary- and pledged-size-aware
+     *     value via ngx_http_zstd_dcz_window_log() and sets THAT instead --
+     *     setting the plain zlcf->window_log here first would just be
+     *     overwritten one call later by the correct value.
      */
-    if (zlcf->window_log > 0) {
+    if (zlcf->window_log > 0 && zlcf->dict == NULL && ctx->dcz_dict == NULL) {
         if (ngx_http_zstd_set_param(r, cctx, ZSTD_c_windowLog,
                                     (int) zlcf->window_log, "windowLog")
             != NGX_OK)

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -3345,23 +3345,26 @@ ngx_http_zstd_filter_init_cctx(ngx_http_request_t *r,
      * ceiling at a small ratio cost on inputs larger than the window.
      * Unset (0) keeps zstd's level-derived default.
      *
-     * Skipped for both dictionary modes -- each sets its own windowLog
-     * with more specific knowledge than this generic block has:
-     *
-     *   - zlcf->dict (trained CDict): ZSTD_c_windowLog is in the same
-     *     refCDict-superseded "compression parameters" block as the level
-     *     above (zstd.h), and conf->dict was already built via
-     *     ZSTD_createCDict_advanced() seeded from this exact
-     *     zlcf->window_log (see the CDict construction site), so setting
-     *     it again here would only be immediately discarded.
-     *   - ctx->dcz_dict (RFC 9842 raw prefix): refPrefix does not override
-     *     sticky parameters, so windowLog here is NOT superseded, but the
-     *     dcz branch below computes a dictionary- and pledged-size-aware
-     *     value via ngx_http_zstd_dcz_window_log() and sets THAT instead --
-     *     setting the plain zlcf->window_log here first would just be
-     *     overwritten one call later by the correct value.
+     * NOT superseded-by-cdict, unlike level above: ZSTD_resetCCtx_
+     * byAttachingCDict() and ZSTD_resetCCtx_byCopyingCDict() (zstd_compress.c,
+     * every version from the module's 1.4.0 floor through 1.5.7) both take
+     * windowLog = params.cParams.windowLog -- the CCtx's OWN value, restored
+     * immediately after copying the CDict's other cParams -- not from the
+     * CDict. Both also assert(windowLog != 0), i.e. they require the CCtx
+     * side to have set it. Leaving it unset here means
+     * ZSTD_CCtx_init_compressStream2() derives cParams (windowLog included)
+     * from cdict->compressionLevel's defaults instead (0 for a CDict built
+     * via ZSTD_createCDict_advanced()), silently dropping zstd_window_log's
+     * cap for every CDict-backed response -- exactly the C2/R1 regression
+     * the CDict construction comment below already fought off once. So this
+     * generic block must still fire for the zlcf->dict (CDict) mode; only
+     * the dcz branch (ctx->dcz_dict) replaces it with a more specific value,
+     * computed a few lines below via ngx_http_zstd_dcz_window_log() --
+     * setting the plain zlcf->window_log here first would just be
+     * overwritten one call later by that dcz-aware value, so dcz mode alone
+     * is skipped here.
      */
-    if (zlcf->window_log > 0 && zlcf->dict == NULL && ctx->dcz_dict == NULL) {
+    if (zlcf->window_log > 0 && ctx->dcz_dict == NULL) {
         if (ngx_http_zstd_set_param(r, cctx, ZSTD_c_windowLog,
                                     (int) zlcf->window_log, "windowLog")
             != NGX_OK)
@@ -4889,18 +4892,30 @@ ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
             /*
              * Bake the location's effective compression parameters into the
-             * CDict. ZSTD_CCtx_refCDict() lets a CDict's compression
-             * parameters supersede the CCtx's, so a CDict built with the
-             * simple ZSTD_createCDict() (level only) would silently override
-             * the windowLog that init_cctx sets — making zstd_window_log a
-             * non-cap whenever a dictionary is loaded (former audit C2 / R1).
-             * Build the CDict with ZSTD_createCDict_advanced() seeding
-             * windowLog from zstd_window_log so the baked params and the CCtx
-             * params agree and the window cap (and the zstd_max_cctx_memory
-             * estimate, computed from the same windowLog below) hold even with
-             * a dictionary. The advanced builder lives in libzstd's static
-             * API; on a non-static build fall back to the level-only CDict
-             * (window cap not honored with a dict — documented in README).
+             * CDict. ZSTD_CCtx_refCDict() lets a CDict's own
+             * ZSTD_compressionParameters supersede compressionLevel (and the
+             * other superseded-by-cdict parameters in that zstd.h block) set
+             * on the CCtx -- but NOT windowLog: ZSTD_resetCCtx_
+             * byAttachingCDict()/ZSTD_resetCCtx_byCopyingCDict() both restore
+             * windowLog from the CCtx's OWN params.cParams.windowLog right
+             * after copying the CDict's other cParams (init_cctx's windowLog
+             * comment has the exact source citation), and assert it is
+             * nonzero -- i.e. the CCtx side must have set it, every time, CDict
+             * or not. A CDict built with the simple ZSTD_createCDict() (level
+             * only, windowLog left at the level's own default) would then
+             * disagree with init_cctx's zlcf->window_log-derived cap: the
+             * FRAME uses windowLog from the CCtx side (correct), but this
+             * repo's own zstd_max_cctx_memory estimate and the CCtx ring-slot
+             * key both need to reason about the SAME windowLog the CDict's
+             * match tables were sized for (former audit C2 / R1). Build the
+             * CDict with ZSTD_createCDict_advanced() seeding windowLog from
+             * zstd_window_log so the CDict's tables, the CCtx's applied
+             * windowLog, and this module's own memory accounting all agree.
+             * The advanced builder lives in libzstd's static API; on a
+             * non-static build fall back to the level-only CDict (window cap
+             * still applies via init_cctx's CCtx-side set either way, but the
+             * CDict's own tables are then sized off the level default instead
+             * of zstd_window_log — documented in README).
              *
              * Long-distance matching is a separate CCtx frame parameter, not
              * part of ZSTD_compressionParameters, so refCDict does not override

--- a/src/ngx_http_zstd_probe_hooks.c
+++ b/src/ngx_http_zstd_probe_hooks.c
@@ -113,6 +113,15 @@ static ngx_uint_t  ngx_http_zstd_probe_refprefix_calls;
 static ngx_int_t   ngx_http_zstd_probe_fault_palloc_nth = -1;
 static ngx_uint_t  ngx_http_zstd_probe_palloc_calls;
 
+/*
+ * ZSTD_CCtx_setParameter() call counter. No fault, no arm -- see the header.
+ * Reset via GET /__probe?setparam_reset=1, mirroring the codec sites'
+ * "disarm zeroes the counter" convention closely enough that a driver
+ * bracketing one request looks the same shape as the codec-call-count
+ * scenario's reset_counters().
+ */
+static ngx_uint_t  ngx_http_zstd_probe_setparam_calls;
+
 static ngx_int_t ngx_http_zstd_probe_handler(ngx_http_request_t *r);
 
 
@@ -268,6 +277,32 @@ ngx_http_zstd_probe_palloc_count(void)
 
 
 /*
+ * Bump the setParameter call counter. Called once per
+ * ngx_http_zstd_set_param() invocation in init_cctx -- see the header for
+ * why this is a plain counter and not a fault site.
+ */
+void
+ngx_http_zstd_probe_note_setparam(void)
+{
+    ngx_http_zstd_probe_setparam_calls++;
+}
+
+
+ngx_uint_t
+ngx_http_zstd_probe_setparam_count(void)
+{
+    return ngx_http_zstd_probe_setparam_calls;
+}
+
+
+void
+ngx_http_zstd_probe_setparam_reset(void)
+{
+    ngx_http_zstd_probe_setparam_calls = 0;
+}
+
+
+/*
  * module_render hook: append this module's zone-independent counters to
  * the top-level "module" object. ngx_test_probe_render_module() has
  * already written the opening `,"module":{` before calling this hook, so
@@ -284,7 +319,8 @@ ngx_http_zstd_probe_module_render(u_char *buf, u_char *last)
                         ",\"codec_calls\":%ui"
                         ",\"codec_end_calls\":%ui"
                         ",\"refprefix_calls\":%ui"
-                        ",\"refprefix_armed\":%ui",
+                        ",\"refprefix_armed\":%ui"
+                        ",\"setparam_calls\":%ui",
                         ngx_http_zstd_probe_chain_links,
                         ngx_http_zstd_probe_bufs_allocated,
                         ngx_http_zstd_probe_palloc_calls,
@@ -294,7 +330,8 @@ ngx_http_zstd_probe_module_render(u_char *buf, u_char *last)
                         ngx_http_zstd_probe_fault_refprefix_nth < 0
                             ? 0
                             : (ngx_uint_t)
-                                ngx_http_zstd_probe_fault_refprefix_nth);
+                                ngx_http_zstd_probe_fault_refprefix_nth,
+                        ngx_http_zstd_probe_setparam_calls);
 
     if (ngx_http_zstd_probe_have_ctx) {
         buf = ngx_slprintf(buf, last,
@@ -391,6 +428,31 @@ ngx_http_zstd_probe_arm_refprefix(ngx_http_request_t *r)
 
     ngx_http_zstd_probe_fault_refprefix_nth = nth;
     ngx_http_zstd_probe_refprefix_calls = 0;
+}
+
+
+/*
+ * Reset the setParameter counter from the request query string
+ * (?setparam_reset=1). No fault to arm here, so this is a bare reset
+ * rather than routed through fault_set_global -- same reasoning as
+ * arm_refprefix() above being module-local because the generic testkit
+ * predates this counter.
+ */
+static void
+ngx_http_zstd_probe_arm_setparam_reset(ngx_http_request_t *r)
+{
+    ngx_str_t  value;
+
+    if (ngx_http_arg(r, (u_char *) "setparam_reset",
+                     sizeof("setparam_reset") - 1, &value)
+        != NGX_OK)
+    {
+        return;
+    }
+
+    if (value.len == 1 && value.data[0] == '1') {
+        ngx_http_zstd_probe_setparam_reset();
+    }
 }
 
 
@@ -533,6 +595,7 @@ ngx_http_zstd_probe_handler(ngx_http_request_t *r)
      * comment.
      */
     ngx_http_zstd_probe_arm_refprefix(r);
+    ngx_http_zstd_probe_arm_setparam_reset(r);
     (void) ngx_test_probe_arm(NULL, &r->args);
 
     /*

--- a/src/ngx_http_zstd_probe_hooks.c
+++ b/src/ngx_http_zstd_probe_hooks.c
@@ -119,6 +119,18 @@ static ngx_uint_t  ngx_http_zstd_probe_palloc_calls;
  * "disarm zeroes the counter" convention closely enough that a driver
  * bracketing one request looks the same shape as the codec-call-count
  * scenario's reset_counters().
+ *
+ * PROCESS GLOBAL, DELIBERATELY, same reasoning and same constraint as the
+ * fault-site counters above (see the "PROCESS GLOBALS, DELIBERATELY"
+ * comment on ngx_http_zstd_probe_fault_codec_nth): the request that resets
+ * this counter and the later request whose ZSTD_CCtx_setParameter() calls
+ * it counts must land in the SAME worker, so every scenario reading it
+ * (setparam-call-count, setparam-call-count-nodict) sets
+ * `worker_processes 1` in its nginx.conf. A multi-worker conf would read
+ * whichever worker happened to answer the GET, not necessarily the one
+ * that served the measured request, and the counter would silently mix
+ * traffic from other requests in that worker instead of counting the one
+ * response the driver is measuring.
  */
 static ngx_uint_t  ngx_http_zstd_probe_setparam_calls;
 

--- a/src/ngx_http_zstd_probe_hooks.h
+++ b/src/ngx_http_zstd_probe_hooks.h
@@ -210,6 +210,25 @@ ngx_http_zstd_probe_refprefix_outcome_e
 ngx_uint_t ngx_http_zstd_probe_palloc_should_fail(void);
 ngx_uint_t ngx_http_zstd_probe_palloc_count(void);
 
+
+/*
+ * ZSTD_CCtx_setParameter() call counter -- observation only, no fault.
+ *
+ * Bumped once per call from ngx_http_zstd_set_param() in init_cctx,
+ * counting from process start (not from an arm: there is nothing to arm
+ * here, only a count to read). Exists to pin the per-mode setParameter
+ * call count this module makes when configuring a request's CCtx --
+ * skipping a superseded-by-CDict parameter must show up as a lower count
+ * for that mode, and a mutation that re-adds the redundant set must show
+ * up as a higher one. ngx_http_zstd_probe_setparam_count() reads it;
+ * ngx_http_zstd_probe_setparam_reset() zeroes it so a driver can bracket
+ * exactly one request's calls the same way the codec sites are bracketed
+ * by their arm-relative reset.
+ */
+void       ngx_http_zstd_probe_note_setparam(void);
+ngx_uint_t ngx_http_zstd_probe_setparam_count(void);
+void       ngx_http_zstd_probe_setparam_reset(void);
+
 #endif /* NGX_TEST_HARNESS */
 
 #endif /* NGX_HTTP_ZSTD_PROBE_HOOKS_H_INCLUDED_ */


### PR DESCRIPTION
When you swap in a pre-mixed cocktail, telling the bartender your usual proportions again is pointless — the mix already decided that. That is what `init_cctx` was doing on a trained-dictionary response: it dialed in the compression level and window size, then handed the context to a dictionary that had those exact settings baked in already, silently throwing the first set away.

In code terms: `ZSTD_CCtx_refCDict()` unconditionally overrides `ZSTD_c_compressionLevel` and `ZSTD_c_windowLog` from the CDict's own baked-in `ZSTD_compressionParameters` (zstd.h: "these parameters are superseded by the parameters used to construct the ZSTD_CDict"). `ngx_http_zstd_filter_init_cctx()` set both before the CDict branch ran, and separately set `ZSTD_c_windowLog` twice on the dcz path — a generic set from `zlcf->window_log`, then the dcz-aware value from `ngx_http_zstd_dcz_window_log()` one call later.

**Severity:** None (perf/cleanliness — no behavior change; output is byte-identical)

## What changed

- Skip the `level` set when `ZSTD_CCtx_refCDict()` is actually going to run: `zlcf->dict != NULL` AND the request did NOT negotiate dcz. `zstd_dict_file` is http{}-context, so a dcz-negotiated request can have both `ctx->dcz_dict` and `zlcf->dict` non-NULL — the dcz branch always wins that mutual exclusion (refPrefix only, never refCDict), so gating on `zlcf->dict` alone would wrongly skip `level` on such a request even though refCDict never runs for it.
- Skip the generic `windowLog` set whenever either dictionary branch is going to set its own value (CDict: baked in via `ZSTD_createCDict_advanced()`, already seeded from `zlcf->window_log`; dcz: the dcz-aware `wlog` computed a few lines later).
- LDM, `targetCBlockSize` and `checksumFlag(dcz)` are untouched — none of them are in zstd.h's superseded-by-cdict block, so they keep being set exactly as before.

## Testing

New `setparam_calls` probe counter (`ngx_http_zstd_probe_note_setparam()`, bumped once per `ngx_http_zstd_set_param()` call) plus two harness scenarios:

- `setparam-call-count`: cdict arm pins **1** call (LDM only — level and windowLog skipped), dcz arm pins **4** (level, windowLog(dcz), LDM, checksumFlag(dcz) — none superseded under refPrefix).
- `setparam-call-count-nodict`: **3** calls (level, windowLog, LDM), the reference count nothing is superseded from. Needs its own conf: `zstd_dict_file` is http{}-scoped, so any conf that sets it gives every enabled location a non-NULL `zlcf->dict`.

Mutation check: reverting the `level` skip condition to unconditional moved the cdict oracle from 1 → 2 while the dcz oracle stayed at 4, confirming the guard is keyed on "will refCDict actually run", not "does this location have a dictionary configured".

Output-identity: built the harness .so before/after, served the same CDict + dcz + no-dict fixtures through both, `cmp`'d the raw compressed bytes — identical in every mode. `ci/t/01-static.t` TEST 19 (trained-dict regression) and the full `ci/t/03-dcz.t` (163 tests) pass unchanged.
