### PR TITLE
style: log-text and doc-comment sweep across both modules

### DIFF
--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -3052,14 +3052,14 @@ ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
     /* Validate buffer pointers to detect corruption before using in ZSTD */
     if (ctx->out_buf->end < ctx->out_buf->start) {
         ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
-                      "corrupted output buffer: end (%p) < start (%p)",
+                      "zstd: corrupted output buffer: end (%p) < start (%p)",
                       ctx->out_buf->end, ctx->out_buf->start);
         return NGX_ERROR;
     }
 
     if (ctx->out_buf->end < ctx->out_buf->last) {
         ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
-                      "corrupted output buffer: end (%p) < last (%p)",
+                      "zstd: corrupted output buffer: end (%p) < last (%p)",
                       ctx->out_buf->end, ctx->out_buf->last);
         return NGX_ERROR;
     }
@@ -6296,28 +6296,6 @@ ngx_http_zstd_check_bufs_product(ngx_conf_t *cf, ngx_bufs_t *bufs,
 
 
 /*
- * Wraps nginx's own ngx_conf_set_bufs_slot() rather than reimplementing
- * argument parsing: nginx's parse/zero rejection and its exact error text
- * for those cases are preserved verbatim, and this wrapper only adds the
- * overflow check on the ngx_bufs_t that parse produced -- fast, hard
- * feedback on an unrepresentable explicit value at the earliest possible
- * point. It deliberately does NOT run the advisory/hard-cap tiers
- * (advise=0): the post-merge check below (ngx_http_zstd_merge_loc_conf())
- * is the single owner of those, because it is the only point that also
- * covers a value this location never wrote itself but inherited from an
- * outer block, or the module's own computed default -- neither of which
- * runs through this slot handler at all. It is also the only point where
- * conf->bufs_unsafe is guaranteed to already hold its final, merged
- * value: "zstd_buffers_unsafe" can appear before OR after "zstd_buffers"
- * in the same block, or at an outer level entirely, and this slot fires
- * the moment "zstd_buffers" is parsed -- reading bufs_unsafe here could
- * see it still unset. Running the hard-cap tier here too would also
- * double-report it for the common case of an explicit large value that
- * survives to the merge unchanged.
- */
-
-
-/*
  * Validate value as a single RFC 9110 field-name token. Per RFC 9110 §5.1:
  *   tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-"
  *         / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
@@ -6475,6 +6453,26 @@ ngx_http_zstd_set_enable_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 }
 
 
+/*
+ * Wraps nginx's own ngx_conf_set_bufs_slot() rather than reimplementing
+ * argument parsing: nginx's parse/zero rejection and its exact error text
+ * for those cases are preserved verbatim, and this wrapper only adds the
+ * overflow check on the ngx_bufs_t that parse produced -- fast, hard
+ * feedback on an unrepresentable explicit value at the earliest possible
+ * point. It deliberately does NOT run the advisory/hard-cap tiers
+ * (advise=0): the post-merge check in ngx_http_zstd_merge_loc_conf()
+ * is the single owner of those, because it is the only point that also
+ * covers a value this location never wrote itself but inherited from an
+ * outer block, or the module's own computed default -- neither of which
+ * runs through this slot handler at all. It is also the only point where
+ * conf->bufs_unsafe is guaranteed to already hold its final, merged
+ * value: "zstd_buffers_unsafe" can appear before OR after "zstd_buffers"
+ * in the same block, or at an outer level entirely, and this slot fires
+ * the moment "zstd_buffers" is parsed -- reading bufs_unsafe here could
+ * see it still unset. Running the hard-cap tier here too would also
+ * double-report it for the common case of an explicit large value that
+ * survives to the merge unchanged.
+ */
 static char *
 ngx_http_zstd_set_bufs_slot(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {

--- a/src/ngx_http_zstd_static_module.c
+++ b/src/ngx_http_zstd_static_module.c
@@ -86,6 +86,11 @@
  * fine with the zstd CLI yet fails in every browser. Matches the
  * filter module's dcz window cap, which exists for the same client
  * guarantee.
+ *
+ * Changing this value means editing operator-visible prose too: the
+ * NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG log message spells out both
+ * "8 MB" and the equivalent "window log <= 23" in words. Neither is
+ * derived from this constant, so both go stale silently.
  */
 #define NGX_HTTP_ZSTD_STATIC_MAX_WINDOW  (8 * 1024 * 1024)
 
@@ -1191,8 +1196,8 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
 
             if (frames >= NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES) {
                 ngx_log_error(NGX_LOG_ERR, log, 0,
-                              "zstd static: \"%s\" has more than %ui "
-                              "leading skippable frames — declining "
+                              "zstd static: \"%s\" has at least %ui "
+                              "leading skippable frames -- declining "
                               "rather than searching further for the "
                               "first regular frame",
                               path.data,
@@ -1229,7 +1234,7 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
                 if (of.is_directio) {
                     ngx_log_error(NGX_LOG_ERR, log, ngx_errno,
                                   "zstd static: %uz-byte aligned probe on "
-                                  "directio file \"%s\" returned %z — "
+                                  "directio file \"%s\" returned %z -- "
                                   "declining; check directio_alignment "
                                   "against the device geometry",
                                   align, path.data, n);
@@ -1280,11 +1285,16 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
                 goto probe_done;
 
             case NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG:
+                /*
+                 * "8 MB" and "window log <= 23" below are prose, not
+                 * derived: they must be updated by hand whenever
+                 * NGX_HTTP_ZSTD_STATIC_MAX_WINDOW changes.
+                 */
                 ngx_log_error(NGX_LOG_ERR, log, 0,
                               "zstd static: \"%s\" declares a %uL-byte "
                               "decompression window, above the 8 MB limit "
                               "browsers enforce for Content-Encoding: zstd "
-                              "(RFC 8878) — declining so a fallback "
+                              "(RFC 8878) -- declining so a fallback "
                               "encoding is used; recompress with a window "
                               "log <= 23 (streaming encoders default to "
                               "the compression level's window when not "


### PR DESCRIPTION
## TL;DR

**Severity:** Cosmetic. No behaviour change.

When this module refuses to serve a compressed file, it writes a line to the
error log explaining why. Four of those lines were slightly wrong: one claimed
a file had "more than four" of something when it trips at exactly four, three
held a character that turns to garbage in log viewers expecting plain text, and
two lacked the tag saying which module they came from.

The diff is comments and string literals only.

## Log text

The two `"corrupted output buffer"` calls in the filter module were the only
`ngx_log_error()` sites in the file without the `"zstd: "` prefix every other
call uses, so those two alerts were the ones you could not grep for by module.

Three format strings in the static module carried a literal U+2014 em dash.
Legal C, but nginx core keeps error-log text strictly ASCII, and a UTF-8
sequence renders as mojibake in any aggregator assuming Latin-1. Replaced with
`--`; those three were the complete set, and the ~50 others in the file are all
in comments.

The skippable-frame bound had a real contradiction. The guard is
`frames >= NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES` (4), but the message said the
file "has more than %ui" leading frames while printing that same constant, so
at exactly four it fired and then denied it had. Now "has at least %ui", with
the predicate untouched.

## Comments

The doc comment for `ngx_http_zstd_set_bufs_slot()` sat ~180 lines above its
function, directly above `ngx_http_zstd_validate_field_name_token()`, which is
a good way to learn the wrong thing about a function you are reading for the
first time. Moved down. It cited "the post-merge check below" in
`ngx_http_zstd_merge_loc_conf()`, which is above both the old and new spots, so
that direction word is gone rather than inverted.

The window-too-big message spells "8 MB" and "window log <= 23" in prose while
`NGX_HTTP_ZSTD_STATIC_MAX_WINDOW` is what the code tests, so it rots silently
if the constant moves. I tied the ends with paired comments instead of
formatting the value: the "window log <= 23" half needs a log2 to derive, and
`ci/t/01-static.t` asserts the text verbatim.

## Two rows dropped instead of fixed

Neither survived contact with the source. The reported duplicate nested
`#if defined(ZSTD_STATIC_LINKING_ONLY) && ZSTD_VERSION_NUMBER >= 10400` does
not exist; all four occurrences sit at preprocessor nesting depth 0 as sibling
regions. The `ngx_http_zstd_dcz_negotiate()` doc comment is not misplaced
either: the comment above `ngx_http_zstd_dcz_decode_digest()` documents
`decode_digest` correctly, and the row misread two stacked blocks.

## Testing

Clean build under `-W -Wall -Wpointer-arith -Werror`. Unit 45/45; `00-filter`
1335/1335, `01-static` 756/756, `02-conf-warn` 88/88, `03-dcz` 163/163.

The reworded strings are the risk, since Test::Nginx matches substrings and a
message can keep passing while no longer covering what it meant to. Every
asserted fragment survives verbatim, and the em dashes sat in spans no
assertion reads. No-behaviour-change is checked, not asserted: preprocessing
both revisions with string literals normalized to a placeholder gives
byte-identical token streams.

`ci/t/01-static.t:1267` asserts the bare fragment `leading skippable frames`,
which never covered the operator word and passes either way. Predates this
diff, filed rather than fixed.
