### PR TITLE
perf(dcz): hoist the cheap negotiation gate, fold vary_dcz's token checks

### DIFF
--- a/ci/t/03-dcz.t
+++ b/ci/t/03-dcz.t
@@ -1182,3 +1182,76 @@ Content-Encoding: dcz
 Vary: Accept-Encoding, Available-Dictionary, Sec-Fetch-Site
 --- no_error_log
 [error]
+
+
+
+=== TEST 47: no explicit dcz gate fires before the header-collect gate
+# Pins the negotiation gate ORDER, not just the accept/reject outcome.
+# This request fails BOTH the cheap "no explicit dcz in Accept-Encoding"
+# predicate (Accept-Encoding carries no dcz coding at all) AND the more
+# expensive duplicate-Available-Dictionary gate that used to run first
+# (behind ngx_http_zstd_collect_dcz_headers()'s header-list walk). The
+# gates are pure predicates that only return NULL, so the accept/reject
+# answer (fall back to zstd) is identical either way -- but WHICH debug
+# line is emitted depends on gate order, and that is what this test
+# pins. If a future change reorders the cheap dcz-coding gate back below
+# the collect call, this flips: the duplicate-Available-Dictionary line
+# would reappear and the "no explicit dcz" line would vanish.
+--- log_level: debug
+--- config
+    location /t {
+        zstd on;
+        zstd_min_length 16;
+        zstd_dcz_dict_file $TEST_NGINX_PERL_PATH/suite/dcz-dict;
+        default_type text/plain;
+        return 200 "dcz negotiation body: shared-boilerplate compute render\n";
+    }
+--- request
+GET /t
+--- more_headers eval
+"Accept-Encoding: zstd\nAvailable-Dictionary: :$::dict_b64:\nAvailable-Dictionary: :$::dict_b64:\nSec-Fetch-Site: same-origin"
+--- response_headers
+Content-Encoding: zstd
+--- error_log eval
+qr/zstd dcz: skip, no explicit dcz in Accept-Encoding/
+--- no_error_log eval
+[
+    qr/zstd dcz: skip, \d+ Available-Dictionary headers/,
+    qr/\[error\]/,
+]
+
+
+
+=== TEST 48: vary_dcz folds an already-present token instead of duplicating it
+# ngx_http_zstd_vary_dcz() detects both tokens in a single pass
+# (ngx_http_zstd_vary_has_two_tokens()) rather than two independent
+# ngx_http_zstd_vary_has_token() calls. Coverage for the fold: the
+# upstream response already carries "Vary: Available-Dictionary" (only
+# ONE of the two tokens), so vary_dcz must detect has_available_dictionary
+# = 1 / has_sec_fetch_site = 0 from that single combined pass and push
+# exactly "Sec-Fetch-Site" -- not the "both absent" 2-token line every
+# other test in this file exercises, and not a duplicated
+# Available-Dictionary. A fold that mixed up which flag belongs to which
+# token, or that only checked one of the two in the single pass, flips
+# this response's Vary line.
+--- config
+    location /t {
+        zstd on;
+        zstd_min_length 16;
+        zstd_dcz_dict_file $TEST_NGINX_PERL_PATH/suite/dcz-dict;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/t-upstream;
+    }
+    location /t-upstream {
+        add_header Vary "Available-Dictionary";
+        default_type text/plain;
+        return 200 "dcz negotiation body: shared-boilerplate compute render\n";
+    }
+--- request
+GET /t
+--- more_headers eval
+"Accept-Encoding: zstd, dcz\nAvailable-Dictionary: :$::dict_b64:"
+--- response_headers
+Content-Encoding: dcz
+Vary: Available-Dictionary, Accept-Encoding, Sec-Fetch-Site
+--- no_error_log
+[error]

