### PR TITLE
perf(debug): guard profile_unpack behind NGX_DEBUG and the runtime log level

### DIFF
--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -3264,24 +3264,29 @@ ngx_http_zstd_acquire_cctx(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx,
             lender = slot;
             borrowed = 1;
 
-            {
-            ngx_int_t   dbg_level, dbg_wlog;
-            ngx_flag_t  dbg_long;
+#if (NGX_DEBUG)
+            if (r->connection->log->log_level & NGX_LOG_DEBUG_HTTP) {
+                ngx_int_t   dbg_level, dbg_wlog;
+                ngx_flag_t  dbg_long;
 
-            /*
-             * Unpack rather than read zlcf: this prints what the SLOT was
-             * built for, which is the thing a reuse decision turns on, and
-             * it exercises the key's reversibility on the hot debug path.
-             */
-            ngx_http_zstd_profile_unpack(slot->profile.key, &dbg_level,
-                                         &dbg_long, &dbg_wlog);
+                /*
+                 * Unpack rather than read zlcf: this prints what the SLOT
+                 * was built for, which is the thing a reuse decision turns
+                 * on, and it exercises the key's reversibility on the hot
+                 * debug path -- gated on NGX_DEBUG and the runtime log
+                 * level so the unpack only runs when the line below will
+                 * actually be emitted.
+                 */
+                ngx_http_zstd_profile_unpack(slot->profile.key, &dbg_level,
+                                             &dbg_long, &dbg_wlog);
 
-            ngx_log_debug5(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-                           "zstd: reusing worker cctx %p (slot:%ui) "
-                           "level:%i long:%i window_log:%i",
-                           ctx->cctx, i, dbg_level, (ngx_int_t) dbg_long,
-                           dbg_wlog);
+                ngx_log_debug5(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                               "zstd: reusing worker cctx %p (slot:%ui) "
+                               "level:%i long:%i window_log:%i",
+                               ctx->cctx, i, dbg_level, (ngx_int_t) dbg_long,
+                               dbg_wlog);
             }
+#endif
             break;
         }
     }

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -1104,7 +1104,15 @@ ngx_http_zstd_profile_pack(ngx_int_t level, ngx_flag_t long_mode,
  * Inverse of ngx_http_zstd_profile_pack() for diagnostics and tests. Kept
  * adjacent to the packer on purpose: the two encode one layout, and splitting
  * them is how a pack/unpack pair drifts.
+ *
+ * Its only in-tree caller is the cctx-reuse debug log in
+ * ngx_http_zstd_acquire_cctx(), which is itself #if (NGX_DEBUG); without the
+ * same guard here a release build trips -Werror=unused-function. The
+ * standalone unit in ci/tools/test_cctx_profile_pack.sh extracts the
+ * "static void" line through the closing brace, so this #if stays outside
+ * that range on purpose -- do not fold it into the signature.
  */
+#if (NGX_DEBUG)
 static void
 ngx_http_zstd_profile_unpack(uint64_t key, ngx_int_t *level,
     ngx_flag_t *long_mode, ngx_int_t *window_log)
@@ -1115,6 +1123,7 @@ ngx_http_zstd_profile_unpack(uint64_t key, ngx_int_t *level,
                                & NGX_HTTP_ZSTD_PROFILE_WLOG_MAX);
     *long_mode = (ngx_flag_t) ((key >> NGX_HTTP_ZSTD_PROFILE_LONG_SHIFT) & 1);
 }
