### PR TITLE
[NIT][perf] dcz window_log computed twice per dcz request

### DIFF
--- a/ci/t/03-dcz.t
+++ b/ci/t/03-dcz.t
@@ -1255,3 +1255,46 @@ Content-Encoding: dcz
 Vary: Available-Dictionary, Accept-Encoding, Sec-Fetch-Site
 --- no_error_log
 [error]
+
+
+
+=== TEST 49: dcz window log is computed exactly once per request
+# ngx_http_zstd_dcz_window_log() used to run twice on a cold dcz request:
+# once in acquire_cctx() to key the CCtx ring slot, once again in
+# init_cctx() to set ZSTD_c_windowLog. Both calls take the same four
+# inputs and cannot observably differ, so a plain response-body test
+# cannot tell one computation from two -- exactly why TEST 46 above passes
+# either way. The debug line at the single memoisation site
+# (ctx->dcz_window_log_cache) is the witness that the value is computed
+# once, not read twice from a shared source that happens to agree: it is
+# logged ONLY on a cache miss, so it appears in the log exactly once per
+# request regardless of how many times the cached value is subsequently
+# read.
+#
+# Falsifiability: reverting the memoisation (each site calling
+# ngx_http_zstd_dcz_window_log() directly again) makes this line -- moved
+# back inside both call sites -- appear twice; grep_error_log_out pins the
+# count at exactly one line, so that regression goes red here while every
+# byte-level assertion in this suite (TEST 46 included) stays green.
+--- config
+    error_log logs/error.log debug;
+    location /test {
+        zstd on;
+        zstd_types *;
+        zstd_min_length 1;
+        zstd_dcz_dict_file $TEST_NGINX_PERL_PATH/suite/dcz-dict;
+        default_type text/plain;
+        return 200 "dcz window-log single-compute witness body\n";
+    }
+--- request
+GET /test
+--- more_headers eval
+"Accept-Encoding: zstd, dcz\nAvailable-Dictionary: :$::dict_b64:"
+--- response_headers
+Content-Encoding: dcz
+--- grep_error_log eval
+qr/zstd: dcz window log computed once: \d+/
+--- grep_error_log_out eval
+qr/^zstd: dcz window log computed once: \d+\n?$/
+--- no_error_log
+[error]

--- a/ci/t/03-dcz.t
+++ b/ci/t/03-dcz.t
@@ -1271,11 +1271,15 @@ Vary: Available-Dictionary, Accept-Encoding, Sec-Fetch-Site
 # request regardless of how many times the cached value is subsequently
 # read.
 #
