### PR TITLE
fix: guard output-side zero-delta pointer advance for UB symmetry

### DIFF
--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -2446,7 +2446,20 @@ ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
         ctx->in_buf->pos += ctx->buffer_in.pos - pos_in;
     }
 
-    ctx->out_buf->last += ctx->buffer_out.pos - pos_out;
+    /*
+     * Same zero-delta guard as the input side above. Here ctx->out_buf and
+     * ctx->out_buf->last are both provably non-NULL -- get_buf() returns
+     * NGX_OK only after the explicit NULL check, and compress() has the
+     * single caller in the body-filter loop -- so this is defensive
+     * symmetry, not a reachable fix. It keeps the `NULL + 0` UB out of the
+     * expression if ->last ever becomes NULL-able the way in_buf->pos is.
+     * Note it does NOT guard a NULL ctx->out_buf: that would fault on the
+     * dereference regardless of the delta.
+     */
+    if (ctx->buffer_out.pos != pos_out) {
+        ctx->out_buf->last += ctx->buffer_out.pos - pos_out;
+    }
+
     ctx->redo = 0;
 
     /* PR #49: State machine logic for action transitions */


### PR DESCRIPTION
## Summary

`ngx_http_zstd_filter_compress()` advances two pointers after each
`ZSTD_compressStream2()` call. The input side already guards the
zero-delta case (comment explains: a data-less carrier link makes the
delta provably 0, but `NULL + 0` is still UB — gcc's UBSan tolerates
it, clang's aborts). The output-side advance one line below was
unconditional:

```c
if (ctx->buffer_in.pos != pos_in) {
    ctx->in_buf->pos += ctx->buffer_in.pos - pos_in;
}

ctx->out_buf->last += ctx->buffer_out.pos - pos_out;   // unguarded
```

This PR applies the same zero-delta guard to the output side, matching
the input side's style and rationale.

## Verified vs assumed

**Verified independently** (read the code, did not just trust the
ledger note):
- The output side genuinely had no guard before this change.
- The input side genuinely has the guard, with the stated rationale
  (comment directly above it, matches word for word).
- `ctx->out_buf` is genuinely non-NULL whenever `compress()` runs
  today: `ngx_http_zstd_filter_get_buf()` returns `NGX_ERROR` if
  `ctx->out_buf == NULL` after allocation (module source, `get_buf`
  around line 3022-3024), and the body filter only calls `compress()`
  after `get_buf()` returns something other than `NGX_ERROR`/
  `NGX_DECLINED` (body filter loop, ~line 2190-2200). So this is
  confirmed **not reachable today** — defensive symmetry, not a live
  bug.

**Not claimed:** no black-box test can observe this guard, since it
protects against a state that cannot currently occur. No test was
added that pretends to exercise it.

## Testing

- Full test suite (release build, `--add-module`, nginx 1.31.4):
  `perl ci/t/00-filter.t` — **1335/1335 pass**.
- ASan+UBSan build (same flags as `.github/workflows/asan.yml`'s
  static `--add-module` job, plus the optional HTTP modules the test
  suite needs: `--with-http_sub_module --with-http_auth_request_module
  --with-http_addition_module --with-http_gzip_static_module
  --with-http_realip_module --with-http_stub_status_module`):
  clean `-Werror` build, then `perl ci/t/00-filter.t` — **1335/1335
  pass**, no sanitizer report attributable to this change.
  - One pre-existing, unrelated UBSan finding was hit in nginx core
    itself (`src/core/ngx_string.c:586`, `ngx_vslprintf`, null `src`
    with `len == 0` under `log_level debug`) — reproduced identically
    on unmodified master with this change stashed, so it predates this
    PR and is orthogonal to the zstd module. Confirmed it is not a
    regression; not otherwise addressed here.
  - To let the full suite run to completion despite that pre-existing
    abort, the local UBSan build used `-fsanitize-recover=undefined`
    instead of CI's `-fno-sanitize-recover=undefined` (a local-only
    tweak, not shipped in the PR); no other change to the sanitizer
    configuration.
- No fuzzing, Valgrind, or soak run performed locally per policy —
  remote CI carries those.

## Scope

Minimal, single-hunk diff (comment + guarded add), matching the
existing input-side pattern exactly. No refactor of surrounding logic.