### PR TITLE
docs(dcz): correct the window-cap floor comment; pin the no-dcz budget path

### DIFF
--- a/ci/t/02-conf-warn.t
+++ b/ci/t/02-conf-warn.t
@@ -654,3 +654,36 @@ symlink $real, "$root/html/current"
 a symlink at any component is refused, not followed
 --- no_error_log
 [alert]
+
+
+
+=== TEST 23: a tight zstd_max_cctx_memory without dcz dictionaries still loads
+# Regression pin for the dcz window-cap floor. ngx_http_zstd_dcz_window_cap()
+# walks down from NGX_HTTP_ZSTD_DCZ_MAX_WINDOW_LOG and, if nothing fit, pins
+# the cap to NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG and succeeds rather than
+# rejecting. That permissive fallthrough must stay permissive: a budget the
+# hard gate accepted has to keep loading, so the cap computation can never
+# turn a working "nginx -t" into a failure. Level 1 at the default window
+# estimates ~1.37 MB (libzstd 1.5.7), so 2m is tight but satisfiable — the
+# budget path is genuinely exercised rather than trivially slack, and the
+# location configures no zstd_dcz_dict_file, which is the scoping that makes
+# the dcz clamp irrelevant here. Asserts a served response, not merely a
+# start, so a config that loads but breaks compression still fails.
+--- config
+    location /budget {
+        zstd on;
+        zstd_min_length 1;
+        zstd_comp_level 1;
+        zstd_max_cctx_memory 2m;
+        zstd_types text/plain;
+        default_type text/plain;
+        return 200 "hello world padding padding padding padding padding\n";
+    }
+--- request
+GET /budget
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+Content-Encoding: zstd
+--- no_error_log
+[error]

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -4637,10 +4637,10 @@ ngx_http_zstd_estimate_cctx_memory(ngx_conf_t *cf,
  * floor is NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG -- returning less would push an
  * invalid windowLog into libzstd. The floor is itself estimated and checked
  * like every other candidate, rather than assumed to fit by falling out of
- * the loop unevaluated. If not even the minimum window fits, the cap is the
- * minimum anyway: the existing nginx -t gate is what refuses an impossible
- * budget, and this function must not invent a second, differently-worded
- * rejection for the same config.
+ * the loop unevaluated. The floor cannot actually fail to fit once the
+ * caller's gate has passed -- see the invariant argument at the pin below
+ * -- so the fallthrough pins to the floor rather than raising a second,
+ * differently-worded rejection for a config the gate already vetted.
  *
  * Writes 0 ("no cap") and succeeds when no budget is configured -- the
  * default, where dcz behaviour must be exactly what it was.
@@ -4682,16 +4682,21 @@ ngx_http_zstd_dcz_window_cap(ngx_conf_t *cf, ngx_http_zstd_loc_conf_t *conf,
      * the cap back to the floor: this function must not return a windowLog
      * below its documented floor.
      *
-     * NOTE: pinning to the floor here is NOT budget enforcement. The hard
-     * gate in the caller estimates against conf->window_log only, so a
-     * location whose conf->window_log fits the budget while even the DCZ
-     * minimum window does not will load successfully and then apply this
-     * floor, exceeding "zstd_max_cctx_memory" on the dcz path. That
-     * enforcement hole predates this loop change (the old wlog > MIN form
-     * returned the same floor, merely unevaluated) and is preserved here
-     * deliberately: rejecting the config instead would turn "nginx -t" from
-     * pass to fail on configurations that load today. Tracked as its own
-     * row; do not "fix" it inside an unrelated change.
+     * The pin is a defensive invariant, not budget enforcement, and needs
+     * no error path: whenever the caller's hard gate passed, this branch
+     * is unreachable. (The search above still does not assume
+     * monotonicity -- that keeps the chosen cap correct under any
+     * libzstd; the argument here is only about whether the fallthrough
+     * can be entered at all.) NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG equals
+     * ZSTD_WINDOWLOG_MIN, so the floor is the smallest window libzstd
+     * accepts, and ZSTD_estimateCStreamSize_usingCCtxParams() is monotone
+     * non-decreasing in windowLog. The gate estimates at a window that is
+     * never below the floor, hence est(floor) <= est(gate window): a
+     * budget the gate accepted always admits the floor too.
+     *
+     * Two changes would falsify that and require re-examining this branch:
+     * a libzstd whose workspace estimate is non-monotone in windowLog, or
+     * raising NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG above ZSTD_WINDOWLOG_MIN.
      */
     if (wlog < NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG) {
         wlog = NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG;


### PR DESCRIPTION
## TL;DR

A comment in `ngx_http_zstd_dcz_window_cap()` claimed the DCZ path could quietly
exceed `zstd_max_cctx_memory`, and #239 filed a backlog row against that claim.
The claim is wrong. The branch it describes cannot be entered once the caller's
budget gate has passed, so there is no enforcement hole to close — only a comment
to correct. This PR rewrites both comment sites and pins the behaviour with a
test. No executable change.

## Why the old comment was wrong

`dcz_window_cap()` walks windowLog down from the DCZ maximum, estimating each
candidate against the budget, and pins to `NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG` if
nothing fit. The old comment described that pin as a live enforcement hole: a
location whose `conf->window_log` fits the budget while the DCZ floor does not
would load anyway and then exceed the budget.

Two facts make that unreachable:

- `NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG == ZSTD_WINDOWLOG_MIN == 10`
  (`/usr/include/zstd.h:1266`). The floor is the smallest window libzstd accepts,
  so the gate's own window is never below it.
- `ZSTD_estimateCStreamSize_usingCCtxParams()` is monotone non-decreasing in
  windowLog.

Together: `est(floor) <= est(gate window)`. A budget the gate accepted always
admits the floor, so the fallthrough is unreachable whenever the gate passed.

I checked the monotonicity empirically as well as structurally — levels 1 through
22 (including the ultra levels the gate's error message cites) crossed with
`long` on and off, windowLog 10..23, and six `targetCBlockSize` values. Zero
counterexamples and zero non-monotone steps. The structural half of the argument
does not depend on that sweep.

## What changed

Both comment sites now say what is actually true: the pin is a defensive
invariant, not budget enforcement, and it needs no error path. The comment names
the two conditions that would falsify the argument and force a re-examination —
a libzstd whose workspace estimate is non-monotone in windowLog, or raising
`NGX_HTTP_ZSTD_DCZ_MIN_WINDOW_LOG` above `ZSTD_WINDOWLOG_MIN`.

The floor pin itself stays. The downward search still does not assume
monotonicity, which keeps the chosen cap correct under any libzstd; the
monotonicity argument is only about whether the fallthrough can be entered.

## Testing

`ci/t/02-conf-warn.t` TEST 23 pins the permissive behaviour: a tight
`zstd_max_cctx_memory 2m` with no `zstd_dcz_dict_file` still loads *and* still
serves `Content-Encoding: zstd`. Level 1 at the default window estimates ~1.37 MB
under libzstd 1.5.7, so the budget is genuinely tight rather than trivially
slack. Asserting a served response rather than a successful start means a config
that loads but breaks compression still fails the test.

Built from this branch's source against nginx 1.31.1 and run locally:

```
1..91
All tests successful.
Files=1, Tests=91,  3 wallclock secs
Result: PASS
```

## Scope

Comment text plus one test. `git diff` against `master` touches no executable
statement in `src/ngx_http_zstd_filter_module.c` — the C hunks are entirely
inside comment blocks. This closes the `zstd_max_cctx_memory` DCZ row filed from
#239 by refuting it rather than by changing enforcement.
