### PR TITLE
refactor(static): decompose ngx_http_zstd_static_handler into three helpers

### DIFF
--- a/src/ngx_http_zstd_static_module.c
+++ b/src/ngx_http_zstd_static_module.c
@@ -1237,6 +1237,137 @@ probe_done:
 
 
 static ngx_int_t
+ngx_http_zstd_static_send(ngx_http_request_t *r, ngx_open_file_info_t *of,
+    ngx_str_t *path, ngx_log_t *log)
+{
+    ngx_int_t          rc;
+    ngx_buf_t         *b;
+    ngx_chain_t        out;
+    ngx_table_elt_t   *h;
+
+    r->root_tested = !r->error_page;
+
+    rc = ngx_http_discard_request_body(r);
+    if (rc != NGX_OK) {
+        return rc;
+    }
+
+    log->action = (char *) "sending response to client";
+
+    r->headers_out.status = NGX_HTTP_OK;
+    r->headers_out.content_length_n = of->size;
+    r->headers_out.last_modified_time = of->mtime;
+
+    if (ngx_http_set_etag(r) != NGX_OK) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    /*
+     * ngx_http_set_content_type() uses r->exten which is derived from the
+     * original URI, not from path. No path manipulation is needed here.
+     */
+    if (ngx_http_set_content_type(r) != NGX_OK) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    h = ngx_list_push(&r->headers_out.headers);
+    if (h == NULL) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    h->hash = 1;
+#if (nginx_version >= 1023000)
+    h->next = NULL;
+#endif
+    ngx_str_set(&h->key, "Content-Encoding");
+    ngx_str_set(&h->value, "zstd");
+    r->headers_out.content_encoding = h;
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, log, 0,
+                   "zstd static: serving precompressed \"%s\"", path->data);
+
+    /* gzip_static parity: byte ranges address the SELECTED
+     * REPRESENTATION (RFC 9110 §14.2) — here the .zst bytes on disk,
+     * which a client can fetch, resume and concatenate coherently
+     * because the validator is strong and the bytes are stable. That
+     * is why gzip_static has always set r->allow_ranges, and ranges
+     * only work by opting in: the range filter bails without the
+     * flag. The FILTER module's clear_accept_ranges remains correct
+     * for the opposite reason — a stream generated on the fly has
+     * nothing stable to seek into. */
+    r->allow_ranges = 1;
+
+    /* HEAD fast path: send headers only, skip body buffer allocation.
+     * r->header_only covers more than HEAD (304/204), so check method
+     * explicitly to avoid breaking other status codes. */
+    if (r->method == NGX_HTTP_HEAD) {
+        return ngx_http_send_header(r);
+    }
+
+    /*
+     * One ngx_pcalloc() for the ngx_buf_t and its ngx_file_t, instead of
+     * ngx_calloc_buf() (itself ngx_pcalloc(pool, sizeof(ngx_buf_t))) plus
+     * a second ngx_pcalloc() for b->file: the two objects share the same
+     * lifetime (this response) and the same ownership (freed together
+     * with the pool), so there is nothing the split allocation buys.
+     * Only reached for a non-HEAD GET — the HEAD fast path above returns
+     * before this point — so this removes one pool-allocation call per
+     * static GET response body, not per request.
+     *
+     * ngx_http_zstd_static_buf_t is declared solely to size and zero
+     * this combined allocation; nothing outside this function names it.
+     * Both members keep the same zero-initialized start ngx_calloc_buf()/
+     * ngx_pcalloc() gave them, so every field this handler does not set
+     * explicitly below (b->pos, b->last, b->temporary, file.offset, ...)
+     * is still guaranteed zero.
+     */
+    {
+        ngx_http_zstd_static_buf_t  *wrap;
+
+        wrap = ngx_pcalloc(r->pool, sizeof(ngx_http_zstd_static_buf_t));
+        if (wrap == NULL) {
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
+
+        b = &wrap->buf;
+        b->file = &wrap->file;
+    }
+
+    rc = ngx_http_send_header(r);
+
+    if (rc == NGX_ERROR || rc > NGX_OK || r->header_only) {
+        return rc;
+    }
+
+    b->file_pos = 0;
+    b->file_last = of->size;
+
+    b->in_file = b->file_last ? 1 : 0;
+    b->last_buf = (r == r->main) ? 1 : 0;
+    b->last_in_chain = 1;
+
+    /* gzip_static parity: a zero-length file served in a subrequest
+     * yields a buf with neither in_file nor last_buf — sync marks it
+     * so the output chain doesn't reject it as a zero-size buf. Only
+     * reachable when the frame-header probe is compiled out (a POSIX
+     * build whose configure found no pread(2) — see
+     * NGX_HTTP_ZSTD_STATIC_HAVE_PROBE); with the probe active, which
+     * now includes Win32, sub-4-byte files never get this far. */
+    b->sync = (b->last_buf || b->in_file) ? 0 : 1;
+
+    b->file->fd = of->fd;
+    b->file->name = *path;
+    b->file->log = log;
+    b->file->directio = of->is_directio;
+
+    out.buf = b;
+    out.next = NULL;
+
+    return ngx_http_output_filter(r, &out);
+}
+
+
+static ngx_int_t
 ngx_http_zstd_static_handler(ngx_http_request_t *r)
 {
     u_char                       *p;
@@ -1245,10 +1376,7 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
     ngx_uint_t                    level;
     size_t                        root;
     ngx_str_t                     path;
-    ngx_buf_t                    *b;
     ngx_log_t                    *log;
-    ngx_table_elt_t              *h;
-    ngx_chain_t                   out;
     ngx_open_file_info_t          of;
     ngx_http_core_loc_conf_t           *clcf;
     const ngx_http_zstd_static_conf_t  *zscf;
@@ -1477,125 +1605,7 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
         }
     }
 
