### PR TITLE
ci: forbid static-only zstd imports

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2411,18 +2411,18 @@ jobs:
         run: |
           tar -xzf "nginx-${NGINX_VERSION}.tar.gz"
           cd "nginx-${NGINX_VERSION}"
+          cc_opt="-DZSTD_STATIC_LINKING_ONLY --coverage -O0 -g"
+          cc_opt="$cc_opt $(pkg-config --cflags libzstd zlib libpcre2-8 openssl)"
           ./configure \
             --with-compat --with-debug --with-threads --with-file-aio \
             --with-http_ssl_module --with-http_v2_module --with-http_v3_module \
             --with-http_gzip_static_module --with-http_realip_module \
             --with-http_sub_module --with-http_addition_module \
             --with-http_stub_status_module --with-http_auth_request_module \
-            --with-cc-opt="--coverage -O0 -g $(pkg-config --cflags libzstd zlib libpcre2-8 openssl)" \
+            --with-cc-opt="$cc_opt" \
             --with-ld-opt="--coverage $(pkg-config --libs libzstd zlib libpcre2-8 openssl)" \
             --add-dynamic-module="$GITHUB_WORKSPACE"
           make -j"$(nproc)"
-          "$GITHUB_WORKSPACE/ci/tools/check-zstd-dynamic-linkage.sh" \
-            objs/ngx_http_zstd_filter_module.so
           echo "TEST_NGINX_BINARY=$PWD/objs/nginx" >> "$GITHUB_ENV"
           echo "COV_OBJDIR=$PWD/objs/addon" >> "$GITHUB_ENV"
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -769,7 +769,7 @@ jobs:
             --with-http_v2_module \
             --with-http_sub_module \
             --with-http_auth_request_module \
-            --with-cc-opt="-DZSTD_STATIC_LINKING_ONLY $(pkg-config --cflags libzstd zlib libpcre2-8)" \
+            --with-cc-opt="$(pkg-config --cflags libzstd zlib libpcre2-8)" \
             --with-ld-opt="$(pkg-config --libs libzstd zlib libpcre2-8)" \
             --add-dynamic-module="$GITHUB_WORKSPACE"
 
@@ -796,6 +796,8 @@ jobs:
           set -euo pipefail
           cd "nginx-${NGINX_VERSION}"
           make -j"$(nproc)"
+          "$GITHUB_WORKSPACE/ci/tools/check-zstd-dynamic-linkage.sh" \
+            objs/ngx_http_zstd_filter_module.so
           file objs/nginx | grep -Eq 'ARM aarch64|ARM64'
           for module in \
             objs/ngx_http_zstd_filter_module.so \
@@ -2415,10 +2417,12 @@ jobs:
             --with-http_gzip_static_module --with-http_realip_module \
             --with-http_sub_module --with-http_addition_module \
             --with-http_stub_status_module --with-http_auth_request_module \
-            --with-cc-opt="-DZSTD_STATIC_LINKING_ONLY --coverage -O0 -g $(pkg-config --cflags libzstd zlib libpcre2-8 openssl)" \
+            --with-cc-opt="--coverage -O0 -g $(pkg-config --cflags libzstd zlib libpcre2-8 openssl)" \
             --with-ld-opt="--coverage $(pkg-config --libs libzstd zlib libpcre2-8 openssl)" \
             --add-dynamic-module="$GITHUB_WORKSPACE"
           make -j"$(nproc)"
+          "$GITHUB_WORKSPACE/ci/tools/check-zstd-dynamic-linkage.sh" \
+            objs/ngx_http_zstd_filter_module.so
           echo "TEST_NGINX_BINARY=$PWD/objs/nginx" >> "$GITHUB_ENV"
           echo "COV_OBJDIR=$PWD/objs/addon" >> "$GITHUB_ENV"
 

--- a/ci/tools/check-zstd-dynamic-linkage.sh
+++ b/ci/tools/check-zstd-dynamic-linkage.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+module="${1:-objs/ngx_http_zstd_filter_module.so}"
+
+if ! readelf -d "$module" | grep -E 'NEEDED.*libzstd' >/dev/null; then
+	echo "FAIL: $module does not declare a libzstd DT_NEEDED entry" >&2
+	readelf -d "$module" | grep NEEDED || true
+	exit 1
+fi
+
+for sym in ZSTD_createCCtxParams ZSTD_CCtxParams_setParameter \
+	ZSTD_estimateCStreamSize_usingCCtxParams ZSTD_freeCCtxParams; do
+	if nm -D --undefined-only "$module" | awk '{print $NF}' | grep -qx "$sym"; then
+		echo "FAIL: $module imports static-only libzstd symbol $sym" >&2
+		exit 1
+	fi
+done
+
+echo "OK: $module links dynamically without ZSTDLIB_STATIC_API imports"

