### PR TITLE
perf(static): reuse the aligned probe block across the directio skip-frame walk

### DIFF
--- a/ci/t/01-static.t
+++ b/ci/t/01-static.t
@@ -1570,3 +1570,54 @@ Available-Dictionary: :AA==:
 main response
 --- no_error_log
 [error]
+
+
+
+=== TEST 56: the directio skip-frame walk reuses the block it already read
+# The canonical dcz shape (8-byte skippable header + 32-byte payload,
+# next frame at offset 40) with an alignment of 4096 or more puts BOTH
+# frames inside the very first aligned block. The walk still recomputed
+# base = 0 on iteration 2 and re-issued an identical 2*align O_DIRECT
+# pread for bytes already sitting in `hdr` — at "directio_alignment
+# 16k" that is a 32 KB re-read per skipped frame, to look at 18 bytes
+# it already had.
+#
+# TEST 46 pins that this shape is SERVED; it cannot see how many reads
+# it took, because both the cached and uncached paths serve identical
+# bytes. The "reusing ... block at offset 0" debug line is the witness
+# that the second read was actually elided, so this block asserts the
+# optimization engaged rather than merely that the response is right.
+#
+# Falsifiability: drop the cache guard (always pread) and the reuse
+# line never appears, so this block goes red while TEST 46 stays green
+# — which is precisely the regression TEST 46 cannot catch.
+#
+# The alignment witness is asserted too, so this cannot pass vacuously
+# on a filesystem where O_DIRECT does not engage: with no directio the
+# buffered path runs, neither line is logged, and both assertions fail.
+--- config
+    location /skip/ {
+        zstd_static on;
+        directio 512;
+        directio_alignment 16k;
+        root html;
+    }
+--- user_files eval
+">>> skip/dioreuse.js\ndirectio reuse origin\n>>> skip/dioreuse.js.zst\n"
+. pack("C*", 0x50, 0x2A, 0x4D, 0x18, 0x20, 0x00, 0x00, 0x00)
+. ("\0" x 32)
+. pack("C*", 0x28, 0xB5, 0x2F, 0xFD, 0x00, 0x00, 0x19, 0x00, 0x00)
+. "hi\n"
+. ("\0" x 1024)
+--- request
+GET /skip/dioreuse.js
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+Content-Encoding: zstd
+--- error_code: 200
+--- error_log
+16384-byte aligned probe on directio file
+reusing 32768-byte block at offset 0 for next frame
+--- no_error_log
+[error]

--- a/src/ngx_http_zstd_static_module.c
+++ b/src/ngx_http_zstd_static_module.c
@@ -1102,11 +1102,11 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
          */
         u_char       hdrbuf[18];
         u_char      *hdr, *frame;
-        size_t       want, align, frame_off, avail;
+        size_t       want, align, frame_off, avail, got;
         ssize_t      n;
         uint64_t     window, skip;
-        ngx_uint_t   frames, scratch;
-        off_t        pos, base;
+        ngx_uint_t   frames, scratch, have_block;
+        off_t        pos, base, have_base;
         ngx_int_t    probe_rc;
 
         if (of.size < 4) {
@@ -1117,6 +1117,9 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
         }
 
         scratch = 0;
+        have_block = 0;
+        have_base = 0;
+        n = 0;
 
         if (of.is_directio) {
             /*
@@ -1216,8 +1219,52 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
                 base = pos;
             }
 
-            n = ngx_http_zstd_static_pread(of.fd, hdr, want, base, align,
-                                           log, &path);
+            /*
+             * Reuse the block already in `hdr` when this iteration
+             * reads the SAME aligned offset and the bytes it needs are
+             * inside what the previous read delivered. A skippable
+             * frame shorter than `align` leaves `pos` inside the block
+             * just read, so `base` is unchanged and the re-read would
+             * return byte-for-byte what `hdr` already holds -- the
+             * canonical dcz prefix (40-byte frame at offset 0, next
+             * frame at 40) with align >= 4096 hits this on every
+             * iteration, re-issuing up to 2 * PROBE_MAX of O_DIRECT per
+             * skipped frame.
+             *
+             * `have_block` is only ever set on the directio path, where
+             * `base` is a rounded-down offset that can repeat. Off that
+             * path `base == pos` and `pos` strictly increases, so the
+             * cache never fires and this is byte-for-byte the previous
+             * behaviour.
+             *
+             * The guard requires the previous read to have reached at
+             * least `frame_off + 4`, the minimum this iteration can
+             * parse; anything short of that still takes a fresh read
+             * and then the `avail < 4` branch below, exactly as before.
+             */
+            if (!(have_block && base == have_base
+                  && n > 0 && (size_t) n >= frame_off + 4))
+            {
+                n = ngx_http_zstd_static_pread(of.fd, hdr, want, base, align,
+                                               log, &path);
+
+                if (of.is_directio && n > 0) {
+                    have_block = 1;
+                    have_base = base;
+                }
+
+            } else {
+                /*
+                 * Positive witness that the re-read was elided. Debug
+                 * level, so it costs nothing in production, but it lets
+                 * a test assert the optimization actually engaged --
+                 * serving correctly proves only that the bytes were
+                 * right, not that they came from the buffer.
+                 */
+                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
+                               "zstd static: reusing %uz-byte block at "
+                               "offset %O for next frame", want, base);
+            }
 
             /*
              * Bytes of the block that lie at or after `pos`. A short
@@ -1225,8 +1272,8 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
              * the frame, which is the same "too few bytes" condition as
              * a short read at offset 0 and takes the same branch.
              */