-    r->root_tested = !r->error_page;
-
-    rc = ngx_http_discard_request_body(r);
-    if (rc != NGX_OK) {
-        return rc;
-    }
-
-    log->action = (char *) "sending response to client";
-
-    r->headers_out.status = NGX_HTTP_OK;
-    r->headers_out.content_length_n = of.size;
-    r->headers_out.last_modified_time = of.mtime;
-
-    if (ngx_http_set_etag(r) != NGX_OK) {
-        return NGX_HTTP_INTERNAL_SERVER_ERROR;
-    }
-
-    /*
-     * ngx_http_set_content_type() uses r->exten which is derived from the
-     * original URI, not from path. No path manipulation is needed here.
-     */
-    if (ngx_http_set_content_type(r) != NGX_OK) {
-        return NGX_HTTP_INTERNAL_SERVER_ERROR;
-    }
-
-    h = ngx_list_push(&r->headers_out.headers);
-    if (h == NULL) {
-        return NGX_HTTP_INTERNAL_SERVER_ERROR;
-    }
-
-    h->hash = 1;
-#if (nginx_version >= 1023000)
-    h->next = NULL;
-#endif
-    ngx_str_set(&h->key, "Content-Encoding");
-    ngx_str_set(&h->value, "zstd");
-    r->headers_out.content_encoding = h;
-
-    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, log, 0,
-                   "zstd static: serving precompressed \"%s\"", path.data);
-
-    /* gzip_static parity: byte ranges address the SELECTED
-     * REPRESENTATION (RFC 9110 §14.2) — here the .zst bytes on disk,
-     * which a client can fetch, resume and concatenate coherently
-     * because the validator is strong and the bytes are stable. That
-     * is why gzip_static has always set r->allow_ranges, and ranges
-     * only work by opting in: the range filter bails without the
-     * flag. The FILTER module's clear_accept_ranges remains correct
-     * for the opposite reason — a stream generated on the fly has
-     * nothing stable to seek into. */
-    r->allow_ranges = 1;
-
-    /* HEAD fast path: send headers only, skip body buffer allocation.
-     * r->header_only covers more than HEAD (304/204), so check method
-     * explicitly to avoid breaking other status codes. */
-    if (r->method == NGX_HTTP_HEAD) {
-        return ngx_http_send_header(r);
-    }
-
-    /*
-     * One ngx_pcalloc() for the ngx_buf_t and its ngx_file_t, instead of
-     * ngx_calloc_buf() (itself ngx_pcalloc(pool, sizeof(ngx_buf_t))) plus
-     * a second ngx_pcalloc() for b->file: the two objects share the same
-     * lifetime (this response) and the same ownership (freed together
-     * with the pool), so there is nothing the split allocation buys.
-     * Only reached for a non-HEAD GET — the HEAD fast path above returns
-     * before this point — so this removes one pool-allocation call per
-     * static GET response body, not per request.
-     *
-     * ngx_http_zstd_static_buf_t is declared solely to size and zero
-     * this combined allocation; nothing outside this function names it.
-     * Both members keep the same zero-initialized start ngx_calloc_buf()/
-     * ngx_pcalloc() gave them, so every field this handler does not set
-     * explicitly below (b->pos, b->last, b->temporary, file.offset, ...)
-     * is still guaranteed zero.
-     */
-    {
-        ngx_http_zstd_static_buf_t  *wrap;
-
-        wrap = ngx_pcalloc(r->pool, sizeof(ngx_http_zstd_static_buf_t));
-        if (wrap == NULL) {
-            return NGX_HTTP_INTERNAL_SERVER_ERROR;
-        }
-
-        b = &wrap->buf;
-        b->file = &wrap->file;
-    }
-
-    rc = ngx_http_send_header(r);
-
-    if (rc == NGX_ERROR || rc > NGX_OK || r->header_only) {
-        return rc;
-    }
-
-    b->file_pos = 0;
-    b->file_last = of.size;
-
-    b->in_file = b->file_last ? 1 : 0;
-    b->last_buf = (r == r->main) ? 1 : 0;
-    b->last_in_chain = 1;
-
-    /* gzip_static parity: a zero-length file served in a subrequest
-     * yields a buf with neither in_file nor last_buf — sync marks it
-     * so the output chain doesn't reject it as a zero-size buf. Only
-     * reachable when the frame-header probe is compiled out (a POSIX
-     * build whose configure found no pread(2) — see
-     * NGX_HTTP_ZSTD_STATIC_HAVE_PROBE); with the probe active, which
-     * now includes Win32, sub-4-byte files never get this far. */
-    b->sync = (b->last_buf || b->in_file) ? 0 : 1;
-
-    b->file->fd = of.fd;
-    b->file->name = path;
-    b->file->log = log;
-    b->file->directio = of.is_directio;
-
-    out.buf = b;
-    out.next = NULL;
-
-    return ngx_http_output_filter(r, &out);
+    return ngx_http_zstd_static_send(r, &of, &path, log);
 }
 
 

--- a/src/ngx_http_zstd_static_module.c
+++ b/src/ngx_http_zstd_static_module.c
@@ -1367,18 +1367,22 @@ ngx_http_zstd_static_send(ngx_http_request_t *r, ngx_open_file_info_t *of,
 }
 
 
+/*
+ * Decide whether this request is a candidate for a precompressed .zst
+ * at all, before any filesystem work: method, URI shape, the
+ * zstd_static setting, and the RFC 9842 dcz stand-aside. Split out of
+ * ngx_http_zstd_static_handler() purely for readability -- the tests,
+ * their order, their log lines and their return values are unchanged.
+ *
+ * Returns NGX_OK to mean "keep going", with the zscf out-param set and
+ * the accepts out-param holding the Accept-Encoding verdict the Vary
+ * decision needs later. Any other value is the handler return.
+ */
 static ngx_int_t
