### PR TITLE
style: name magic numbers, correct stale docs, const-qualify read-only params

### DIFF
--- a/ci/fuzz/ngx_shim.h
+++ b/ci/fuzz/ngx_shim.h
@@ -38,6 +38,10 @@ typedef unsigned char u_char;
  * exceed NGX_HTTP_ZSTD_SHA256_DIGEST_LEN. */
 #define NGX_HTTP_ZSTD_DCZ_DECODE_BUF_LEN  48
 
+/* src/ngx_http_zstd_filter_module.c: padded base64 length of a 32-byte
+ * digest, the length ceiling dcz_decode_digest() rejects above. */
+#define NGX_HTTP_ZSTD_DCZ_DIGEST_B64_LEN  44
+
 typedef struct {
     size_t  len;
     u_char *data;

--- a/ci/t/01-static.t
+++ b/ci/t/01-static.t
@@ -1264,7 +1264,7 @@ Accept-Encoding: zstd
 too long origin
 --- error_code: 200
 --- error_log
-leading skippable frames
+has at least 4 leading skippable frames
 
 
 

--- a/ci/tools/test_dcz_window_log_unit.sh
+++ b/ci/tools/test_dcz_window_log_unit.sh
@@ -64,6 +64,12 @@ if [ -z "$MIN_LINE" ]; then
     echo "FAIL: could not locate NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG in $SRC" >&2
     exit 1
 fi
+GUESS_LINE="$(grep -n '^#define NGX_HTTP_ZSTD_UNKNOWN_SIZE_GUESS' "$SRC" \
+              | head -1 | cut -d: -f1)"
+if [ -z "$GUESS_LINE" ]; then
+    echo "FAIL: could not locate NGX_HTTP_ZSTD_UNKNOWN_SIZE_GUESS in $SRC" >&2
+    exit 1
+fi
 
 # --- ngx_http_zstd_dcz_window_log() (the function under test) ------------
 DCZ_SIG="$(grep -n '^ngx_http_zstd_dcz_window_log(size_t dict_len' "$SRC" \
@@ -79,10 +85,12 @@ read -r DCZ_START DCZ_END < <(extract "$((DCZ_SIG - 1))" "dcz_window_log")
     echo " * from $SRC:"
     echo " *   ceil_log2      lines ${CEIL_START}-${CEIL_END}"
     echo " *   window cap     line  ${CAP_LINE}"
+    echo " *   size guess     line  ${GUESS_LINE}"
     echo " *   dcz_window_log lines ${DCZ_START}-${DCZ_END}"
     echo " * Do not edit; re-run the script to regenerate. */"
     sed -n "${CAP_LINE}p" "$SRC"
     sed -n "${MIN_LINE}p" "$SRC"
+    sed -n "${GUESS_LINE}p" "$SRC"
     echo
     sed -n "${CEIL_START},${CEIL_END}p" "$SRC"
     echo
@@ -94,6 +102,7 @@ read -r DCZ_START DCZ_END < <(extract "$((DCZ_SIG - 1))" "dcz_window_log")
 for marker in 'ngx_http_zstd_ceil_log2(size_t x)' \
               'NGX_HTTP_ZSTD_DCZ_MAX_WINDOW_LOG' \
               'NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG' \
+              'NGX_HTTP_ZSTD_UNKNOWN_SIZE_GUESS' \
               'ngx_http_zstd_dcz_window_log(size_t dict_len' \
               'budget_window_cap'; do
     if ! grep -q "$marker" "$OUT/generated_dcz_window_log.inc"; then

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -732,9 +732,9 @@ typedef struct {
  */
 #define NGX_HTTP_ZSTD_LDM_WINDOWLOG      27
 #define NGX_HTTP_ZSTD_LDM_MINMATCH       64
-#define NGX_HTTP_ZSTD_LDM_BUCKETSIZELOG  3
 /* libzstd's own default: hash log trails the window log by 7. */
 #define NGX_HTTP_ZSTD_LDM_HASHLOG_OFFSET 7
+#define NGX_HTTP_ZSTD_LDM_BUCKETSIZELOG  3
 
 
 static ngx_http_output_header_filter_pt  ngx_http_next_header_filter;

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -171,6 +171,27 @@ ngx_http_zstd_dcz_dict_hash(const u_char *data, size_t len,
 #define NGX_HTTP_ZSTD_MAX_DICT_SIZE  (10 * 1024 * 1024)  /* 10 MB limit */
 
 /*
+ * Stand-in body size when the response length is unknown, used only to size
+ * the CCtx window estimate -- see the ring-key discussion below.
+ */
+#define NGX_HTTP_ZSTD_UNKNOWN_SIZE_GUESS  (1024 * 1024)
+
+/*
+ * ZSTD_compressBound() covers the compressed payload only; pad it by
+ * _FRAME_SLACK for libzstd's frame and block headers, and never size an
+ * output buffer below _MIN so a tiny or empty body still gets a buffer the
+ * frame overhead fits inside.
+ */
+#define NGX_HTTP_ZSTD_BOUND_FRAME_SLACK  64
+#define NGX_HTTP_ZSTD_BOUND_MIN          256
+
+/*
+ * Highest response status the filter will encode. 3xx and above carry no
+ * body worth encoding, except the 403/404 error pages excluded separately.
+ */
+#define NGX_HTTP_ZSTD_MAX_ELIGIBLE_STATUS  299
+
+/*
  * RFC 9842 §2.2 dcz framing: an 8-byte zstd skippable-frame header
  * (magic 0x184D2A5E and frame-size 32, both little-endian on the wire)
  * followed by the 32-byte SHA-256 of the dictionary, prepended to an
@@ -187,6 +208,9 @@ ngx_http_zstd_dcz_dict_hash(const u_char *data, size_t len,
  * length check runs, so the destination buffer must have that headroom.
  */
 #define NGX_HTTP_ZSTD_DCZ_DECODE_BUF_LEN  48
+
+/* Padded standard-base64 length of a 32-byte SHA-256 (43 unpadded). */
+#define NGX_HTTP_ZSTD_DCZ_DIGEST_B64_LEN  44
 
 /*
  * RFC 9842 §2.2.2: a dcz client guarantees a decode window of at least
@@ -273,7 +297,7 @@ ngx_http_zstd_dcz_window_log(size_t dict_len, off_t pledged_size,
      * everything above 2^23 the same way, so no finer clamp is needed.
      */
     if (pledged_size < 0) {
-        pledged_contribution = 1024 * 1024;
+        pledged_contribution = NGX_HTTP_ZSTD_UNKNOWN_SIZE_GUESS;
 
     } else if (sizeof(off_t) > sizeof(size_t)
                && (uintmax_t) pledged_size > (uintmax_t) SIZE_MAX)
@@ -687,7 +711,7 @@ typedef struct {
  * sentinel, "zstd_comp_level -1;" was indistinguishable from an absent
  * directive, so the merge below silently replaced it with the inherited
  * value or the default 3 -- and the duplicate-directive guard in
- * ngx_conf_zstd_set_num_slot_with_negatives() could never fire for it.
+ * ngx_http_zstd_set_num_slot_with_negatives() could never fire for it.
  * The value is out of band for every libzstd: ZSTD_minCLevel() is
  * -131072 at its most extreme, far above the type minimum. nginx defines
  * NGX_MAX_INT_T_VALUE but no signed minimum, so derive it.
@@ -709,6 +733,8 @@ typedef struct {
 #define NGX_HTTP_ZSTD_LDM_WINDOWLOG      27
 #define NGX_HTTP_ZSTD_LDM_MINMATCH       64
 #define NGX_HTTP_ZSTD_LDM_BUCKETSIZELOG  3
+/* libzstd's own default: hash log trails the window log by 7. */
+#define NGX_HTTP_ZSTD_LDM_HASHLOG_OFFSET 7
 
 
 static ngx_http_output_header_filter_pt  ngx_http_next_header_filter;
@@ -763,6 +789,16 @@ static ngx_str_t  ngx_http_zstd_default_types[] = {
 };
 
 
+/*
+ * Forward declarations below cover the module-table entry points and the
+ * handlers referenced across the file. They are not a full index of this
+ * TU: the remaining file-static helpers (dcz_decode_digest, profile_pack /
+ * profile_unpack, cctx_profiles_match, open_dict_strict,
+ * build_cctx_params_profile, estimate_cctx_memory, dcz_window_cap,
+ * predicate_is_direct_header_or_cookie, int_max_bound,
+ * validate_field_name_token) are each defined before their first use and
+ * need no declaration here.
+ */
 static ngx_int_t ngx_http_zstd_header_filter(ngx_http_request_t *r);
 static ngx_int_t ngx_http_zstd_body_filter(ngx_http_request_t *r,
     ngx_chain_t *in);
@@ -795,12 +831,13 @@ static char *ngx_http_zstd_check_size_int_max(ngx_conf_t *cf, void *post,
     void *data);
 static char *ngx_http_zstd_check_num_int_max(ngx_conf_t *cf, void *post,
     void *data);
-static char *ngx_conf_zstd_set_num_slot_with_negatives(ngx_conf_t *cf,
+static char *ngx_http_zstd_set_num_slot_with_negatives(ngx_conf_t *cf,
     ngx_command_t *cmd, void *conf);
 static char *ngx_http_zstd_set_bufs_slot(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 static char *ngx_http_zstd_check_bufs_product(ngx_conf_t *cf,
-    ngx_bufs_t *bufs, ngx_flag_t unsafe, const char *ctx, ngx_flag_t advise);
+    const ngx_bufs_t *bufs, ngx_flag_t unsafe, const char *ctx,
+    ngx_flag_t advise);
 static char *ngx_http_zstd_set_bypass_vary(ngx_conf_t *cf,
     ngx_command_t *cmd, void *conf);
 static char *ngx_http_zstd_set_enable_slot(ngx_conf_t *cf,
@@ -1139,7 +1176,7 @@ static ngx_command_t  ngx_http_zstd_filter_commands[] = {
 
     { ngx_string("zstd_comp_level"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
-      ngx_conf_zstd_set_num_slot_with_negatives,
+      ngx_http_zstd_set_num_slot_with_negatives,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_zstd_loc_conf_t, level),
       &ngx_http_zstd_comp_level_bounds },
@@ -1371,7 +1408,7 @@ ngx_http_zstd_header_filter(ngx_http_request_t *r)
         || r->headers_out.status == NGX_HTTP_NO_CONTENT
         || r->headers_out.status == 205   /* 205 Reset Content: no core macro */
         || r->headers_out.status == NGX_HTTP_PARTIAL_CONTENT
-        || (r->headers_out.status > 299
+        || (r->headers_out.status > NGX_HTTP_ZSTD_MAX_ELIGIBLE_STATUS
             && r->headers_out.status != NGX_HTTP_FORBIDDEN
             && r->headers_out.status != NGX_HTTP_NOT_FOUND))
     {
@@ -1774,7 +1811,7 @@ ngx_http_zstd_dcz_decode_digest(ngx_str_t raw,
     if (raw.len < 2
         || raw.data[0] != ':'
         || raw.data[raw.len - 1] != ':'
-        || raw.len - 2 > 44)
+        || raw.len - 2 > NGX_HTTP_ZSTD_DCZ_DIGEST_B64_LEN)
     {
         return NGX_DECLINED;
     }
@@ -2956,10 +2993,10 @@ ngx_http_zstd_filter_get_buf(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
                  * keep a small floor so tiny/empty bodies still get a
                  * buffer the frame overhead fits inside.
                  */
-                bound += 64;
+                bound += NGX_HTTP_ZSTD_BOUND_FRAME_SLACK;
 
-                if (bound < 256) {
-                    bound = 256;
+                if (bound < NGX_HTTP_ZSTD_BOUND_MIN) {
+                    bound = NGX_HTTP_ZSTD_BOUND_MIN;
                 }
 
                 if (bound < buf_size) {
@@ -4407,7 +4444,7 @@ ngx_http_zstd_estimate_cctx_memory(ngx_conf_t *cf,
         ldm_wlog = window_log > 0 ? window_log
                                         : NGX_HTTP_ZSTD_LDM_WINDOWLOG;
 
-        ldm_hlog = ldm_wlog - 7;
+        ldm_hlog = ldm_wlog - NGX_HTTP_ZSTD_LDM_HASHLOG_OFFSET;
         if (ldm_hlog < ZSTD_LDM_HASHLOG_MIN) {
             ldm_hlog = ZSTD_LDM_HASHLOG_MIN;
         }
@@ -4588,7 +4625,7 @@ ngx_http_zstd_dcz_window_cap(ngx_conf_t *cf, ngx_http_zstd_loc_conf_t *conf,
  * a false warning on a map is worse than missing the direct case.
  */
 static ngx_uint_t
-ngx_http_zstd_predicate_is_direct_header_or_cookie(ngx_str_t *v)
+ngx_http_zstd_predicate_is_direct_header_or_cookie(const ngx_str_t *v)
 {
     u_char  *p, *last;
 
@@ -6069,7 +6106,7 @@ ngx_http_zstd_check_num_int_max(ngx_conf_t *cf, void *post, void *data)
 
 
 static char *
-ngx_conf_zstd_set_num_slot_with_negatives(ngx_conf_t *cf,
+ngx_http_zstd_set_num_slot_with_negatives(ngx_conf_t *cf,
     ngx_command_t *cmd, void *conf)
 {
     char  *p = conf;
@@ -6208,7 +6245,7 @@ ngx_conf_zstd_set_num_slot_with_negatives(ngx_conf_t *cf,
  * possible point.
  */
 static char *
-ngx_http_zstd_check_bufs_product(ngx_conf_t *cf, ngx_bufs_t *bufs,
+ngx_http_zstd_check_bufs_product(ngx_conf_t *cf, const ngx_bufs_t *bufs,
     ngx_flag_t unsafe, const char *ctx, ngx_flag_t advise)
 {
     size_t  total;
@@ -6307,7 +6344,7 @@ ngx_http_zstd_check_bufs_product(ngx_conf_t *cf, ngx_bufs_t *bufs,
  * return from the directive handler otherwise.
  */
 static const char *
-ngx_http_zstd_validate_field_name_token(ngx_str_t *value)
+ngx_http_zstd_validate_field_name_token(const ngx_str_t *value)
 {
     u_char  *p, *end;
 

--- a/src/ngx_http_zstd_probe_hooks.c
+++ b/src/ngx_http_zstd_probe_hooks.c
@@ -43,9 +43,9 @@ static ngx_uint_t  ngx_http_zstd_probe_chain_links;
 static ngx_uint_t  ngx_http_zstd_probe_bufs_allocated;
 
 /* Snapshot of the most recently observed request's ctx state, taken by
- * ngx_http_zstd_probe_note_ctx(). Observational only -- see the
- * single-worker caveat above the includes. -1 (via the "have" flag) until
- * the first request populates it. */
+ * ngx_http_zstd_probe_note_ctx_state(). Observational only -- see the
+ * single-worker caveat above the includes. Renders as null (via the "have"
+ * flag) until the first request populates it. */
 static ngx_uint_t  ngx_http_zstd_probe_free_links;
 static ngx_uint_t  ngx_http_zstd_probe_out_buf_present;
 static size_t      ngx_http_zstd_probe_out_buf_size;

--- a/src/ngx_http_zstd_probe_hooks.h
+++ b/src/ngx_http_zstd_probe_hooks.h
@@ -57,12 +57,12 @@ char *ngx_http_zstd_probe_directive(ngx_conf_t *cf, ngx_command_t *cmd,
  * buffer created in ngx_http_zstd_filter_get_buf() (the ctx->bufs < ...
  * branch, i.e. NOT the free-list reuse branch).
  *
- * ngx_http_zstd_probe_note_ctx() -- called with the request's ctx so the
- * probe can snapshot free-list length and out_buf state. Safe to call
- * repeatedly (e.g. once per body filter invocation); last write wins. The
- * pointer is observational only and is never dereferenced outside the
- * request that owns it -- see the .c file for the single-worker caveat this
- * inherits from fault_set_global's per-worker-global contract.
+ * ngx_http_zstd_probe_note_ctx_state() -- called with values already
+ * derived from the request's ctx so the probe can snapshot free-list length
+ * and out_buf state. Safe to call repeatedly (e.g. once per body filter
+ * invocation); last write wins. The snapshot is observational only -- see
+ * the .c file for the single-worker caveat this inherits from
+ * fault_set_global's per-worker-global contract.
  */
 void ngx_http_zstd_probe_note_chain_link(void);
 void ngx_http_zstd_probe_note_buf_alloc(void);

--- a/src/ngx_http_zstd_sha256.h
+++ b/src/ngx_http_zstd_sha256.h
@@ -20,9 +20,12 @@
  * runtime fallback: EVP_Digest() allocates internally and may fail
  * under memory pressure, and falling back keeps this a total function.
  *
- * static inline (matching ngx_http_zstd_common.h's pattern): only the
- * filter TU uses it today; inline definitions are exempt from
- * -Werror=unused-function if the static module ever includes this.
+ * Only the filter TU uses these today. The one-shot entry point
+ * ngx_http_zstd_sha256() is static ngx_inline; the four helpers it drives
+ * (_compress, _init, _update, _final) are plain static and are reached only
+ * through it, so they carry no -Werror=unused-function exemption of their
+ * own. A second TU including this header would need them marked
+ * ngx_inline too, or would have to use every one of them.
  */
 
 #ifndef NGX_HTTP_ZSTD_SHA256_H


### PR DESCRIPTION
## TL;DR

This is a tidying pass. Nothing the module does at runtime changes: I gave names
to a handful of bare numbers scattered through the code, fixed three comments
that described how things used to work rather than how they work now, and
tightened one test that was quietly passing no matter what the code said.

**Severity:** cosmetic. No behaviour change, no ABI or config change.

Six rows off the backlog, grouped as one sweep because none of them qualifies
for a PR of its own.

## Named constants

Five numbers were sitting bare in expressions, each already explained by an
adjacent comment but not tied to anything. They now have names next to their
siblings:

| constant | was |
| --- | --- |
| `NGX_HTTP_ZSTD_LDM_HASHLOG_OFFSET` | `ldm_wlog - 7` |
| `NGX_HTTP_ZSTD_DCZ_DIGEST_B64_LEN` | `raw.len - 2 > 44` |
| `NGX_HTTP_ZSTD_UNKNOWN_SIZE_GUESS` | `1024 * 1024` |
| `NGX_HTTP_ZSTD_BOUND_FRAME_SLACK` / `_BOUND_MIN` | `64` / `256` |
| `NGX_HTTP_ZSTD_MAX_ELIGIBLE_STATUS` | `status > 299` |

## Comments that had gone stale

`probe_hooks.{h,c}` still documented `ngx_http_zstd_probe_note_ctx()` as taking
the request's ctx, complete with a caveat about a pointer that is "never
dereferenced". That design was deliberately replaced: the shipped function is
`note_ctx_state()`, which takes three scalars precisely so the probe TU never
sees `ngx_http_zstd_ctx_t`'s layout — the header's own next comment block says
exactly that, two paragraphs below the one contradicting it. The same block also
claimed the empty snapshot reads as `-1`; it renders `null`.

`sha256.h` claimed its helpers were `static inline` and therefore exempt from
`-Werror=unused-function`. Only the one-shot entry point is `ngx_inline`; the
other four are plain `static`, so the exemption does not cover them. I corrected
the comment rather than adding `ngx_inline` — inlining is a codegen decision and
does not belong in a sweep. Latent either way: the static module does not
include the header today.

The forward-declaration block in `filter_module.c` presents as the file's index
but omits eleven later static helpers, which compile only because each is
defined before first use. I noted what the block actually covers rather than
padding it with declarations nothing needs.

## Naming and const

`ngx_conf_zstd_set_num_slot_with_negatives()` was the only function in the file
outside the `ngx_http_zstd_` prefix, and the `ngx_conf_` spelling reads as an
nginx-core helper. Renamed.

`const` on three read-only parameters: `predicate_is_direct_header_or_cookie`,
`validate_field_name_token`, and `check_bufs_product`'s `ngx_bufs_t *bufs`.

## The test that wasn't testing

TEST 44 asserted the bare fragment `leading skippable frames`, never the
operator word in front of it — so it passed equally on "has more than 4" and
"has at least 4". PR #231 changed that wording (the guard is `>=`, so it fires
*at* four while the old text denied it) and the test did not notice. It now pins
`has at least 4 leading skippable frames`, matching the three window-message
assertions in the same file. The gap predates #231; TEST 44's real
discriminating power was always its 200-with-no-`Content-Encoding` assertions,
which do hold.

One row I did not take: the same backlog entry asked for `clcf` to be
const-qualified alongside `zscf` in `static_module.c`. It cannot be —
`ngx_http_set_disable_symlinks()` takes a non-const `ngx_http_core_loc_conf_t *`.

## What naming the constants broke

Worth knowing about if you ever do this again in this repo. Three test
harnesses lift production code out of `filter_module.c` verbatim and compile it
as a standalone translation unit, without the module's headers. Moving a
literal behind a macro is invisible to the compiler here but fatal there, and
CI caught all three:

```
ci/fuzz/fuzz_dcz            NGX_HTTP_ZSTD_DCZ_DIGEST_B64_LEN undeclared
test_dcz_window_log_unit    NGX_HTTP_ZSTD_UNKNOWN_SIZE_GUESS undeclared
test_freecctxparams_unit    NGX_HTTP_ZSTD_LDM_HASHLOG_OFFSET undeclared
```

Each already had a mechanism for this, so none needed a new one. `ngx_shim.h`
mirrors the module constants the fuzz TU needs, so the base64 length joins the
two already there. `test_dcz_window_log_unit.sh` copies named `#define` lines
out of the source, failing loudly when one is missing and asserting each marker
in the generated `.inc`; I extended both lists rather than hardcoding 1 MB.

`test_freecctxparams_unit.sh` is the interesting one: it extracts a *range*,
from `NGX_HTTP_ZSTD_LDM_WINDOWLOG` through `NGX_HTTP_ZSTD_LDM_BUCKETSIZELOG`. I
had appended the new constant after the closing bound, which left it outside
that window. Moving it up between `MINMATCH` and `BUCKETSIZELOG` fixes the
extraction and is where it belonged anyway — it is an LDM constant, and its
siblings are right there. No script change needed for that one.

## Verification

Built against nginx 1.31.4, both modules. Full suites, all green:

```
01-static     756 assertions
00-filter    1335
02-conf-warn   88
03-dcz        163
```

Plus, after the harness fixes: all eight extraction fixtures pass (native and
`-m32` where they model it), `ci/tests/unit/run.sh` 45/45, and both fuzz targets
build.

`review-lint.sh --diff HEAD` clean with no coverage gap. The nginx 80-column
linter caught the reflowed `check_bufs_product` declaration in the pre-commit
hook, before it went in.

One advisory finding left standing: `shfmt` reports the whole of
`test_dcz_window_log_unit.sh` as unformatted, since the file is 4-space indented
and shfmt wants 2. That predates this PR, and reformatting it would bury a
three-line change in a whole-file diff.