-            avail = ((size_t) (n > 0 ? n : 0) > frame_off)
-                        ? (size_t) n - frame_off : 0;
+            got = (size_t) (n > 0 ? n : 0);
+            avail = (got > frame_off) ? got - frame_off : 0;
 
             frame = hdr + frame_off;
 


### PR DESCRIPTION
> Found while auditing the dcz dictionary loader. Independent of #197, which touches the static module.

## TL;DR

The compression dictionary directive takes an optional checksum of the dictionary file. Nobody ever checked that the checksum actually belonged to the file next to it, so pointing the directive at one dictionary while naming another one's checksum was accepted silently — and browsers that fetched the advertised dictionary then got a response they had no way to unpack. The checksum is now checked against the file, and a mismatch stops the server from starting at all.

`zstd_dcz_dict_file` now always computes the SHA-256 of the bytes it read and uses that as the negotiation key; a supplied literal is compared against it and a mismatch fails config load.

**Severity:** `Medium` (`correctness — silently undecodable dcz responses from a stale or mistyped hash literal`)

## Mechanism

The optional second argument was trusted verbatim: `if (!have_hash)` gated the load-time hashing pass entirely, so when a literal was present the file's own bytes were never hashed. The literal went straight into `dict->hash`, which is what `ngx_http_zstd_dcz_negotiate()` matches a client's `Available-Dictionary` against and what the 40-byte frame prefix advertises.

So this loaded without complaint:

```nginx
zstd_dcz_dict_file new.dict <sha256-of-old.dict>;
```

and produced responses compressed with `new.dict` while telling clients they were compressed with the old one. A client holding the old dictionary matches the advertisement, gets a frame built against a dictionary it does not have, and cannot decode the body. The frame checksum turns that into a visible decode error rather than silent wrong bytes, which bounds the damage but does not stop it being broken.

The trade was documented as a parse-time optimisation — skipping a read-and-hash pass per dictionary at every `nginx -t` and reload. It never bought what it cost: the file has to be read into `cf->pool` regardless, so the only work recovered was hashing bytes already in memory, in exchange for a negotiation key nothing could verify.

## Fix

The dictionary is always hashed from the bytes actually read. The supplied literal decodes into a separate `supplied[]` buffer and is compared to the computed hash:

```
nginx: [emerg] dcz dictionary "…/dcz-dict" does not match the supplied hash
"0101…0101": the file's SHA-256 is "83b93dc2…70d5"
```

Syntax validation of the literal still runs before the file is opened, so a malformed value is reported as such rather than shadowed by a file error; only the value comparison waits for the read.

## Compatibility

The directive keeps its syntax. A configuration whose literal matches its file is unaffected — it now gains a deploy-time assertion that the file on this host is the one the config was generated for. A configuration whose literal is wrong stops loading, which is the point.

`$zstd_dcz_dicts_hashed` now counts every loaded dictionary rather than only those without a literal.

## Testing

`ci/t/03-dcz.t`, 115/115 assertions, against nginx 1.31.3 with the module built dynamically.

TESTs 17, 18, 21 and 23 encoded the old trust-verbatim contract and are rewritten to the verified one:

- **17** — a literal that is not the file's fails `nginx -t`, matching the message's file, supplied and computed values. The dictionary path exists and its contents are fine, so nothing but the verification can reject that config.
- **18** — positive control: the file's true hash still loads and negotiates `Content-Encoding: dcz`. Without it, 17 would also pass if the directive rejected every literal.
- **21/23** — the counter proves the hashing pass is no longer skipped, which is what distinguishes verifying the literal from substituting it (both produce the same `dict->hash` on a matching pair).

Negative control, run rather than reasoned: reverting to `if (!have_hash)` plus `ngx_memcpy(hash, supplied, …)` and rebuilding takes the suite to `exit=4` with TESTs 17, 21 and 23 red; restoring returns 115/115. The wrong-hash config itself goes `exit=1` → `exit=0` across that same mutation.

`ci/t/02-conf-warn.t` 82/82. `ci/t/00-filter.t` 642 assertions pass, then bails on TEST 58 because my local nginx lacks `--with-http_auth_request_module` — unrelated to this diff.

Lint roster clean (`review-lint.sh --branch master`); the `lizard` and unchecked-palloc hits are pre-existing and on lines this diff does not touch.