+#endif
 
 
 /*


### PR DESCRIPTION
## TL;DR

When the module reuses a compressor it already has warmed up, it was unpacking
a few numbers out of a bit-packed value purely so it could mention them in a
diagnostic log message — and it did that work whether or not anyone had asked
for diagnostic logging. This makes the unpacking happen only when the message
is actually going to be written, which matters because our test builds have
diagnostics compiled in and this runs on every reuse.

Concretely: `ngx_http_zstd_profile_unpack()` on the cached-CCtx borrow path in
`ngx_http_zstd_acquire_cctx()` is now behind `#if (NGX_DEBUG)` plus a runtime
`log->log_level & NGX_LOG_DEBUG_HTTP` test, matching the `ngx_log_debug5()` it
feeds.

**Severity:** Nit — a `[NIT] [perf]` row from the 2026-08-28 audit. No
behaviour change, no contract change; the emitted log line is byte-identical.

## The mechanism

`ngx_log_debug5()` tests the log level itself, so in a release build the whole
statement compiles out. The `ngx_http_zstd_profile_unpack()` call sitting in
front of it had no such test — it ran on every cached-CCtx borrow regardless,
doing a bitfield unpack plus three stack writes whose only consumer was a
message that in most runs is never emitted.

That is free in a release build. It is not free in an `NGX_DEBUG` build, which
is what this project's CI runs, and the borrow path is hot. Guarding it costs
two lines of wrapping and no new abstraction; the shape is the one nginx core
already uses (`if (log->log_level & NGX_LOG_DEBUG_HTTP)`, e.g.
`src/http/ngx_http_script.c`).

The existing comment noted that unpacking the slot key — rather than reading
`zlcf` — also exercises the key's reversibility on the hot debug path. That
self-check is deliberate and worth keeping, so the comment now records that it
holds in `NGX_DEBUG` builds with debug logging on, which is the only place it
was ever meaningful.

## Verification

Behaviour tests can only show this did not break anything; they cannot show the
guard fires. Both were checked.

* `ci/t/03-dcz.t` + `ci/t/00-filter.t`: **1511/1511** (176 + 1335), run to
  completion — plan lines printed, "All tests successful.", `Result: PASS`. Run
  independently by the supervisor as well as the implementer, because a
  Test::Nginx bail-out reports a plausible smaller count rather than a failure.
* **The debug line still appears when debug logging is on.** Two requests to a
  zstd-negotiated location on one worker, `error_log` at `debug`:
  `zstd: reusing worker cctx 000055AD58C00040 (slot:0) level:3 long:0 window_log:0`.
* **The unpack really is skipped when it should be.** A temporary
  `ngx_log_stderr()` was placed as the first statement of
  `ngx_http_zstd_profile_unpack()` and the same two-request test run twice: with
  `error_log ... debug` the instrumentation fired once, alongside the reuse
  line; with `error_log ... notice` it fired zero times and no `[debug]`-tagged
  zstd line appeared at all. Instrumentation removed and rebuilt — the `.so`
  returned to exactly 192136 bytes, matching the guarded build byte-for-byte
  and confirming a clean revert.
* `review-lint.sh --diff HEAD~1`: no coverage gap, no new findings on touched
  lines. The `lizard` and `ast-grep` entries are pre-existing and sit in other
  functions.
* CodeRabbit CLI: terminal `{"type":"complete","status":"review_completed","findings":0}`.

## Build fix after the first CI run

The first push guarded the caller but not the callee. That debug block is
`ngx_http_zstd_profile_unpack()`'s only in-tree caller, so a release build
compiled the function with nothing calling it and `-Werror=unused-function`
made it fatal:

    error: 'ngx_http_zstd_profile_unpack' defined but not used
           [-Werror=unused-function]

which failed both Windows builds, the dynamic-module linkage isolation job and
the compression_vary interop job. It did not reproduce locally because both
local build trees define `NGX_DEBUG 1` — the flag is absent from the 1.31.4
Makefile, but `objs/ngx_auto_config.h` sets it anyway — so the guarded caller
was always compiled in and the function always had one. A local `--with-debug`
build cannot see this class of failure at all.

Fixed in `77b4742` by guarding the definition with the same `#if`. Reproduced
first: forcing `NGX_DEBUG 0` in `objs/ngx_auto_config.h` and rebuilding
produces the exact CI error without the fix and a clean build with it.

The `#if` sits above the doc comment rather than around the signature, because
`ci/tools/test_cctx_profile_pack.sh` extracts the `static void` line through
the closing brace by line number and would break silently otherwise. That
harness was re-run and passes; the comment records the constraint so the guard
does not get "tidied" into the signature later.

## Review

No independent agent sweep, recorded as a deliberate call: single file, one
hunk, a guard around code that already only feeds a debug log, with the guard's
effect demonstrated by instrumentation rather than assumed. Per CLAUDE.md that
is the CodeRabbit-alone tier.
