### PR TITLE
fix(build): stop leaking -DZSTD_STATIC_LINKING_ONLY into dynamic fallback

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -835,9 +835,13 @@ jobs:
           tar -xzf "nginx-${NGINX_VERSION}.tar.gz"
           cd "nginx-${NGINX_VERSION}"
           # ZSTD_INC/ZSTD_LIB tell the module's filter/config to pick up
-          # the private libzstd 1.4.x build, not the system one. No
-          # -DZSTD_STATIC_LINKING_ONLY here on purpose: the fallback
-          # paths must compile under the plain dynamic-link build too.
+          # the private libzstd 1.4.x build, not the system one. This
+          # prefix has no libzstd.a (install-shared only, above), so
+          # auto/zstd's static probe fails and it falls back to the
+          # dynamic -lzstd retry, which auto/zstd no longer builds with
+          # -DZSTD_STATIC_LINKING_ONLY (see the symbol-import assertion
+          # below): the fallback paths must compile clean under the plain
+          # dynamic-link build too, without ZSTDLIB_STATIC_API imports.
           ZSTD_INC="$ZSTD_INC" ZSTD_LIB="$ZSTD_LIB" \
             ./configure \
               --with-compat \
@@ -859,6 +863,30 @@ jobs:
           # through the dynamic auto-discovery path).
           echo "LD_LIBRARY_PATH=$ZSTD_LIB" >> "$GITHUB_ENV"
           echo "TEST_NGINX_BINARY=$PWD/objs/nginx" >> "$GITHUB_ENV"
+
+      - name: Assert no static-only libzstd symbols leaked into the dynamic build
+        run: |
+          set -euo pipefail
+          cd "nginx-${NGINX_VERSION}"
+          # This job's private libzstd was built with install-shared only
+          # (no libzstd.a), so auto/zstd's static probe must have failed
+          # and fallen back to the dynamic -lzstd retry. That retry must
+          # NOT carry -DZSTD_STATIC_LINKING_ONLY: those declarations
+          # (ZSTDLIB_STATIC_API) have no stable ABI, so importing them
+          # into a dynamically linked module is unsupported even when the
+          # symbols happen to resolve today. Confirm none of the four
+          # static-only entry points the module's estimator/params code
+          # can reference are undefined imports of this binary.
+          ls "$HOME"/zstd14/lib/libzstd.a 2>/dev/null && \
+            { echo "FAIL: static archive present, this leg no longer tests the dynamic-only fallback"; exit 1; }
+          for sym in ZSTD_createCCtxParams ZSTD_CCtxParams_setParameter \
+                     ZSTD_estimateCStreamSize_usingCCtxParams ZSTD_freeCCtxParams; do
+            if nm -D --undefined-only objs/nginx | awk '{print $NF}' | grep -qx "$sym"; then
+              echo "FAIL: dynamic-only build imports static-only symbol $sym"
+              exit 1
+            fi
+          done
+          echo "✓ dynamic-only libzstd build carries no ZSTDLIB_STATIC_API imports"
 
       - name: Assert the private 1.4.x HEADERS were really compiled against
         run: |

--- a/auto/zstd
+++ b/auto/zstd
@@ -80,12 +80,15 @@ if [ -n "$ZSTD_INC" -o -n "$ZSTD_LIB" ]; then
         ngx_zstd_static_archive="libzstd.a"
     fi
 
-    # we try the static library first. The define rides CFLAGS (a flag
-    # context); the module compiles fine without it, but keeping it
-    # preserves the historical compile environment for these builds.
+    # we try the static library first. The define is only a candidate here:
+    # it rides ngx_zstd_opt_I for the probe, and is committed to CFLAGS (a
+    # flag context every source file sees) ONLY once the static archive is
+    # actually confirmed below. If it were added to CFLAGS unconditionally,
+    # a subsequent dynamic-library fallback would compile against
+    # ZSTDLIB_STATIC_API declarations while linking a shared object whose
+    # ABI does not guarantee them -- see the dynamic branch's comment.
     ngx_zstd_opt_I="-I$ZSTD_INC -DZSTD_STATIC_LINKING_ONLY"
     ngx_zstd_incs="$ZSTD_INC"