--- a/src/ngx_http_zstd_common.h
+++ b/src/ngx_http_zstd_common.h
@@ -811,21 +811,118 @@ ngx_http_zstd_vary_has_token(ngx_http_request_t *r, const char *token,
 
 
 /*
+ * Same walk as ngx_http_zstd_vary_has_token(), but checks for two tokens
+ * in one pass over r->headers_out.headers instead of two. Used only by
+ * ngx_http_zstd_vary_dcz(), whose two calls are adjacent and always want
+ * both answers -- folding them avoids a second full header-list walk plus
+ * a second per-Vary-line comma-token sub-scan.
+ */
+static ngx_inline void
+ngx_http_zstd_vary_has_two_tokens(ngx_http_request_t *r,
+    const char *token_a, size_t token_a_len,
+    const char *token_b, size_t token_b_len,
+    ngx_uint_t *has_a, ngx_uint_t *has_b)
+{
+    ngx_uint_t        i;
+    ngx_list_part_t  *part;
+    ngx_table_elt_t  *h;
+
+    *has_a = 0;
+    *has_b = 0;
+
+    for (part = &r->headers_out.headers.part, h = part->elts, i = 0;
+         /* void */;
+         i++)
+    {
+        if (i >= part->nelts) {
+            if (part->next == NULL) {
+                break;
+            }
+
+            part = part->next;
+            h = part->elts;
+            i = 0;
+        }
+
+        if (h[i].hash == 0
+            || h[i].key.len != sizeof("Vary") - 1
+            || ngx_strncasecmp(h[i].key.data, (u_char *) "Vary",
+                               sizeof("Vary") - 1) != 0)
+        {
+            continue;
+        }
+
+        {
+            u_char  *end, *p, *start;
+
+            p = h[i].value.data;
+            end = p + h[i].value.len;
+
+            while (p < end) {
+                while (p < end && (*p == ' ' || *p == '\t' || *p == ',')) {
+                    p++;
+                }
+
+                start = p;
+                while (p < end && *p != ',') {
+                    p++;
+                }
+
+                while (p > start && (p[-1] == ' ' || p[-1] == '\t')) {
+                    p--;
+                }
+
+                if (!*has_a
+                    && (size_t) (p - start) == token_a_len
+                    && ngx_strncasecmp(start, (u_char *) token_a,
+                                       token_a_len) == 0)
+                {
+                    *has_a = 1;
+                }
+
+                if (!*has_b
+                    && (size_t) (p - start) == token_b_len
+                    && ngx_strncasecmp(start, (u_char *) token_b,
+                                       token_b_len) == 0)
+                {
+                    *has_b = 1;
+                }
+
+                if (*has_a && *has_b) {
+                    return;
+                }
+
+                while (p < end && *p != ',') {
+                    p++;
+                }
+            }
+        }
+    }
+}
+
+
+/*
  * Add the two request-header dimensions that can select a dcz response.
  * The static content handler and the response filter can both reach this
  * helper on one request. Detect tokens across every active Vary field, so
  * repeated calls and fields flattened or reordered by another filter remain
  * duplicate-free.
+ *
+ * The two tokens are looked up together in a single header-list walk
+ * (ngx_http_zstd_vary_has_two_tokens()) rather than as two independent
+ * calls to ngx_http_zstd_vary_has_token() -- the two lookups are always
+ * wanted together here, so paying for the walk and the per-line
+ * comma-token scan twice was redundant.
  */
 static ngx_inline ngx_int_t
 ngx_http_zstd_vary_dcz(ngx_http_request_t *r)
 {
     ngx_uint_t  has_available_dictionary, has_sec_fetch_site;
 
-    has_available_dictionary = ngx_http_zstd_vary_has_token(
-        r, "Available-Dictionary", sizeof("Available-Dictionary") - 1);
-    has_sec_fetch_site = ngx_http_zstd_vary_has_token(
-        r, "Sec-Fetch-Site", sizeof("Sec-Fetch-Site") - 1);
+    ngx_http_zstd_vary_has_two_tokens(
+        r, "Available-Dictionary", sizeof("Available-Dictionary") - 1,
+        "Sec-Fetch-Site", sizeof("Sec-Fetch-Site") - 1,
+        &has_available_dictionary, &has_sec_fetch_site);
 
     if (has_available_dictionary && has_sec_fetch_site) {
         return NGX_OK;

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -1912,6 +1912,28 @@ ngx_http_zstd_dcz_negotiate(ngx_http_request_t *r,
     }
 
     /*
+     * Cheapest gate first: reject before paying for the header-list walk
+     * or the base64 decode below. No client sends "dcz" in Accept-Encoding
+     * unless it already holds a dictionary, so this rejects essentially
+     * all real traffic -- the two calls it now guards
+     * (ngx_http_zstd_collect_dcz_headers() and
+     * ngx_http_zstd_dcz_decode_digest()) are provably wasted work on that
+     * path. All gates below are pure predicates that only return NULL, so
+     * reordering is behaviour-preserving for the accept/reject decision --
+     * EXCEPT for which debug log line fires for a request that fails both
+     * this gate and one of the gates below: this one now wins and its
+     * message is emitted instead of theirs. See t/03-dcz.t for a test
+     * pinning that order.
+     */
+    if (ngx_http_zstd_chain_coding_weight(ae, "dcz",
+                                          sizeof("dcz") - 1, 0) <= 0)
+    {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "zstd dcz: skip, no explicit dcz in Accept-Encoding");
+        return NULL;
+    }
+
+    /*
      * Collect both dcz-negotiation headers in a single header-list walk.
      * This eliminates a second traversal over what can be a long list.
      */
@@ -1972,14 +1994,6 @@ ngx_http_zstd_dcz_negotiate(ngx_http_request_t *r,
         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                        "zstd dcz: skip, Sec-Fetch-Site (%uz bytes, "
                        "not same-origin or none)", sec_fetch_site_h->value.len);
-        return NULL;
-    }
-
-    if (ngx_http_zstd_chain_coding_weight(ae, "dcz",
-                                          sizeof("dcz") - 1, 0) <= 0)
-    {
-        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                       "zstd dcz: skip, no explicit dcz in Accept-Encoding");
         return NULL;
     }
 


### PR DESCRIPTION
## TL;DR