-# Falsifiability: reverting the memoisation (each site calling
-# ngx_http_zstd_dcz_window_log() directly again) makes this line -- moved
-# back inside both call sites -- appear twice; grep_error_log_out pins the
-# count at exactly one line, so that regression goes red here while every
-# byte-level assertion in this suite (TEST 46 included) stays green.
+# Falsifiability: the witness is emitted at BOTH memoisation sites
+# (acquire_cctx() and init_cctx()), each inside its own cache-miss guard,
+# so it is logged once per ACTUAL computation rather than once per
+# request. Defeating the memoisation (forcing both guards true) makes the
+# line appear twice and this test goes red on grep_error_log_out, while
+# every byte-level assertion in this suite (TEST 46 included) stays green
+# -- verified by mutation, not assumed. Emitting the witness at only one
+# of the two sites would make this test pass whether the value is computed
+# once or twice; do not "simplify" it that way.
 --- config
     error_log logs/error.log debug;
     location /test {

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -671,6 +671,21 @@ typedef struct {
      */
     off_t                        pledged_size;
 
+    /*
+     * Memoised ngx_http_zstd_dcz_window_log() result for this request.
+     * acquire_cctx() and init_cctx() must derive the IDENTICAL window log --
+     * a request that borrows a CCtx ring slot keyed on one window and then
+     * compresses at another contaminates that slot's retained workspace for
+     * every later borrower. Computing it twice risked exactly that drift if
+     * either call site's inputs ever diverged; this field makes the two
+     * reads provably the same value by construction instead of relying on
+     * both call sites staying in lockstep. 0 means "not yet computed" -- the
+     * helper's documented range is [10, 23]
+     * (ZSTD_WINDOWLOG_MIN..NGX_HTTP_ZSTD_DCZ_MAX_WINDOW_LOG), so 0 can never
+     * be a real result. Meaningless when ctx->dcz_dict == NULL.
+     */
+    ngx_int_t                    dcz_window_log_cache;
+
     unsigned                     last:1;
     unsigned                     redo:1;
     unsigned                     flush:1;
@@ -3191,9 +3206,17 @@ ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
      * while a CCtx is only acquired on the first body buffer.
      */
     if (ctx->dcz_dict != NULL) {
-        eff_window_log = ngx_http_zstd_dcz_window_log(
-                             ctx->dcz_dict->bytes.len, ctx->pledged_size,
-                             zlcf->window_log, zlcf->dcz_window_cap);
+        if (ctx->dcz_window_log_cache == 0) {
+            ctx->dcz_window_log_cache = ngx_http_zstd_dcz_window_log(
+                                 ctx->dcz_dict->bytes.len, ctx->pledged_size,
+                                 zlcf->window_log, zlcf->dcz_window_cap);
+
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "zstd: dcz window log computed once: %i",
+                           ctx->dcz_window_log_cache);
+        }
+
+        eff_window_log = ctx->dcz_window_log_cache;
     } else {
         eff_window_log = zlcf->window_log;
     }
@@ -3467,19 +3490,31 @@ ngx_http_zstd_filter_init_cctx(ngx_http_request_t *r,
         ngx_int_t  wlog;
 
         /*
-         * RFC 9842 window bound, plus both operator memory ceilings. The
-         * whole computation lives in ngx_http_zstd_dcz_window_log() because
-         * ngx_http_zstd_acquire_cctx() must derive the IDENTICAL value
-         * before it packs the CCtx ring key -- a request that borrows a slot
+         * RFC 9842 window bound, plus both operator memory ceilings. Read
+         * ngx_http_zstd_dcz_window_log()'s comment for the sizing rationale
+         * and for why both clamps are opt-in.
+         *
+         * This must be the SAME value ngx_http_zstd_acquire_cctx() packed
+         * into the CCtx ring key above -- a request that borrows a slot
          * keyed on one window and then compresses at another contaminates
-         * that slot's retained workspace for every later borrower. Read that
-         * function's comment for the sizing rationale and for why both
-         * clamps are opt-in.
+         * that slot's retained workspace for every later borrower. Rather
+         * than calling the helper again and relying on both call sites
+         * staying in lockstep, read the single memoised result computed at
+         * most once per request in ctx->dcz_window_log_cache: acquire_cctx()
+         * fills it when it runs (ctx->cctx == NULL above), and when it is
+         * skipped (a borrowed cctx already set on this ctx) the cache was
+         * necessarily already filled the first time this request acquired
+         * one, since ctx->dcz_dict does not change mid-request.
          */
-        wlog = ngx_http_zstd_dcz_window_log(ctx->dcz_dict->bytes.len,
-                                            ctx->pledged_size,
-                                            zlcf->window_log,
-                                            zlcf->dcz_window_cap);
+        if (ctx->dcz_window_log_cache == 0) {
+            ctx->dcz_window_log_cache = ngx_http_zstd_dcz_window_log(
+                                        ctx->dcz_dict->bytes.len,
+                                        ctx->pledged_size,
+                                        zlcf->window_log,
+                                        zlcf->dcz_window_cap);
+        }
+
+        wlog = ctx->dcz_window_log_cache;
 
         if (ngx_http_zstd_set_param(r, cctx, ZSTD_c_windowLog, (int) wlog,
                                     "windowLog(dcz)")

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -3512,6 +3512,10 @@ ngx_http_zstd_filter_init_cctx(ngx_http_request_t *r,
                                         ctx->pledged_size,
                                         zlcf->window_log,
                                         zlcf->dcz_window_cap);
+
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                           "zstd: dcz window log computed once: %i",
+                           ctx->dcz_window_log_cache);
         }
 
         wlog = ctx->dcz_window_log_cache;


### PR DESCRIPTION
Every dcz request figured out how big its compression window should be twice: once to pick which cached compressor to reuse, once more right before actually compressing. Same answer both times, so nothing broke, but the two calculations had no way to be told they were the same number apart from a comment asking nicely. I made that a guarantee instead of a promise.

`ngx_http_zstd_dcz_window_log()` ran once in `ngx_http_zstd_acquire_cctx()` to key the CCtx ring slot and again in `ngx_http_zstd_filter_init_cctx()` to set `ZSTD_c_windowLog`, both times on identical arguments. The existing comment at the second call site already spelled out why that duplication was dangerous: a request that borrows a ring slot keyed on one window and then compresses at another contaminates that slot's retained workspace for every later borrower. I memoised the result on `ctx->dcz_window_log_cache` (`ngx_int_t`, `0` = not yet computed; the helper's range is `[10, 23]` so `0` is never a real answer) instead of leaving the two call sites to stay in lockstep by convention.

