### PR TITLE
sweep-nit: root t/servroot gitignore, dcz window-cap floor, TEST 49 witness audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,14 @@ objs/
 ci/t/servroot/
 ci/t/servroot-*/
 
+# Test::Nginx defaults to t/servroot/ relative to CWD when
+# TEST_NGINX_SERVROOT is unset (e.g. `prove ci/t/foo.t` run from the repo
+# root). CI always sets TEST_NGINX_SERVROOT explicitly, so this is narrowly
+# scoped to the generated servroot dir rather than ignoring all of `t/`,
+# which could later mask a real source directory.
+/t/servroot/
+/t/servroot-*/
+
 # Python bytecode cache (test tooling under tools/)
 __pycache__/
 *.pyc

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -4632,12 +4632,15 @@ ngx_http_zstd_estimate_cctx_memory(ngx_conf_t *cf,
  * would be a hot-path regression for a constant.
  *
  * Search is a downward walk from NGX_HTTP_ZSTD_DCZ_MAX_WINDOW_LOG to
- * ZSTD_WINDOWLOG_MIN: at most 14 estimate calls, once, and monotonicity of
- * workspace in the window is not assumed. The floor is ZSTD_WINDOWLOG_MIN --
- * returning less would push an invalid windowLog into libzstd. If not even
- * the minimum window fits, the cap is the minimum anyway: the existing
- * nginx -t gate is what refuses an impossible budget, and this function must
- * not invent a second, differently-worded rejection for the same config.
+ * NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG, inclusive: at most 14 estimate calls,
+ * once, and monotonicity of workspace in the window is not assumed. The
+ * floor is NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG -- returning less would push an
+ * invalid windowLog into libzstd. The floor is itself estimated and checked
+ * like every other candidate, rather than assumed to fit by falling out of
+ * the loop unevaluated. If not even the minimum window fits, the cap is the
+ * minimum anyway: the existing nginx -t gate is what refuses an impossible
+ * budget, and this function must not invent a second, differently-worded
+ * rejection for the same config.
  *
  * Writes 0 ("no cap") and succeeds when no budget is configured -- the
  * default, where dcz behaviour must be exactly what it was.
@@ -4658,7 +4661,7 @@ ngx_http_zstd_dcz_window_cap(ngx_conf_t *cf, ngx_http_zstd_loc_conf_t *conf,
     }
 
     for (wlog = NGX_HTTP_ZSTD_DCZ_MAX_WINDOW_LOG;
-         wlog > ZSTD_WINDOWLOG_MIN;
+         wlog >= NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG;
          wlog--)
     {
         if (ngx_http_zstd_estimate_cctx_memory(cf, conf, wlog, &est)
@@ -4670,6 +4673,18 @@ ngx_http_zstd_dcz_window_cap(ngx_conf_t *cf, ngx_http_zstd_loc_conf_t *conf,
         if (est <= (size_t) conf->max_cctx_memory) {
             break;
         }
+    }
+
+    /*
+     * If even NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG did not fit the budget, the
+     * loop above still evaluated it (unlike the old wlog > MIN loop, which
+     * exited with the floor unevaluated) and then decremented past it. Pin
+     * the cap back to the floor: the hard budget gate above is what refuses
+     * an impossible config, this function must not return a windowLog below
+     * its documented floor.
+     */
+    if (wlog < NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG) {
+        wlog = NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG;
     }
 
     *cap = wlog;

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -4679,9 +4679,19 @@ ngx_http_zstd_dcz_window_cap(ngx_conf_t *cf, ngx_http_zstd_loc_conf_t *conf,
      * If even NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG did not fit the budget, the
      * loop above still evaluated it (unlike the old wlog > MIN loop, which
      * exited with the floor unevaluated) and then decremented past it. Pin
-     * the cap back to the floor: the hard budget gate above is what refuses
-     * an impossible config, this function must not return a windowLog below
-     * its documented floor.
+     * the cap back to the floor: this function must not return a windowLog
+     * below its documented floor.
+     *
+     * NOTE: pinning to the floor here is NOT budget enforcement. The hard
+     * gate in the caller estimates against conf->window_log only, so a
+     * location whose conf->window_log fits the budget while even the DCZ
+     * minimum window does not will load successfully and then apply this
+     * floor, exceeding "zstd_max_cctx_memory" on the dcz path. That
+     * enforcement hole predates this loop change (the old wlog > MIN form
+     * returned the same floor, merely unevaluated) and is preserved here
+     * deliberately: rejecting the config instead would turn "nginx -t" from
+     * pass to fail on configurations that load today. Tracked as its own
+     * row; do not "fix" it inside an unrelated change.
      */
     if (wlog < NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG) {
         wlog = NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG;


### PR DESCRIPTION
## Summary

Three `sweep-nit` TODO rows in one sweep commit.

- **`.gitignore`**: `prove ci/t/03-dcz.t` run from the repo root (the natural
  local invocation) leaves Test::Nginx's default `t/servroot/` untracked,
  since Test::Nginx creates its servroot relative to CWD when
  `TEST_NGINX_SERVROOT` is unset. Added `/t/servroot/` and `/t/servroot-*/`
  at the repo root -- narrow, not a blanket `t/` ignore, since `t/` could
  later hold a real source directory. Verified CI's explicit
  `TEST_NGINX_SERVROOT` exports in `.github/workflows/*.yml` and
  `ci/tools/coverage.sh` are all absolute/prefixed paths and untouched by
  this change.

- **`ngx_http_zstd_dcz_window_cap()`** (`src/ngx_http_zstd_filter_module.c`):
  the search loop used the raw `ZSTD_WINDOWLOG_MIN` macro instead of the
  module's own `NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG`, and stopped at
  `wlog > MIN`, so the floor was never itself passed to the estimator --
  it became the returned cap by falling out of the loop unevaluated, not
  by measurement. Fixed to walk down to and including the floor, with a
  post-loop clamp that preserves the exact prior return value when nothing
  fits (the existing hard budget gate is still what refuses an impossible
  config). Confirmed by mutation (see test plan) that the floor is now
  genuinely evaluated and that this changes no observable behaviour.

- **`ci/` debug-log witness audit**: audited every debug-log witness test
  for the TEST 49 shape (PR #234) -- a witness emitted at only one of
  several call sites making a "happens exactly once" `grep_error_log_out`
  count assertion pass whether the code runs once or N times. Result:
  `grep_error_log_out`/`grep_error_log` appear nowhere else in `ci/`, and
  `error_log ... debug` is enabled only in `03-dcz.t`, whose sole such
  assertion (TEST 49) already emits and asserts across both call sites
  since PR #234. No other test has this shape. No edit made; this is an
  audit-only deliverable.

## Test plan

- [x] `prove ci/03-dcz.t` from the repo root reproduces stray `t/servroot/`
      pre-fix; post-fix `git status` is clean.
- [x] `ci/03-dcz.t` + `ci/00-filter.t`: `Files=2, Tests=1511,
      Result: PASS`, "All tests successful."
- [x] Mutation on the window-cap floor fix: reverted `wlog >= MIN` to the
      old `wlog > MIN`, rebuilt the module, and confirmed via a temporary
      debug print that `wlog=10` is never evaluated for a config
      engineered to need it (budget between the wlog=11 and wlog=10
      estimates); restored the fix and confirmed `wlog=10` is evaluated
      (`est=98148 <= budget=100000`) and `nginx -t` succeeds in both
      versions with identical config-load behaviour.
- [x] `.claude/skills/_shared/review-lint.sh --branch master`: all linters
      clean; lizard/ast-grep findings present are pre-existing and not on
      touched lines.
- [ ] CodeRabbit CLI gate (`coderabbit review --agent --base master`):
      **rate-limited** (`rate_limit`, "used all 5 included reviews"),
      retried once after backoff, still rate-limited. Not run; reported
      here rather than skipped or claimed passing.