### PR TITLE
ci: scope a UBSan ignorelist for the nginx-core debug-logging abort

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1410,14 +1410,39 @@ jobs:
           # inside libcrypto anyway), while the mainline build asserts the
           # EVP path.
           NGX_ZSTD_NO_LIBCRYPTO: 1
+          # ubsan.ignorelist below needs -fsanitize-ignorelist=, which is a
+          # clang-only flag (gcc has no equivalent); force the compiler so
+          # this step does not silently fall back to whatever `cc` resolves
+          # to on the runner. Verified present: clang is preinstalled on
+          # this pool's images.
+          CC: clang
         run: |
           tar -xzf "nginx-${NGINX_VERSION}.tar.gz"
           cd "nginx-${NGINX_VERSION}"
           SAN="-fsanitize=address,undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g3 -O1"
+          IGNORELIST="-fsanitize-ignorelist=$GITHUB_WORKSPACE/ubsan.ignorelist"
+          # The Perl suites below (`asan-perl-*`) run ci/t/00-filter.t and
+          # ci/t/01-static.t, both `log_level 'debug'`. nginx core's
+          # ngx_sprintf_str (src/core/ngx_string.c:586, called from
+          # ngx_vslprintf on every debug log line) does memcpy(dst, NULL, 0)
+          # for a NULL/zero-length %s argument -- well-defined in practice,
+          # flagged by UBSan's nonnull-attribute check, and unreachable
+          # below `info`/`warn` log levels, which is why this only surfaces
+          # once the suite runs at debug. -fno-sanitize-recover=undefined
+          # above makes that abort the worker outright, regardless of any
+          # runtime UBSAN_OPTIONS=halt_on_error override -- verified: the
+          # nonnull-attribute check has no UBSAN_OPTIONS=suppressions=
+          # runtime opt-out either. ubsan.ignorelist scopes the ONLY
+          # workaround that verifiably works (-fsanitize-ignorelist=, which
+          # IS honored per-function) to that one nginx-core function by
+          # name; see the file's header for the full derivation. It applies
+          # to this whole compile (module included, since nginx's build has
+          # no per-file cc-opt), but it cannot silence this module's own UB
+          # because no ngx_http_zstd_* symbol is listed.
           ./configure \
             --with-compat \
             --with-debug \
-            --with-cc-opt="-DZSTD_STATIC_LINKING_ONLY $SAN $(pkg-config --cflags libzstd zlib libpcre2-8)" \
+            --with-cc-opt="-DZSTD_STATIC_LINKING_ONLY $SAN $IGNORELIST $(pkg-config --cflags libzstd zlib libpcre2-8)" \
             --with-ld-opt="$SAN $(pkg-config --libs libzstd zlib libpcre2-8)" \
             --with-http_sub_module \
             --add-module="$GITHUB_WORKSPACE"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1374,7 +1374,12 @@ jobs:
             'Acquire::https::Timeout "20";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config libzstd-dev \
+          # clang, not just build-essential: the ASAN+UBSAN configure below
+          # passes -fsanitize-ignorelist=, which gcc does not implement, so
+          # this step sets CC=clang. runs-on is a pool variable rather than a
+          # pinned image, so the compiler is installed here rather than
+          # assumed present on the runner.
+          sudo apt-get install -y build-essential clang pkg-config libzstd-dev \
             libpcre2-dev zlib1g-dev wget
 
       - name: Cache nginx source tarball

--- a/ubsan.ignorelist
+++ b/ubsan.ignorelist
@@ -1,0 +1,44 @@
+# UBSan ignorelist (compile-time, -fsanitize-ignorelist=) for a debug-level
+# ASAN+UBSAN nginx build.
+#
+# Scope: ONE nginx-core function, ONE known-benign UB pattern. Nothing of
+# this module's is or may ever be listed here.
+#
+# What: src/core/ngx_string.c, ngx_sprintf_str() (the static helper
+# ngx_vslprintf() calls for every %s/%*s conversion) does:
+#
+#     buf = ngx_cpymem(buf, src, len);   // ngx_string.c:586
+#
+# ngx_cpymem is a memcpy wrapper. When ngx_vslprintf is asked to format a
+# NULL char* with an explicit zero length (a "%*s" argument pair of
+# (NULL, 0), or a %s field whose string pointer is NULL and len resolves to
+# 0 after clamping against the buffer), src is NULL and len is 0. UBSan's
+# nonnull-attribute check flags this as "null pointer passed as argument 2,
+# which is declared to never be null" because libc's memcpy prototype is
+# annotated nonnull, even though passing NULL with a zero count copies
+# nothing and is well-defined in practice on every libc this project
+# targets. This is nginx core's own long-standing pattern, not a bug this
+# module introduced, and not reachable through any ngx_http_zstd_* symbol.
+#
+# Why it only shows up now: it only fires when the format actually hits that
+# NULL/zero-length pair, which in practice means `error_log ... debug` --
+# nginx's own debug logging is by far the heaviest user of ngx_vslprintf
+# with caller-assembled, sometimes-empty string arguments. Every other log
+# level in this project's CI runs at `info` or `warn` (see ci/tools/soak.sh),
+# so a plain ASAN+UBSAN run never reaches it; only a debug-level run does.
+#
+# Why an ignorelist and not a suppressions= file: UBSan's runtime
+# `UBSAN_OPTIONS=suppressions=` mechanism does NOT support the
+# nonnull-attribute check -- verified empirically (clang 19.1.7, three
+# suppression patterns against `nonnull-attribute:<symbol>`, all still
+# aborted). -fsanitize-ignorelist= is a compile-time, function-scoped
+# mechanism that DOES work for this check, verified the same way: a second,
+# unlisted function with the identical memcpy(dst, NULL, 0) call still
+# aborts with the identical ignorelist file in effect.
+#
+# DO NOT add ngx_http_zstd_* (or any other symbol) to this file. Its entire
+# purpose is to keep the module's own undefined behaviour aborting the build
+# it is compiled into -- widening this list defeats that.
+
+[nonnull-attribute]
+fun:ngx_sprintf_str