When a browser asks for a page, this module checks whether the browser can use
a shared "dictionary" to make the download smaller. Almost no browser can, but
the code was doing two pieces of expensive preparation before it got around to
asking that question — work thrown away on nearly every request. This moves the
cheap question first, and separately stops a second check from walking the same
list of response headers twice.

Concretely: hoist the `chain_coding_weight(ae, "dcz", ...) <= 0` early-out in
`ngx_http_zstd_dcz_negotiate()` above `ngx_http_zstd_collect_dcz_headers()` and
`ngx_http_zstd_dcz_decode_digest()`, and fold `ngx_http_zstd_vary_dcz()`'s two
adjacent `ngx_http_zstd_vary_has_token()` calls into a single pass.

**Severity:** Minor — two `[MINOR] [perf]` rows from the 2026-08-28 four-lens
audit. No correctness or security impact; no caller-visible contract changes.

## 1. Hoist dcz's cheapest gate above its two expensive ones

`ngx_http_zstd_dcz_negotiate()` ran its "no explicit `dcz` in Accept-Encoding"
early-out *after* a full `headers_in` walk (`ngx_http_zstd_collect_dcz_headers()`)
and a base64 decode (`ngx_http_zstd_dcz_decode_digest()`). No client sends `dcz`
unless it already holds a dictionary, so that gate rejects essentially all real
traffic — and both calls ahead of it were doing work whose only consumer was a
decision already made. Hoisted above both.

Every gate in this function is a pure predicate that either falls through or
returns NULL, so the accept/reject outcome is identical. **One observable
difference, and it is the reason this needed a test:** for a request that fails
both this gate and one behind it, the debug line that fires is now this gate's
rather than the other's. TEST 47 pins that ordering so a later refactor cannot
quietly swap it back.

## 2. Fold `vary_dcz()`'s two adjacent token checks into one pass

`ngx_http_zstd_vary_has_token()` walks all of `r->headers_out.headers` with an
`ngx_strncasecmp` per header, plus a comma-token sub-scan for every `Vary` line
it finds. `ngx_http_zstd_vary_dcz()` called it twice back to back — once for
`Available-Dictionary`, once for `Sec-Fetch-Site` — so the second call re-walked
a list the first had just finished with.

`ngx_http_zstd_vary_has_two_tokens()` collects both flags in one pass and returns
as soon as both are found. Behaviour is unchanged.

The third call site, in `ngx_http_zstd_vary_accept_encoding()`, is deliberately
untouched: the audit row scopes the adjacent pair as "the cheap half and worth
doing alone", and folding the non-adjacent third would mean restructuring a
function this PR has no other reason to open.

## Why there is no benchmark here

This repo's measured benchmark noise floor is +143.9%, which swamps any
single-pass measurement of changes this small. A timing number produced here
would be noise wearing a decimal point, so there isn't one. The case for both
changes is structural — work avoided on the path nearly every request takes, and
one redundant list walk removed — and it rests on the behaviour tests below.

## Verification

* `ci/t/03-dcz.t`: **172/172**, run to completion — plan line printed, "All
  tests successful.", `Result: PASS`. Re-run independently by the supervisor
  rather than taken from the implementer's report, because a Test::Nginx
  bail-out reports a plausible-looking smaller count instead of a failure. The
  baseline was 167; TESTs 47 and 48 add 5 subtests.
* **Negative controls, both items.** Item 1: reverted the hoist alone, rebuilt
  (`.so` 191736 → 192000 bytes), TEST 47 went red on both order-encoding
  assertions, restored → green. Item 2: cross-wired the two output pointers,
  rebuilt (distinct md5), TEST 48's `Vary` assertion went red, restored → green.
* `ci/t/01-static.t`: the 12 TEST 55 failures are pre-existing on unmodified
  master in a build configured without `auth_request`; not a regression from
  this diff.
* `review-lint.sh --diff HEAD~1`: no coverage gap, no new findings on touched
  lines. The three `lizard` complexity warnings sit on pre-existing functions
  (`ngx_http_zstd_eval_qvalue`, `ngx_http_zstd_coding_weight`, and the original
  `ngx_http_zstd_vary_has_token`); the `ast-grep` pool-allocation notes are
  whole-file candidates at `:3769`, `:4943` and `:5824`, none of them in this
  diff.
* CodeRabbit CLI: terminal `{"type":"complete","status":"review_completed","findings":0}`
  over all three files.

## Known trade-off

`ngx_http_zstd_vary_has_two_tokens()` duplicates `ngx_http_zstd_vary_has_token()`'s
walk rather than sharing it, so the two can drift. Unifying them would have to
touch the out-of-scope third call site and would put a token-array loop in the
single-token hot path. The duplication is accepted here, sits directly beside
the original, and is filed as a follow-up nit rather than left unrecorded.

## Review

No independent agent sweep on this one, recorded as a deliberate call: a 3-file
single-purpose diff, both changes reordering or merging pure predicates, tests
shown by negative control to catch each change, and zero findings from lint and
CodeRabbit. Per CLAUDE.md that is the CodeRabbit-alone tier.
