### PR TITLE
ci: install gcc-multilib so the 32-bit off_t fixtures actually run

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -163,6 +163,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
+            gcc-multilib \
             libpcre2-dev \
             zlib1g-dev \
             shellcheck \
@@ -258,6 +259,12 @@ jobs:
           bash "$GITHUB_WORKSPACE"/ci/tools/test_cctx_profile_pack.sh
 
       - name: dcz window-log unit fixture (clamps + range)
+        env:
+          # gcc-multilib is installed above, so a missing -m32 toolchain
+          # here means the runner image regressed, not that multilib is
+          # optionally absent -- fail loudly instead of silently losing
+          # the 32-bit off_t lens (see the scripts' own comments).
+          REQUIRE_M32: "1"
         run: |
           # ngx_http_zstd_dcz_window_log() is the single source of truth for
           # a value derived in TWO places that must never disagree: the CCtx

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -144,7 +144,7 @@ jobs:
           # save" (a warning, so CI stays green while nothing is ever cached).
           # Only the .deb files are worth caching anyway.
           path: ${{ runner.temp }}/apt-archives/*.deb
-          key: apt-validation-${{ runner.os }}-shellcheck-cppcheck-clang-tools-nginx-dev
+          key: apt-validation-${{ runner.os }}-shellcheck-cppcheck-clang-tools-nginx-dev-gcc-multilib
           restore-keys: apt-validation-${{ runner.os }}-
 
       - name: Install dependencies

--- a/ci/tools/test_dcz_window_log_unit.sh
+++ b/ci/tools/test_dcz_window_log_unit.sh
@@ -15,6 +15,11 @@
 # dependency are extracted VERBATIM by line range and compiled standalone.
 #
 # No nginx tree and no libzstd needed: pure C, self-contained.
+#
+# REQUIRE_M32: unset/"0"/""/false/no/off (case insensitive) keeps the
+# default local-dev behaviour -- SKIP with exit 0 when no -m32 toolchain is
+# present. Any other value (1/true/yes/on, case insensitive, or anything
+# else non-empty) makes a missing -m32 toolchain a hard FAILURE instead.
 set -euo pipefail
 
 # ci/tools/ -> ci/ -> repo root.
@@ -112,9 +117,16 @@ echo "OK: dcz window-log unit fixture (extracted from current $SRC)"
 # host has off_t == size_t width and cannot reach either defect -- -m32 with
 # _FILE_OFFSET_BITS=64 is what reproduces it, so it is not optional coverage.
 # Skipped (not failed) when the runner has no 32-bit toolchain at all --
-# UNLESS REQUIRE_M32=1, in which case a missing toolchain is a hard failure
-# rather than a silent skip (set in CI so a runner image that drops
-# multilib loses this lens loudly, not quietly).
+# UNLESS REQUIRE_M32 is set to a truthy value (1/true/yes/on, case
+# insensitive; anything else non-empty and not "0" also counts as set), in
+# which case a missing toolchain is a hard failure rather than a silent
+# skip (set in CI so a runner image that drops multilib loses this lens
+# loudly, not quietly).
+require_m32="${REQUIRE_M32:-0}"
+case "${require_m32,,}" in
+    0 | "" | false | no | off) require_m32_set=0 ;;
+    *) require_m32_set=1 ;;
+esac
 if "$CC" -m32 -x c -o /dev/null - <<<'int main(void){return 0;}' \
     >/dev/null 2>&1
 then
@@ -122,8 +134,8 @@ then
         -o "$OUT/dcz_window_log_unit_ilp32" "$OUT/test_dcz_window_log_unit.c"
     "$OUT/dcz_window_log_unit_ilp32"
     echo "OK: dcz window-log unit fixture (ILP32 + LFS, off_t wider than size_t)"
-elif [ "${REQUIRE_M32:-0}" = "1" ]; then
-    echo "FAIL: no -m32 toolchain available and REQUIRE_M32=1; ILP32/LFS pass cannot run" >&2
+elif [ "$require_m32_set" = "1" ]; then
+    echo "FAIL: no -m32 toolchain available and REQUIRE_M32 is set; ILP32/LFS pass cannot run" >&2
     exit 1
 else
     echo "SKIP: no -m32 toolchain available; ILP32/LFS pass not run" >&2

--- a/ci/tools/test_dcz_window_log_unit.sh
+++ b/ci/tools/test_dcz_window_log_unit.sh
@@ -111,7 +111,10 @@ echo "OK: dcz window-log unit fixture (extracted from current $SRC)"
 # in ngx_http_zstd_dcz_window_log(). A plain native build on this (64-bit)
 # host has off_t == size_t width and cannot reach either defect -- -m32 with
 # _FILE_OFFSET_BITS=64 is what reproduces it, so it is not optional coverage.
-# Skipped (not failed) when the runner has no 32-bit toolchain at all.
+# Skipped (not failed) when the runner has no 32-bit toolchain at all --
+# UNLESS REQUIRE_M32=1, in which case a missing toolchain is a hard failure
+# rather than a silent skip (set in CI so a runner image that drops
+# multilib loses this lens loudly, not quietly).
 if "$CC" -m32 -x c -o /dev/null - <<<'int main(void){return 0;}' \
     >/dev/null 2>&1
 then
@@ -119,6 +122,9 @@ then
         -o "$OUT/dcz_window_log_unit_ilp32" "$OUT/test_dcz_window_log_unit.c"
     "$OUT/dcz_window_log_unit_ilp32"
     echo "OK: dcz window-log unit fixture (ILP32 + LFS, off_t wider than size_t)"
+elif [ "${REQUIRE_M32:-0}" = "1" ]; then
+    echo "FAIL: no -m32 toolchain available and REQUIRE_M32=1; ILP32/LFS pass cannot run" >&2
+    exit 1
 else
     echo "SKIP: no -m32 toolchain available; ILP32/LFS pass not run" >&2
 fi

--- a/ci/tools/test_max_length_cap_unit.sh
+++ b/ci/tools/test_max_length_cap_unit.sh
@@ -91,7 +91,9 @@ echo "OK: max_length cap unit fixture (extracted from current $SRC)"
 # off_t (glibc's legacy 32-bit off_t), which is what this cap's comment
 # describes and what reproduces the cast losing bits. Not optional
 # coverage; skipped (not failed) when the runner has no 32-bit toolchain
-# at all.
+# at all -- UNLESS REQUIRE_M32=1, in which case a missing toolchain is a
+# hard failure rather than a silent skip (set in CI so a runner image that
+# drops multilib loses this lens loudly, not quietly).
 if "$CC" -m32 -x c -o /dev/null - <<<'int main(void){return 0;}' \
     >/dev/null 2>&1
 then
@@ -99,6 +101,9 @@ then
         -o "$OUT/max_length_cap_unit_32off" "$OUT/test_max_length_cap_unit.c"
     "$OUT/max_length_cap_unit_32off"
     echo "OK: max_length cap unit fixture (32-bit off_t, bytes_in > INT32_MAX)"
+elif [ "${REQUIRE_M32:-0}" = "1" ]; then
+    echo "FAIL: no -m32 toolchain available and REQUIRE_M32=1; 32-bit off_t pass cannot run" >&2
+    exit 1
 else
     echo "SKIP: no -m32 toolchain available; 32-bit off_t pass not run" >&2
 fi

--- a/ci/tools/test_max_length_cap_unit.sh
+++ b/ci/tools/test_max_length_cap_unit.sh
@@ -24,6 +24,11 @@
 # production.
 #
 # No nginx tree and no libzstd needed: pure C, self-contained.
+#
+# REQUIRE_M32: unset/"0"/""/false/no/off (case insensitive) keeps the
+# default local-dev behaviour -- SKIP with exit 0 when no -m32 toolchain is
+# present. Any other value (1/true/yes/on, case insensitive, or anything
+# else non-empty) makes a missing -m32 toolchain a hard FAILURE instead.
 set -euo pipefail
 
 # ci/tools/ -> ci/ -> repo root.
@@ -91,9 +96,16 @@ echo "OK: max_length cap unit fixture (extracted from current $SRC)"
 # off_t (glibc's legacy 32-bit off_t), which is what this cap's comment
 # describes and what reproduces the cast losing bits. Not optional
 # coverage; skipped (not failed) when the runner has no 32-bit toolchain
-# at all -- UNLESS REQUIRE_M32=1, in which case a missing toolchain is a
-# hard failure rather than a silent skip (set in CI so a runner image that
-# drops multilib loses this lens loudly, not quietly).
+# at all -- UNLESS REQUIRE_M32 is set to a truthy value (1/true/yes/on,
+# case insensitive; anything else non-empty and not "0" also counts as
+# set), in which case a missing toolchain is a hard failure rather than a
+# silent skip (set in CI so a runner image that drops multilib loses this
+# lens loudly, not quietly).
+require_m32="${REQUIRE_M32:-0}"
+case "${require_m32,,}" in
+    0 | "" | false | no | off) require_m32_set=0 ;;
+    *) require_m32_set=1 ;;
+esac
 if "$CC" -m32 -x c -o /dev/null - <<<'int main(void){return 0;}' \
     >/dev/null 2>&1
 then
@@ -101,8 +113,8 @@ then
         -o "$OUT/max_length_cap_unit_32off" "$OUT/test_max_length_cap_unit.c"
     "$OUT/max_length_cap_unit_32off"
     echo "OK: max_length cap unit fixture (32-bit off_t, bytes_in > INT32_MAX)"
-elif [ "${REQUIRE_M32:-0}" = "1" ]; then
-    echo "FAIL: no -m32 toolchain available and REQUIRE_M32=1; 32-bit off_t pass cannot run" >&2
+elif [ "$require_m32_set" = "1" ]; then
+    echo "FAIL: no -m32 toolchain available and REQUIRE_M32 is set; 32-bit off_t pass cannot run" >&2
     exit 1
 else
     echo "SKIP: no -m32 toolchain available; 32-bit off_t pass not run" >&2


### PR DESCRIPTION
## Problem

`ci/tools/test_max_length_cap_unit.sh` and `ci/tools/test_dcz_window_log_unit.sh`
each carry a second `-m32` compile pass that is the only lens able to observe
the 32-bit-`off_t` defect class (their own in-source comments say this
explicitly — "not optional coverage"). Both scripts print `SKIP: ...` to
stderr and exit 0 when no 32-bit toolchain is present. `ubuntu-latest` does
not ship `gcc-multilib` by default, and the `validation` job's apt install
list did not include it.

## Verified, not assumed

Checked the actual CI log rather than assuming: the `Validation` job on PR
#227 (run `33173213130`, job `98855203929`, 2026-08-28) prints, for both
scripts:

```
SKIP: no -m32 toolchain available; ILP32/LFS pass not run
SKIP: no -m32 toolchain available; 32-bit off_t pass not run
```

So on real CI the 32-bit-`off_t` lens has been nominal (job green) but not
actually exercised. No run of `build-test.yml` since `test_max_length_cap_unit.sh`
was introduced (in #227) has run with a 32-bit toolchain present.

## Change

1. Add `gcc-multilib` to the `validation` job's `apt-get install -y` list.
2. Add an opt-in `REQUIRE_M32=1` env var to both scripts: when set, a missing
   `-m32` toolchain is a hard `FAIL` (exit 1) instead of a silent `SKIP`. Set
   `REQUIRE_M32: "1"` on the CI step that runs these scripts, so a future
   runner-image change that drops multilib fails the build loudly instead of
   silently losing this lens again. Default (unset) behaviour is unchanged —
   local contributors without a 32-bit toolchain still get a clean skip.

## Local verification (this host has a working -m32 toolchain)

Both scripts, real 32-bit pass executing:

```
$ bash ci/tools/test_dcz_window_log_unit.sh
...
OK: dcz window-log unit fixture (ILP32 + LFS, off_t wider than size_t)

$ bash ci/tools/test_max_length_cap_unit.sh
...
OK: max_length cap unit fixture (32-bit off_t, bytes_in > INT32_MAX)
```

Simulated a multilib-free runner with a `CC` wrapper that rejects `-m32`:

```
$ CC=./fakecc REQUIRE_M32=1 bash ci/tools/test_dcz_window_log_unit.sh
...
FAIL: no -m32 toolchain available and REQUIRE_M32=1; ILP32/LFS pass cannot run
exit=1

$ CC=./fakecc bash ci/tools/test_dcz_window_log_unit.sh
...
SKIP: no -m32 toolchain available; ILP32/LFS pass not run
exit=0
```

(same pattern confirmed for `test_max_length_cap_unit.sh`.)

## Lint

`review-lint.sh --diff HEAD`: all linters clean except `shfmt` (advisory,
flags this repo's existing 4-space convention — not a real issue) and
pre-existing `yamllint` long-line warnings on lines this diff did not touch.
No `== coverage gap ==` block was produced.

## Not done / out of scope

No fuzzing, valgrind, or soak/stress runs, per scope. No change to any other
apt install list or job.