-ngx_http_zstd_static_handler(ngx_http_request_t *r)
+ngx_http_zstd_static_negotiate(ngx_http_request_t *r,
+    const ngx_http_zstd_static_conf_t **zscfp, ngx_uint_t *accepts)
 {
-    u_char                       *p;
-    ngx_int_t                     rc;
-    ngx_uint_t                    accepts;
-    ngx_uint_t                    level;
-    size_t                        root;
-    ngx_str_t                     path;
-    ngx_log_t                    *log;
-    ngx_open_file_info_t          of;
-    ngx_http_core_loc_conf_t           *clcf;
+    ngx_int_t                           rc;
     const ngx_http_zstd_static_conf_t  *zscf;
 
     if (!(r->method & (NGX_HTTP_GET|NGX_HTTP_HEAD))) {
@@ -1443,7 +1447,32 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
      * variable to reach the Vary decision after the .zst has been
      * validated (see the emission site near the end of the probe).
      */
-    accepts = (rc == NGX_OK);
+
+    *accepts = (rc == NGX_OK);
+    *zscfp = zscf;
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+ngx_http_zstd_static_handler(ngx_http_request_t *r)
+{
+    u_char                       *p;
+    ngx_int_t                     rc;
+    ngx_uint_t                    accepts;
+    ngx_uint_t                    level;
+    size_t                        root;
+    ngx_str_t                     path;
+    ngx_log_t                    *log;
+    ngx_open_file_info_t          of;
+    ngx_http_core_loc_conf_t           *clcf;
+    const ngx_http_zstd_static_conf_t  *zscf;
+
+    rc = ngx_http_zstd_static_negotiate(r, &zscf, &accepts);
+    if (rc != NGX_OK) {
+        return rc;
+    }
 
     clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
 
@@ -1468,10 +1497,10 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
      * stored zstd body for this one.
      *
      * "always" ignores Accept-Encoding and never varies, so it keeps
-     * its own shortcut: rc is forced to NGX_OK for it above, which
+     * its own shortcut: accepts is forced true for it above, which
      * leaves this test false regardless of gzip_vary.
      */
-    if (zscf->enable != NGX_HTTP_ZSTD_STATIC_ON && rc != NGX_OK) {
+    if (zscf->enable != NGX_HTTP_ZSTD_STATIC_ON && !accepts) {
         ngx_log_debug0(NGX_LOG_DEBUG_HTTP, log, 0,
                        "zstd static: skip, client did not accept zstd");
         return NGX_DECLINED;

--- a/src/ngx_http_zstd_static_module.c
+++ b/src/ngx_http_zstd_static_module.c
@@ -823,6 +823,419 @@ ngx_http_zstd_static_should_bypass(ngx_http_request_t *r)
 }
 
 
+#if (NGX_HTTP_ZSTD_STATIC_HAVE_PROBE)
+/*
+ * Magic-number sanity check on the .zst file.
+ *
+ * Without this, a truncated, half-downloaded, mistakenly-renamed
+ * (e.g. `cp foo.txt foo.zst`), or otherwise non-zstd file would be
+ * served with `Content-Encoding: zstd` and the client would get an
+ * undecodable body — a confusing outage class that nginx's built-in
+ * gzip_static also doesn't defend against. The probe is cheap (one
+ * offset-explicit read of the frame-header prefix at offset 0 — 18
+ * bytes, or a pair of aligned blocks under directio — via
+ * ngx_http_zstd_static_pread(): pread(2) on POSIX, ngx_read_file()
+ * on Win32, both of which take the offset as an argument and so
+ * never move the open_file_cache's shared fd position. Using plain
+ * read(2)/SetFilePointer would do exactly that and corrupt
+ * subsequent requests serving the same cached fd). On mismatch we
+ * decline, so nginx falls back to serving the uncompressed original (or
+ * returns 404 if it is absent), and the operator sees a clear
+ * error log line.
+ *
+ * Both a regular zstd frame (ZSTD_MAGICNUMBER) and a skippable
+ * frame (ZSTD_MAGIC_SKIPPABLE_START..+0xF) are accepted, since
+ * either is a valid leading frame in a zstd stream.
+ *
+ * Gated by NGX_HTTP_ZSTD_STATIC_HAVE_PROBE (see its definition):
+ * compiled in on Win32 and on any POSIX build whose configure found
+ * pread(2). On a POSIX build WITHOUT pread(2) the probe is skipped
+ * rather than degraded to a read+lseek pair that would mutate the
+ * shared fd offset — every modern POSIX target has it, so that
+ * branch is essentially a build-time tripwire.
+ *
+ * The probe deliberately runs on Win32 too. It used to be compiled
+ * out there, which meant a Windows build served ANY .zst with no
+ * magic check, no truncation check, no 8 MB window guard and no
+ * skippable-frame chain bound — a strictly weaker validation than
+ * the POSIX build, on a target the Windows build CI ships. The
+ * verdict logic is shared, so the two platforms cannot drift apart
+ * again; only the byte fetch differs.
+ *
+ * When the file was opened with O_DIRECT (of.is_directio, set by
+ * ngx_open_cached_file when "directio <size>" is configured and the
+ * file meets the threshold), BOTH the read offset and the length
+ * must be block-aligned, so the probe rounds each frame offset down
+ * to directio_alignment CLAMPED to
+ * [NGX_HTTP_ZSTD_STATIC_DIO_PROBE, NGX_HTTP_ZSTD_STATIC_DIO_PROBE_MAX]
+ * and reads two such blocks into an equally-aligned pool buffer,
+ * parsing the frame at its offset inside them. The clamp follows the
+ * operator's declared geometry only as far as a header probe can
+ * use it: the floor is what keeps the read legal on 512-byte and
+ * 4K-native devices, and the ceiling is why an unbounded
+ * "directio_alignment" cannot turn an 18-byte header check into a
+ * multi-megabyte allocation and O_DIRECT read on every request that
+ * reaches the probe. Rounding the OFFSET is what the skippable-frame
+ * walk needs:
+ * the second and later probes are at whatever offset the previous
+ * frame's declared length produced (40 for a canonical dcz prefix),
+ * which an O_DIRECT descriptor rejects with EINVAL if passed raw.
+ *
+ * The window check in particular must not be skipped under
+ * directio: oversized declared windows are a
+ * systematic build-pipeline product, not rare corruption, and every
+ * browser rejects them. If the aligned read STILL fails, the file
+ * is DECLINED, not served: for a validation read, falling back to
+ * another encoding is safer than certifying a file we could not
+ * inspect, and the error log tells the operator which knob
+ * (directio_alignment) disagrees with the device. On Win32
+ * ngx_directio_on() is an upstream no-op stub, so of.is_directio
+ * only ever reflects the operator's "directio" directive there and
+ * the aligned path costs one pool allocation with no behavioural
+ * difference — it is left shared rather than forked, because a
+ * Win32-only bypass of this branch is exactly the kind of split
+ * that reintroduces the gap this change closes.
+ */
+static ngx_int_t
+ngx_http_zstd_static_probe_file(ngx_http_request_t *r,
+    const ngx_http_core_loc_conf_t *clcf, ngx_open_file_info_t *of,
+    ngx_str_t *path, ngx_log_t *log)
+{
+    /*
+     * 18 bytes covers the largest possible frame header prefix this
+     * check needs: magic(4) + descriptor(1) + window byte(1) for
+     * streaming frames, or magic(4) + descriptor(1) + dictionary
+     * id(<=4) + content size(<=8) for single-segment frames. Short
+     * files return fewer bytes; each parse path checks it got what
+     * that frame layout requires.
+     */
+    u_char       hdrbuf[18];
+    u_char      *hdr, *frame;
+    size_t       want, align, frame_off, avail, got;
+    ssize_t      n;
+    uint64_t     window, skip;
+    ngx_uint_t   frames, scratch, have_block;
+    off_t        pos, base, have_base;
+    ngx_int_t    probe_rc;
+
+    if (of->size < 4) {
+        ngx_log_error(NGX_LOG_ERR, log, 0,
+                      "zstd static: \"%s\" too small to be a zstd frame "
+                      "(%O bytes)", path->data, of->size);
+        return NGX_DECLINED;
+    }
+
+    scratch = 0;
+    have_block = 0;
+    have_base = 0;
+    n = 0;
+
+    if (of->is_directio) {
+        /*
+         * Clamped to [PROBE, PROBE_MAX]. The floor keeps the read
+         * O_DIRECT-legal on 512-byte and 4K-native devices and
+         * leaves room for a frame header behind any in-block start;
+         * the ceiling stops an unbounded "directio_alignment" from
+         * scaling a header probe that never needs more than 18
+         * bytes. See NGX_HTTP_ZSTD_STATIC_DIO_PROBE_MAX.
+         */
+        align = NGX_HTTP_ZSTD_STATIC_DIO_PROBE;
+        if ((size_t) clcf->directio_alignment > align) {
+            align = (size_t) clcf->directio_alignment;
+        }
+        if (align > NGX_HTTP_ZSTD_STATIC_DIO_PROBE_MAX) {
+            align = NGX_HTTP_ZSTD_STATIC_DIO_PROBE_MAX;
+        }
+
+        /*
+         * TWO blocks, not one. The probe offset is rounded down to
+         * `align` (an O_DIRECT descriptor rejects an unaligned file
+         * offset with EINVAL), so a frame header can start as late
+         * as `align - 1` bytes into the first block and would then
+         * straddle the boundary — parsing only one block would
+         * report that legitimate frame as truncated. A second block
+         * guarantees at least `align` (>= 4096) bytes behind any
+         * in-block start position, far more than the 18 a frame
+         * header can need. Both the length and the buffer stay
+         * `align`-aligned, which is what O_DIRECT requires.
+         */
+        want = align * 2;
+
+        /*
+         * Worker-lifetime scratch buffer instead of a fresh
+         * ngx_pmemalign(r->pool, ...) on every directio hit — see
+         * ngx_http_zstd_static_dio_buf()'s own comment for the
+         * sizing and reentrancy argument. `scratch` remembers
+         * whether THIS call actually got the shared buffer (vs. a
+         * pool fallback), so the single release point below only
+         * clears the reuse guard when it was this call that set it.
+         */
+        hdr = ngx_http_zstd_static_dio_buf(r->pool, want, align);
+        if (hdr == NULL) {
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
+
+        scratch = (hdr == ngx_http_zstd_static_dio_scratch);
+
+    } else {
+        align = 0;
+        hdr = hdrbuf;
+        want = sizeof(hdrbuf);
+    }
+
+    pos = 0;
+
+    /*
+     * Walk a bounded chain of leading skippable frames to reach the
+     * first regular frame, so the window guard below cannot be
+     * dodged by prepending one (see NGX_HTTP_ZSTD_STATIC_FRAME_SKIP
+     * and NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES).
+     *
+     * Each iteration reads at the current offset. Under directio
+     * the O_DIRECT descriptor rejects an unaligned file offset with
+     * EINVAL, and `pos` after a leading skippable frame is whatever
+     * that frame's length made it (40 for the canonical dcz
+     * SHA-256 prefix) — almost never a multiple of the block size.
+     * So the read offset is rounded DOWN to the alignment and the
+     * frame is parsed at its offset inside the block: `base` is the
+     * aligned read offset, `frame_off` the distance from there to
+     * `pos`, and `avail` the bytes of that block that actually lie
+     * at or after `pos`. Off the directio path `base == pos`,
+     * `frame_off == 0` and this is byte-for-byte the previous
+     * behaviour.
+     */
+    for (frames = 0; ; frames++) {
+
+        if (frames >= NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES) {
+            ngx_log_error(NGX_LOG_ERR, log, 0,
+                          "zstd static: \"%s\" has at least %ui "
+                          "leading skippable frames -- declining "
+                          "rather than searching further for the "
+                          "first regular frame",
+                          path->data,
+                          (ngx_uint_t)
+                              NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES);
+            probe_rc = NGX_DECLINED;
+            goto probe_done;
+        }
+
+        if (of->is_directio) {
+            frame_off = (size_t) ((uint64_t) pos % (uint64_t) align);
+            base = pos - (off_t) frame_off;
+
+        } else {
+            frame_off = 0;
+            base = pos;
+        }
+
+        /*
+         * Reuse the block already in `hdr` when this iteration
+         * reads the SAME aligned offset and the bytes it needs are
+         * inside what the previous read delivered. A skippable
+         * frame shorter than `align` leaves `pos` inside the block
+         * just read, so `base` is unchanged and the re-read would
+         * return byte-for-byte what `hdr` already holds -- the
+         * canonical dcz prefix (40-byte frame at offset 0, next
+         * frame at 40) with align >= 4096 hits this on every
+         * iteration, re-issuing up to 2 * PROBE_MAX of O_DIRECT per
+         * skipped frame.
+         *
+         * `have_block` is only ever set on the directio path, where
+         * `base` is a rounded-down offset that can repeat. Off that
+         * path `base == pos` and `pos` strictly increases, so the
+         * cache never fires and this is byte-for-byte the previous
+         * behaviour.
+         *
+         * The guard requires the previous read to have reached at
+         * least `frame_off + 4`, the minimum this iteration can
+         * parse; anything short of that still takes a fresh read
+         * and then the `avail < 4` branch below, exactly as before.
+         */
+        if (!(have_block && base == have_base
+              && n > 0 && (size_t) n >= frame_off + 4))
+        {
+            n = ngx_http_zstd_static_pread(of->fd, hdr, want, base, align,
+                                           log, path);
+
+            if (of->is_directio && n > 0) {
+                have_block = 1;
+                have_base = base;
+            }
+
+        } else {
+            /*
+             * Positive witness that the re-read was elided. Debug
+             * level, so it costs nothing in production, but it lets
+             * a test assert the optimization actually engaged --
+             * serving correctly proves only that the bytes were
+             * right, not that they came from the buffer.
+             */
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
+                           "zstd static: reusing %uz-byte block at "
+                           "offset %O for next frame", want, base);
+        }
+
+        /*
+         * Bytes of the block that lie at or after `pos`. A short
+         * read that stopped inside the prefix leaves nothing for
+         * the frame, which is the same "too few bytes" condition as
+         * a short read at offset 0 and takes the same branch.
+         */
+        got = (size_t) (n > 0 ? n : 0);
+        avail = (got > frame_off) ? got - frame_off : 0;
+
+        frame = hdr + frame_off;
+
+        if (n < 0 || avail < 4) {
+            if (of->is_directio) {
+                ngx_log_error(NGX_LOG_ERR, log, ngx_errno,
+                              "zstd static: %uz-byte aligned probe on "
+                              "directio file \"%s\" returned %z -- "
+                              "declining; check directio_alignment "
+                              "against the device geometry",
+                              align, path->data, n);
+                probe_rc = NGX_DECLINED;
+                goto probe_done;
+            }
+
+            /*
+             * The primitive is named in the log because it is the
+             * operator's first clue about which syscall to strace.
+             * The POSIX text is preserved verbatim from before the
+             * Win32 port so existing log tooling keeps matching;
+             * Win32 names ReadFile() instead of claiming a pread(2)
+             * it never issued.
+             */
+            ngx_log_error(NGX_LOG_CRIT, log, ngx_errno,
+                          "zstd static: " NGX_HTTP_ZSTD_STATIC_PREAD_NAME
+                          "(\"%s\", frame header) returned %z",
+                          path->data, n);
+            probe_rc = NGX_DECLINED;
+            goto probe_done;
+        }
+
+        if (of->is_directio) {
+            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
+                           "zstd static: %uz-byte aligned probe on "
+                           "directio file \"%s\"", align, path->data);
+        }
+
+        switch (ngx_http_zstd_static_probe_frame(frame, avail, &window))
+        {
+
+        case NGX_HTTP_ZSTD_STATIC_FRAME_NOT_ZSTD:
+            ngx_log_error(NGX_LOG_ERR, log, 0,
+                          "zstd static: \"%s\" is not a zstd frame "
+                          "(leading bytes 0x%02xd%02xd%02xd%02xd)",
+                          path->data,
+                          (ngx_uint_t) frame[0], (ngx_uint_t) frame[1],
+                          (ngx_uint_t) frame[2], (ngx_uint_t) frame[3]);
+            probe_rc = NGX_DECLINED;
+            goto probe_done;
+
+        case NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED:
+            ngx_log_error(NGX_LOG_ERR, log, 0,
+                          "zstd static: \"%s\" frame header truncated",
+                          path->data);
+            probe_rc = NGX_DECLINED;
+            goto probe_done;
+
+        case NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG:
+            /*
+             * "8 MB" and "window log <= 23" below are prose, not
+             * derived: they must be updated by hand whenever
+             * NGX_HTTP_ZSTD_STATIC_MAX_WINDOW changes.
+             */
+            ngx_log_error(NGX_LOG_ERR, log, 0,
+                          "zstd static: \"%s\" declares a %uL-byte "
+                          "decompression window, above the 8 MB limit "
+                          "browsers enforce for Content-Encoding: zstd "
+                          "(RFC 8878) -- declining so a fallback "
+                          "encoding is used; recompress with a window "
+                          "log <= 23 (streaming encoders default to "
+                          "the compression level's window when not "
+                          "told the input size)",
+                          path->data, window);
+            probe_rc = NGX_DECLINED;
+            goto probe_done;
+
+        case NGX_HTTP_ZSTD_STATIC_FRAME_SKIP:
+
+            /*
+             * `window` carries the declared skip length here (see
+             * the probe's doc comment). Prove the 8-byte skippable
+             * header AND the full declared skip both fit within
+             * of->size before trusting the jump — checked
+             * arithmetic throughout, since `skip` is attacker-
+             * controlled and 32-bit-wide enough to overflow a
+             * 32-bit off_t/size_t add on its own.
+             */
+            skip = window;
+
+            if ((uint64_t) pos > (uint64_t) of->size
+                || (uint64_t) of->size - (uint64_t) pos < 8)
+            {
+                ngx_log_error(NGX_LOG_ERR, log, 0,
+                              "zstd static: \"%s\" skippable frame "
+                              "header runs past end of file",
+                              path->data);
+                probe_rc = NGX_DECLINED;
+                goto probe_done;
+            }
+
+            if (skip > (uint64_t) of->size - (uint64_t) pos - 8) {
+                ngx_log_error(NGX_LOG_ERR, log, 0,
+                              "zstd static: \"%s\" skippable frame "
+                              "declares a %uL-byte skip past end of "
+                              "file", path->data, skip);
+                probe_rc = NGX_DECLINED;
+                goto probe_done;
+            }
+
+            pos += (off_t) 8 + (off_t) skip;
+
+            continue;
+
+        default:
+            break;
+        }
+
+        break;
+    }
+
+    /*
+     * Reached only on NGX_HTTP_ZSTD_STATIC_FRAME_OK: the leading
+     * frame is a genuine, in-window zstd frame and the file may be
+     * served. NGX_OK is not itself a meaningful "keep going"
+     * verdict for the caller below (nothing after probe_done reads
+     * probe_rc on this path) — it only has to be distinct from
+     * NGX_DECLINED/NGX_HTTP_INTERNAL_SERVER_ERROR so a future edit
+     * cannot accidentally fall through the release into a stray
+     * early return.
+     */
+    probe_rc = NGX_OK;
+
+probe_done:
+
+    /*
+     * Single release point for every exit from this block,
+     * including each `goto` above: clears the reuse guard only if
+     * THIS call is the one that set it (see `scratch` and
+     * ngx_http_zstd_static_dio_buf()'s own comment) — a call that
+     * fell back to a pool-scoped buffer never touched the guard and
+     * must not clear it out from under a genuinely concurrent
+     * caller.
+     */
+    if (scratch) {
+        ngx_http_zstd_static_dio_buf_release();
+    }
+
+    return probe_rc;
+}
+
+#endif /* NGX_HTTP_ZSTD_STATIC_HAVE_PROBE */
+
+
 static ngx_int_t
 ngx_http_zstd_static_handler(ngx_http_request_t *r)
 {
@@ -1019,411 +1432,9 @@ ngx_http_zstd_static_handler(ngx_http_request_t *r)
 #endif /* !NGX_WIN32 */
 
 #if (NGX_HTTP_ZSTD_STATIC_HAVE_PROBE)
-    /*
-     * Magic-number sanity check on the .zst file.
-     *
-     * Without this, a truncated, half-downloaded, mistakenly-renamed
-     * (e.g. `cp foo.txt foo.zst`), or otherwise non-zstd file would be
-     * served with `Content-Encoding: zstd` and the client would get an
-     * undecodable body — a confusing outage class that nginx's built-in
-     * gzip_static also doesn't defend against. The probe is cheap (one
-     * offset-explicit read of the frame-header prefix at offset 0 — 18
-     * bytes, or a pair of aligned blocks under directio — via
-     * ngx_http_zstd_static_pread(): pread(2) on POSIX, ngx_read_file()
-     * on Win32, both of which take the offset as an argument and so
-     * never move the open_file_cache's shared fd position. Using plain
-     * read(2)/SetFilePointer would do exactly that and corrupt
-     * subsequent requests serving the same cached fd). On mismatch we
-     * decline, so nginx falls back to serving the uncompressed original (or
-     * returns 404 if it is absent), and the operator sees a clear
-     * error log line.
-     *
-     * Both a regular zstd frame (ZSTD_MAGICNUMBER) and a skippable
-     * frame (ZSTD_MAGIC_SKIPPABLE_START..+0xF) are accepted, since
-     * either is a valid leading frame in a zstd stream.
-     *
-     * Gated by NGX_HTTP_ZSTD_STATIC_HAVE_PROBE (see its definition):
-     * compiled in on Win32 and on any POSIX build whose configure found
-     * pread(2). On a POSIX build WITHOUT pread(2) the probe is skipped
-     * rather than degraded to a read+lseek pair that would mutate the
-     * shared fd offset — every modern POSIX target has it, so that
-     * branch is essentially a build-time tripwire.
-     *
-     * The probe deliberately runs on Win32 too. It used to be compiled
-     * out there, which meant a Windows build served ANY .zst with no
-     * magic check, no truncation check, no 8 MB window guard and no
-     * skippable-frame chain bound — a strictly weaker validation than
-     * the POSIX build, on a target the Windows build CI ships. The
-     * verdict logic is shared, so the two platforms cannot drift apart
-     * again; only the byte fetch differs.
-     *
-     * When the file was opened with O_DIRECT (of.is_directio, set by
-     * ngx_open_cached_file when "directio <size>" is configured and the
-     * file meets the threshold), BOTH the read offset and the length
-     * must be block-aligned, so the probe rounds each frame offset down
-     * to directio_alignment CLAMPED to
-     * [NGX_HTTP_ZSTD_STATIC_DIO_PROBE, NGX_HTTP_ZSTD_STATIC_DIO_PROBE_MAX]
-     * and reads two such blocks into an equally-aligned pool buffer,
-     * parsing the frame at its offset inside them. The clamp follows the
-     * operator's declared geometry only as far as a header probe can
-     * use it: the floor is what keeps the read legal on 512-byte and
-     * 4K-native devices, and the ceiling is why an unbounded
-     * "directio_alignment" cannot turn an 18-byte header check into a
-     * multi-megabyte allocation and O_DIRECT read on every request that
-     * reaches the probe. Rounding the OFFSET is what the skippable-frame
-     * walk needs:
-     * the second and later probes are at whatever offset the previous
-     * frame's declared length produced (40 for a canonical dcz prefix),
-     * which an O_DIRECT descriptor rejects with EINVAL if passed raw.
-     *
-     * The window check in particular must not be skipped under
-     * directio: oversized declared windows are a
-     * systematic build-pipeline product, not rare corruption, and every
-     * browser rejects them. If the aligned read STILL fails, the file
-     * is DECLINED, not served: for a validation read, falling back to
-     * another encoding is safer than certifying a file we could not
-     * inspect, and the error log tells the operator which knob
-     * (directio_alignment) disagrees with the device. On Win32
-     * ngx_directio_on() is an upstream no-op stub, so of.is_directio
-     * only ever reflects the operator's "directio" directive there and
-     * the aligned path costs one pool allocation with no behavioural
-     * difference — it is left shared rather than forked, because a
-     * Win32-only bypass of this branch is exactly the kind of split
-     * that reintroduces the gap this change closes.
-     */
-    {
-        /*
-         * 18 bytes covers the largest possible frame header prefix this
-         * check needs: magic(4) + descriptor(1) + window byte(1) for
-         * streaming frames, or magic(4) + descriptor(1) + dictionary
-         * id(<=4) + content size(<=8) for single-segment frames. Short
-         * files return fewer bytes; each parse path checks it got what
-         * that frame layout requires.
-         */
-        u_char       hdrbuf[18];
-        u_char      *hdr, *frame;
-        size_t       want, align, frame_off, avail, got;
-        ssize_t      n;
-        uint64_t     window, skip;
-        ngx_uint_t   frames, scratch, have_block;
-        off_t        pos, base, have_base;
-        ngx_int_t    probe_rc;
-
-        if (of.size < 4) {
-            ngx_log_error(NGX_LOG_ERR, log, 0,
-                          "zstd static: \"%s\" too small to be a zstd frame "
-                          "(%O bytes)", path.data, of.size);
-            return NGX_DECLINED;
-        }
-
-        scratch = 0;
-        have_block = 0;
-        have_base = 0;
-        n = 0;
-
-        if (of.is_directio) {
-            /*
-             * Clamped to [PROBE, PROBE_MAX]. The floor keeps the read
-             * O_DIRECT-legal on 512-byte and 4K-native devices and
-             * leaves room for a frame header behind any in-block start;
-             * the ceiling stops an unbounded "directio_alignment" from
-             * scaling a header probe that never needs more than 18
-             * bytes. See NGX_HTTP_ZSTD_STATIC_DIO_PROBE_MAX.
-             */
-            align = NGX_HTTP_ZSTD_STATIC_DIO_PROBE;
-            if ((size_t) clcf->directio_alignment > align) {
-                align = (size_t) clcf->directio_alignment;
-            }
-            if (align > NGX_HTTP_ZSTD_STATIC_DIO_PROBE_MAX) {
-                align = NGX_HTTP_ZSTD_STATIC_DIO_PROBE_MAX;
-            }
-
-            /*
-             * TWO blocks, not one. The probe offset is rounded down to
-             * `align` (an O_DIRECT descriptor rejects an unaligned file
-             * offset with EINVAL), so a frame header can start as late
-             * as `align - 1` bytes into the first block and would then
-             * straddle the boundary — parsing only one block would
-             * report that legitimate frame as truncated. A second block
-             * guarantees at least `align` (>= 4096) bytes behind any
-             * in-block start position, far more than the 18 a frame
-             * header can need. Both the length and the buffer stay
-             * `align`-aligned, which is what O_DIRECT requires.
-             */
-            want = align * 2;
-
-            /*
-             * Worker-lifetime scratch buffer instead of a fresh
-             * ngx_pmemalign(r->pool, ...) on every directio hit — see
-             * ngx_http_zstd_static_dio_buf()'s own comment for the
-             * sizing and reentrancy argument. `scratch` remembers
-             * whether THIS call actually got the shared buffer (vs. a
-             * pool fallback), so the single release point below only
-             * clears the reuse guard when it was this call that set it.
-             */
-            hdr = ngx_http_zstd_static_dio_buf(r->pool, want, align);
-            if (hdr == NULL) {
-                return NGX_HTTP_INTERNAL_SERVER_ERROR;
-            }
-
-            scratch = (hdr == ngx_http_zstd_static_dio_scratch);
-
-        } else {
-            align = 0;
-            hdr = hdrbuf;
-            want = sizeof(hdrbuf);
-        }
-
-        pos = 0;
-
-        /*
-         * Walk a bounded chain of leading skippable frames to reach the
-         * first regular frame, so the window guard below cannot be
-         * dodged by prepending one (see NGX_HTTP_ZSTD_STATIC_FRAME_SKIP
-         * and NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES).
-         *
-         * Each iteration reads at the current offset. Under directio
-         * the O_DIRECT descriptor rejects an unaligned file offset with
-         * EINVAL, and `pos` after a leading skippable frame is whatever
-         * that frame's length made it (40 for the canonical dcz
-         * SHA-256 prefix) — almost never a multiple of the block size.
-         * So the read offset is rounded DOWN to the alignment and the
-         * frame is parsed at its offset inside the block: `base` is the
-         * aligned read offset, `frame_off` the distance from there to
-         * `pos`, and `avail` the bytes of that block that actually lie
-         * at or after `pos`. Off the directio path `base == pos`,
-         * `frame_off == 0` and this is byte-for-byte the previous
-         * behaviour.
-         */
-        for (frames = 0; ; frames++) {
-
-            if (frames >= NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES) {
-                ngx_log_error(NGX_LOG_ERR, log, 0,
-                              "zstd static: \"%s\" has at least %ui "
-                              "leading skippable frames -- declining "
-                              "rather than searching further for the "
-                              "first regular frame",
-                              path.data,
-                              (ngx_uint_t)
-                                  NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES);
-                probe_rc = NGX_DECLINED;
-                goto probe_done;
-            }
-
-            if (of.is_directio) {
-                frame_off = (size_t) ((uint64_t) pos % (uint64_t) align);
-                base = pos - (off_t) frame_off;
-
-            } else {
-                frame_off = 0;
-                base = pos;
-            }
-
-            /*
-             * Reuse the block already in `hdr` when this iteration
-             * reads the SAME aligned offset and the bytes it needs are
-             * inside what the previous read delivered. A skippable
-             * frame shorter than `align` leaves `pos` inside the block
-             * just read, so `base` is unchanged and the re-read would
-             * return byte-for-byte what `hdr` already holds -- the
-             * canonical dcz prefix (40-byte frame at offset 0, next
-             * frame at 40) with align >= 4096 hits this on every
-             * iteration, re-issuing up to 2 * PROBE_MAX of O_DIRECT per
-             * skipped frame.
-             *
-             * `have_block` is only ever set on the directio path, where
-             * `base` is a rounded-down offset that can repeat. Off that
-             * path `base == pos` and `pos` strictly increases, so the
-             * cache never fires and this is byte-for-byte the previous
-             * behaviour.
-             *
-             * The guard requires the previous read to have reached at
-             * least `frame_off + 4`, the minimum this iteration can
-             * parse; anything short of that still takes a fresh read
-             * and then the `avail < 4` branch below, exactly as before.
-             */
-            if (!(have_block && base == have_base
-                  && n > 0 && (size_t) n >= frame_off + 4))
-            {
-                n = ngx_http_zstd_static_pread(of.fd, hdr, want, base, align,
-                                               log, &path);
-
-                if (of.is_directio && n > 0) {
-                    have_block = 1;
-                    have_base = base;
-                }
-
-            } else {
-                /*
-                 * Positive witness that the re-read was elided. Debug
-                 * level, so it costs nothing in production, but it lets
-                 * a test assert the optimization actually engaged --
-                 * serving correctly proves only that the bytes were
-                 * right, not that they came from the buffer.
-                 */
-                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
-                               "zstd static: reusing %uz-byte block at "
-                               "offset %O for next frame", want, base);
-            }
-
-            /*
-             * Bytes of the block that lie at or after `pos`. A short
-             * read that stopped inside the prefix leaves nothing for
-             * the frame, which is the same "too few bytes" condition as
-             * a short read at offset 0 and takes the same branch.
-             */
-            got = (size_t) (n > 0 ? n : 0);
-            avail = (got > frame_off) ? got - frame_off : 0;
-
-            frame = hdr + frame_off;
-
-            if (n < 0 || avail < 4) {
-                if (of.is_directio) {
-                    ngx_log_error(NGX_LOG_ERR, log, ngx_errno,
-                                  "zstd static: %uz-byte aligned probe on "
-                                  "directio file \"%s\" returned %z -- "
-                                  "declining; check directio_alignment "
-                                  "against the device geometry",
-                                  align, path.data, n);
-                    probe_rc = NGX_DECLINED;
-                    goto probe_done;
-                }
-
-                /*
-                 * The primitive is named in the log because it is the
-                 * operator's first clue about which syscall to strace.
-                 * The POSIX text is preserved verbatim from before the
-                 * Win32 port so existing log tooling keeps matching;
-                 * Win32 names ReadFile() instead of claiming a pread(2)
-                 * it never issued.
-                 */
-                ngx_log_error(NGX_LOG_CRIT, log, ngx_errno,
-                              "zstd static: " NGX_HTTP_ZSTD_STATIC_PREAD_NAME
-                              "(\"%s\", frame header) returned %z",
-                              path.data, n);
-                probe_rc = NGX_DECLINED;
-                goto probe_done;
-            }
-
-            if (of.is_directio) {
-                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
-                               "zstd static: %uz-byte aligned probe on "
-                               "directio file \"%s\"", align, path.data);
-            }
-
-            switch (ngx_http_zstd_static_probe_frame(frame, avail, &window))
-            {
-
-            case NGX_HTTP_ZSTD_STATIC_FRAME_NOT_ZSTD:
-                ngx_log_error(NGX_LOG_ERR, log, 0,
-                              "zstd static: \"%s\" is not a zstd frame "
-                              "(leading bytes 0x%02xd%02xd%02xd%02xd)",
-                              path.data,
-                              (ngx_uint_t) frame[0], (ngx_uint_t) frame[1],
-                              (ngx_uint_t) frame[2], (ngx_uint_t) frame[3]);
-                probe_rc = NGX_DECLINED;
-                goto probe_done;
-
-            case NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED:
-                ngx_log_error(NGX_LOG_ERR, log, 0,
-                              "zstd static: \"%s\" frame header truncated",
-                              path.data);
-                probe_rc = NGX_DECLINED;
-                goto probe_done;
-
-            case NGX_HTTP_ZSTD_STATIC_FRAME_WINDOW_BIG:
-                /*
-                 * "8 MB" and "window log <= 23" below are prose, not
-                 * derived: they must be updated by hand whenever
-                 * NGX_HTTP_ZSTD_STATIC_MAX_WINDOW changes.
-                 */
-                ngx_log_error(NGX_LOG_ERR, log, 0,
-                              "zstd static: \"%s\" declares a %uL-byte "
-                              "decompression window, above the 8 MB limit "
-                              "browsers enforce for Content-Encoding: zstd "
-                              "(RFC 8878) -- declining so a fallback "
-                              "encoding is used; recompress with a window "
-                              "log <= 23 (streaming encoders default to "
-                              "the compression level's window when not "
-                              "told the input size)",
-                              path.data, window);
-                probe_rc = NGX_DECLINED;
-                goto probe_done;
-
-            case NGX_HTTP_ZSTD_STATIC_FRAME_SKIP:
-
-                /*
-                 * `window` carries the declared skip length here (see
-                 * the probe's doc comment). Prove the 8-byte skippable
-                 * header AND the full declared skip both fit within
-                 * of.size before trusting the jump — checked
-                 * arithmetic throughout, since `skip` is attacker-
-                 * controlled and 32-bit-wide enough to overflow a
-                 * 32-bit off_t/size_t add on its own.
-                 */
-                skip = window;
-
-                if ((uint64_t) pos > (uint64_t) of.size
-                    || (uint64_t) of.size - (uint64_t) pos < 8)
-                {
-                    ngx_log_error(NGX_LOG_ERR, log, 0,
-                                  "zstd static: \"%s\" skippable frame "
-                                  "header runs past end of file",
-                                  path.data);
-                    probe_rc = NGX_DECLINED;
-                    goto probe_done;
-                }
-
-                if (skip > (uint64_t) of.size - (uint64_t) pos - 8) {
-                    ngx_log_error(NGX_LOG_ERR, log, 0,
-                                  "zstd static: \"%s\" skippable frame "
-                                  "declares a %uL-byte skip past end of "
-                                  "file", path.data, skip);
-                    probe_rc = NGX_DECLINED;
-                    goto probe_done;
-                }
-
-                pos += (off_t) 8 + (off_t) skip;
-
-                continue;
-
-            default:
-                break;
-            }
-
-            break;
-        }
-
-        /*
-         * Reached only on NGX_HTTP_ZSTD_STATIC_FRAME_OK: the leading
-         * frame is a genuine, in-window zstd frame and the file may be
-         * served. NGX_OK is not itself a meaningful "keep going"
-         * verdict for the caller below (nothing after probe_done reads
-         * probe_rc on this path) — it only has to be distinct from
-         * NGX_DECLINED/NGX_HTTP_INTERNAL_SERVER_ERROR so a future edit
-         * cannot accidentally fall through the release into a stray
-         * early return.
-         */
-        probe_rc = NGX_OK;
-
-    probe_done:
-
-        /*
-         * Single release point for every exit from this block,
-         * including each `goto` above: clears the reuse guard only if
-         * THIS call is the one that set it (see `scratch` and
-         * ngx_http_zstd_static_dio_buf()'s own comment) — a call that
-         * fell back to a pool-scoped buffer never touched the guard and
-         * must not clear it out from under a genuinely concurrent
-         * caller.
-         */
-        if (scratch) {
-            ngx_http_zstd_static_dio_buf_release();
-        }
-
-        if (probe_rc != NGX_OK) {
-            return probe_rc;
-        }
+    rc = ngx_http_zstd_static_probe_file(r, clcf, &of, &path, log);
+    if (rc != NGX_OK) {
+        return rc;
     }
 #endif /* NGX_HTTP_ZSTD_STATIC_HAVE_PROBE */
 


### PR DESCRIPTION
## TL;DR

`ngx_http_zstd_static_handler()` had grown to 762 lines with a cyclomatic
complexity of 74 — one function carrying the whole static-file request path.
This splits three self-contained seams out into helpers. The handler drops to
CCN 23 / 92 NLOC. Nothing about how a request is served changes.

## What moved

Three `static` helpers, extracted one at a time with a build and a full suite
run after each:

| helper | what it owns | CCN |
|---|---|---|
| `ngx_http_zstd_static_negotiate()` | Accept-Encoding / Vary negotiation | 11 |
| `ngx_http_zstd_static_probe_file()` | magic-number / directio probe walk | 29 |
| `ngx_http_zstd_static_send()` | header and body-send tail | 15 |

`ngx_http_zstd_static_handler()`: CCN 74 → 23, NLOC 336 → 92, length 762 → 180.
File average CCN 10.8 → 8.8.

## Zero behaviour change

That is the whole point of the patch, so it is the thing worth checking rather
than taking on trust. What backs it:

- The extracted regions are byte-identical to their originals once the
  local-to-out-param conversions (`of.` → `of->`, `path` → `*path`) are
  normalised away. The send tail diffs to literally nothing.
- Return-site census is unchanged across the file: 11
  `NGX_HTTP_INTERNAL_SERVER_ERROR`, 1 `NGX_HTTP_NOT_FOUND`, 10 `NGX_DECLINED`
  before and after.
- A full string-literal frequency diff over both versions of the file shows one
  delta — the phrase "keep going" gains an occurrence, both of them inside
  comments. No log message, header name or value, or status code differs.
- The directio scratch buffer's acquire and release now sit in the same
  function, which is tighter than before; all eight `goto probe_done` sites
  still funnel through the single release point.

One predicate reads differently: a Vary shortcut that tested `rc != NGX_OK` now
tests `!accepts`. `accepts` is not a new variable — it already existed and
already held `(rc == NGX_OK)`, assigned immediately after the accept check, and
nothing writes `rc` between that assignment and the shortcut. Same value, same
truth, fewer hops.

`ngx_http_zstd_static_probe_file()` and its call site are each wrapped in
`#if (NGX_HTTP_ZSTD_STATIC_HAVE_PROBE)`, matching the span the code came from.
I compiled the `HAVE_PROBE == 0` variant under `-Werror` on this branch and on
`master`; both are clean, so the guard placement does not break the
no-pread/no-Win32 configuration.

## Testing

Built with `make modules` under `-Werror` after every extraction, and re-verified
after rebasing onto `49c37ea`:

| suite | result |
|---|---|
| `01-static.t` | 774 tests, 12 failures — all TEST 55, pre-existing when `auth_request` is absent, identical set to `master` |
| `03-dcz.t` | 176 tests, `All tests successful.` / `Result: PASS` |
| `00-filter.t` | 1335 tests, `All tests successful.` / `Result: PASS` |
| `02-conf-warn.t` | 91 tests, `All tests successful.` / `Result: PASS` |

The `01-static.t` failures were measured on `master` first and compared by test
name, not by count.

## What I left alone

`probe_file()` stays at CCN 29 rather than being split further. I tried pulling
its directio-geometry setup out as a fourth helper and reverted it: CCN 29 → 26
in exchange for a nine-parameter out-param helper is a worse interface for a
marginal number. The only other seam is the frame-classification `switch`, whose
six `goto probe_done` sites would have to become a returned verdict the loop
dispatches on — a control-flow rewrite, which is not what this patch is.