### PR DESCRIPTION
## TL;DR

A debug-level ASan+UBSan run of the `t/` suite aborts before it finishes, and
the abort is in nginx core rather than in this module. This adds a narrowly
scoped UBSan ignorelist so those runs can complete, without giving the module's
own undefined behaviour anywhere to hide.

## The finding

`ngx_sprintf_str()` in `src/core/ngx_string.c:586` — the helper `ngx_vslprintf()`
calls for every `%s` conversion — does `ngx_cpymem(buf, src, len)`, a `memcpy`
wrapper. When it is asked to format a NULL `char *` with a zero length, that is
`memcpy(dst, NULL, 0)`: well-defined in practice, but libc annotates `memcpy`'s
source as non-null, so UBSan's `nonnull-attribute` check flags it. With
`-fno-sanitize-recover=undefined` the worker dies on the spot.

It only fires at `error_log ... debug`, because nginx's debug logging is by far
the heaviest user of `ngx_vslprintf` with caller-assembled, sometimes-empty
string arguments. That is why CI has been green: `.github/workflows/asan.yml`
builds with `--with-debug` and `-fno-sanitize-recover=undefined`, but its only
test step is `ci/tools/soak.sh`, whose generated config sets `error_log ... info`.
The path was never reached remotely. The bug was not absent — the arm did not
exercise it.

## Why an ignorelist rather than a suppressions file

`UBSAN_OPTIONS=suppressions=` does not cover the `nonnull-attribute` check. I
checked rather than assumed: three suppression patterns against the symbol under
clang 19.1.7, all still aborted. `-fsanitize-ignorelist=` is a compile-time,
function-scoped mechanism that does work for it, verified the same way — a
second, unlisted function containing the identical `memcpy(dst, NULL, 0)` call
still aborts with the ignorelist in effect. That is what makes the scoping real
rather than nominal.

The list contains exactly one entry, `fun:ngx_sprintf_str`, under
`[nonnull-attribute]`. No `ngx_http_zstd_*` symbol is listed, and the file's
header says plainly that none may ever be — the point of the file is to keep
this module's own UB aborting.

The previous local workaround was toggling `-fsanitize-recover=undefined` in the
built Makefile, which suppresses *all* UB including the module's. That is not
shipped here and should not be used.

## Evidence

- **Red, without the ignorelist:** built nginx 1.31.4 plus this module with CI's
  exact sanitizer flags and ran `ci/t/00-filter.t` (which sets `log_level 'debug'`)
  through Test::Nginx. Captured the abort with a full stack —
  `ngx_sprintf_str` (`ngx_string.c:586`) ← `ngx_vslprintf` ← `ngx_log_error_core`
  ← `ngx_http_process_request_uri` — killing the worker and cascading into
  connection-refused failures.
- **Green, with it:** same build plus `-fsanitize-ignorelist=`; that abort is gone.

## One thing this does not fix

The suite still cannot run end-to-end under `-fno-sanitize-recover=undefined`,
because it then hits a separate pre-existing finding: `function-type-mismatch` on
`ngx_http_trailers_filter` called through an incompatible function-pointer type
in `ngx_output_chain.c`. That is a different nginx-core/UBSan interaction, it
reproduces identically with and without this change, and it fires at every log
level. It is out of scope here and is going on the backlog as its own item —
likely a scoped `-fno-sanitize=function`. I would rather say so than let this PR
imply a fully green debug-level run that does not exist yet.

## Build wiring

`-fsanitize-ignorelist=` is clang-only, so the `build-asan` job's configure step
sets `CC: clang`. That job's `runs-on` is a pool variable rather than a pinned
image and its dependency step installed only `build-essential`, so the second
commit installs `clang` explicitly instead of assuming the runner has it.
`tests-asan` consumes this build via `needs: build-asan`, which is the job the
ignorelist is there to unblock.

## Items

| item | origin | commit |
|---|---|---|
| UBSan ignorelist for the nginx-core `nonnull-attribute` abort | `TODO.md` MINOR `[ci]` row | `1d6e85a` |
| install clang in the ASAN+UBSAN job | follow-on defect in the wiring above | `2cf113a` |