`cctx_ready` already makes `init_cctx()` single-shot per request, so the cache is filled before it's ever read, including on the borrowed-cctx path that skips `acquire_cctx()` outright.

## Testing

Added TEST 49 to `ci/t/03-dcz.t` (renumbered from 47 in the rebase below): a debug-log witness asserting the "computed once" line appears exactly once per request. The fix is behaviour-preserving, so no output test can tell it apart from the bug.

**Correction — the negative control originally recorded here was wrong, and the test has been fixed.** The witness was emitted at only ONE of the two memoisation sites (`acquire_cctx()`), so it printed exactly once per request whether or not the memoisation was in place: defeating the cache entirely still produced a single line and TEST 49 stayed green. It could not detect the defect it was written for. Caught by re-running the mutation while rebasing onto the merged #235 — the recorded control did not reproduce. Commit `709b291` emits the witness inside `init_cctx()`'s cache-miss guard as well, so the line count now tracks actual computations rather than requests. Re-verified by mutation both ways: forcing both guards true yields two lines and TEST 49 goes red on `grep_error_log_out`; restored, 176/176 green, with every byte-level dcz assertion (TEST 46 included) green throughout.

`ci/t/03-dcz.t`: 167/167. `ci/t/00-filter.t` and `ci/t/02-conf-warn.t`: pass. `ci/t/01-static.t`: 774 run, the same 12 pre-existing TEST 55 failures (an `auth_request` subrequest fixture gap) reproduce identically on unmodified master with the same binary, so they're not this change's doing.

`review-lint.sh --diff HEAD` is clean, no coverage gap. CodeRabbit CLI came back `{"type":"complete","findings":0}`.



## Follow-up commit (`ea257c7`)

TEST 47 originally set its debug `error_log` via `$TEST_NGINX_SERVROOT`. The CI
workflows export that variable, but nothing else does — so on a local run it was
unset and Test::Nginx bailed out of the whole file rather than failing one test,
taking the remaining subtests with it. It was also the only test in the suite
referencing that variable. Switched to a servroot-relative `logs/error.log`,
which nginx resolves against its prefix under both the harness default
(`t/servroot`) and an exported `TEST_NGINX_SERVROOT`, so the witness lands where
`grep_error_log` reads it either way. Also dropped a duplicated `[error]` line
left in TEST 46's `no_error_log` block.

The suite runs to completion locally with no environment beyond
`TEST_NGINX_BINARY`. Counts, for the record: 164/164 was a masked bail-out,
167/167 the real figure after the bail-out fix, and **176/176** on this branch
now that it sits on the merged #235 (which added TESTs 47 and 48) and this PR's
test landed as TEST 49.

## Rebased onto #235

#235 merged first and touched the same two files, so this branch was rebased
onto it. `src/ngx_http_zstd_filter_module.c` auto-merged; `ci/t/03-dcz.t`
conflicted because both PRs appended a "TEST 47". Resolved by keeping #235's
TESTs 47 and 48 and renumbering this PR's test to 49. The follow-up commit
`ea257c7` became empty in the rebase — its two changes (the servroot-relative
`error_log`, and the duplicated `[error]`) were already carried in the resolved
file — so it was skipped, and both are present and verified in the result.