-    CFLAGS="$CFLAGS -DZSTD_STATIC_LINKING_ONLY"
     ngx_zstd_opt_L="$ZSTD_LIB/$ngx_zstd_static_archive"
     SAVED_CC_TEST_FLAGS=$CC_TEST_FLAGS
     CC_TEST_FLAGS="$ngx_zstd_opt_I $CC_TEST_FLAGS"
@@ -98,9 +101,22 @@ if [ -n "$ZSTD_INC" -o -n "$ZSTD_LIB" ]; then
     CC_TEST_FLAGS=$SAVED_CC_TEST_FLAGS
     NGX_TEST_LD_OPT=$SAVED_NGX_TEST_LD_OPT
 
-    if [ $ngx_found = no ]; then
-        # then try the dynamic shared library
+    if [ $ngx_found = yes ]; then
+        # Static archive confirmed: commit the define to CFLAGS so every
+        # source file compiles with the experimental API visible, matching
+        # what was just probed and linked.
+        CFLAGS="$CFLAGS -DZSTD_STATIC_LINKING_ONLY"
+    else
+        # then try the dynamic shared library. Do NOT carry
+        # -DZSTD_STATIC_LINKING_ONLY into this probe or into CFLAGS: the
+        # experimental (ZSTDLIB_STATIC_API) section has no stable ABI
+        # guarantee, so a module built against it but linked dynamically
+        # would import symbols (ZSTD_createCCtxParams and friends) that a
+        # future libzstd.so is free to remove or reshape. ngx_zstd_opt_I is
+        # reset to plain -I so downstream consumers (ngx_module_incs, the
+        # version-probe below) see the dynamic build's real flags.
         ngx_feature="ZStandard dynamic library in $ZSTD_INC and $ZSTD_LIB"
+        ngx_zstd_opt_I="-I$ZSTD_INC"
         if [ "${NGX_PLATFORM:-}" = win32 ]; then
             # MinGW produces PE/COFF modules. Its linker has no ELF runtime
             # search path to encode, and --enable-new-dtags/-rpath are either


### PR DESCRIPTION
## Summary
- `auto/zstd` added `-DZSTD_STATIC_LINKING_ONLY` to `CFLAGS` unconditionally before probing for `libzstd.a`, and never removed it when that probe failed and the code fell back to a plain `-lzstd` dynamic link.
- A `ZSTD_LIB` directory with only a shared library therefore produced a dynamically linked module importing `ZSTD_createCCtxParams`, `ZSTD_CCtxParams_setParameter`, `ZSTD_estimateCStreamSize_usingCCtxParams`, and `ZSTD_freeCCtxParams` — all `ZSTDLIB_STATIC_API`, which upstream documents as having no stable ABI when linked dynamically.
- The define is now committed to `CFLAGS` only after the static-archive probe succeeds; the dynamic retry probes and builds without it. This matches the module's existing documented no-estimator degradation path (`zstd_max_cctx_memory` already gets an actionable configure-time error when the macro is absent).
- The auto-discovery branch (no `ZSTD_INC`/`ZSTD_LIB` set) never added the define in the first place — confirmed by reading the rest of `auto/zstd`; no change needed there.
- Extended the existing libzstd-1.4.x CI leg (`build-old-libzstd`), which already builds a dynamic-only private prefix (`install-shared`, no `libzstd.a`), with a symbol-import assertion pinning the fix. The true-static `ZSTD_INC`/`ZSTD_LIB` leg is untouched.

## Test plan
- [x] Local repro: dynamic-only `libzstd.so`-only directory (no `.a`), configured against pre-fix `auto/zstd` (master) — `nm -D --undefined-only` on the built `.so` showed all four static-only symbols as undefined imports (negative control genuinely red).
- [x] Same directory against the fixed tree — `nm -D --undefined-only` shows none of the four symbols (`NONE_FOUND`).
- [x] True-static leg (`libzstd.a` present) still selects the static probe, commits the macro to `CFLAGS`, and builds/links correctly.
- [x] Canonical jail build (`make modules` against `.build/nginx-1.31.1`, auto-discovery path, no `ZSTD_INC`/`ZSTD_LIB`) builds clean, confirming that branch is unaffected.
- [x] `review-lint.sh --branch master`: all lenses clean or benign (yamllint line-length warnings pre-existing style, zizmor/trivy/checkov report no findings).