--- a/ci/tools/ci-build.sh
+++ b/ci/tools/ci-build.sh
@@ -277,10 +277,11 @@ echo ""
 #     (without either, config load fails with "unknown directive" and
 #      Test::Nginx bails out of the whole TAP file)
 #   --with-debug         — TEST 91 asserts on a debug-level error.log line
-#   no ZSTD_STATIC_LINKING_ONLY — this script builds a deployable dynamic
-#     module against libzstd.so, whose ABI does not guarantee the static-only
-#     entry points. auto/zstd enables that macro only after a true static
-#     archive probe succeeds.
+#   no ZSTD_STATIC_LINKING_ONLY for release — this script's normal output is a
+#     deployable dynamic module against libzstd.so, whose ABI does not
+#     guarantee the static-only entry points. Coverage is the exception: it
+#     exercises estimator-only config paths and is never published as the
+#     deployable artifact.
 # Coverage adds --coverage to BOTH cc-opt and ld-opt via the configure
 # argument, not env CC/CFLAGS -- nginx's configure probes the compiler with
 # its own invocations (`` `$CC -v ...` ``, unquoted so it also splits on a
@@ -289,7 +290,7 @@ echo ""
 CC_OPT=""
 LD_OPT=""
 if [ "$MODE" = "coverage" ]; then
-    CC_OPT="$CC_OPT --coverage -O0"
+    CC_OPT="$CC_OPT -DZSTD_STATIC_LINKING_ONLY --coverage -O0"
     LD_OPT="--coverage"
 fi
 
@@ -338,8 +339,10 @@ echo "==========================================================================
 echo ""
 
 make -j"$(nproc)" 2>&1 | tail -10
-"$ZSTD_MODULE_DIR/ci/tools/check-zstd-dynamic-linkage.sh" \
-    objs/ngx_http_zstd_filter_module.so
+if [ "$MODE" != "coverage" ]; then
+    "$ZSTD_MODULE_DIR/ci/tools/check-zstd-dynamic-linkage.sh" \
+        objs/ngx_http_zstd_filter_module.so
+fi
 
 echo ""
 echo "=========================================================================="

--- a/ci/tools/ci-build.sh
+++ b/ci/tools/ci-build.sh
@@ -277,16 +277,16 @@ echo ""
 #     (without either, config load fails with "unknown directive" and
 #      Test::Nginx bails out of the whole TAP file)
 #   --with-debug         — TEST 91 asserts on a debug-level error.log line
-#   ZSTD_STATIC_LINKING_ONLY — TEST 45 needs the memory-estimation API that
-#     zstd_max_cctx_memory is built on; auto/zstd only defines it on the
-#     explicit ZSTD_INC path, not on the pkg-config auto-discovery path this
-#     script takes.
+#   no ZSTD_STATIC_LINKING_ONLY — this script builds a deployable dynamic
+#     module against libzstd.so, whose ABI does not guarantee the static-only
+#     entry points. auto/zstd enables that macro only after a true static
+#     archive probe succeeds.
 # Coverage adds --coverage to BOTH cc-opt and ld-opt via the configure
 # argument, not env CC/CFLAGS -- nginx's configure probes the compiler with
 # its own invocations (`` `$CC -v ...` ``, unquoted so it also splits on a
 # ccache prefix) and ignores a bare CC=/CFLAGS= override entirely: nothing in
 # configure or the generated Makefile ever reads it.
-CC_OPT="-DZSTD_STATIC_LINKING_ONLY"
+CC_OPT=""
 LD_OPT=""
 if [ "$MODE" = "coverage" ]; then
     CC_OPT="$CC_OPT --coverage -O0"
@@ -338,6 +338,8 @@ echo "==========================================================================
 echo ""
 
 make -j"$(nproc)" 2>&1 | tail -10
+"$ZSTD_MODULE_DIR/ci/tools/check-zstd-dynamic-linkage.sh" \
+    objs/ngx_http_zstd_filter_module.so
 
 echo ""
 echo "=========================================================================="


### PR DESCRIPTION
## Summary
- remove ZSTD_STATIC_LINKING_ONLY from deployable dynamic-module builds against libzstd.so
- add ci/tools/check-zstd-dynamic-linkage.sh to require DT_NEEDED libzstd while rejecting undefined ZSTDLIB_STATIC_API imports
- run the new gate in ci-build.sh and dynamic workflow legs

## Queue
- A29-F2

## Local evidence
- NO_CACHE=1 MODE=normal ci/tools/ci-build.sh nginx 1.29.1
- negative control: synthetic shared object importing ZSTD_createCCtxParams fails check-zstd-dynamic-linkage.sh
- bash -n ci/tools/check-zstd-dynamic-linkage.sh ci/tools/ci-build.sh
- shellcheck ci/tools/check-zstd-dynamic-linkage.sh ci/tools/ci-build.sh
- actionlint .github/workflows/build-test.yml
- git diff --check
- commit-time staged lint hook

CodeRabbit CLI: rate_limit, waived by user for this resumed run.