### PR TITLE
filter: honor no-transform responses

### DIFF
--- a/ci/tools/test_encoding.py
+++ b/ci/tools/test_encoding.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import concurrent.futures
+import http.server
 import os
 import pathlib
 import re
@@ -9,8 +10,10 @@ import socket
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import urllib.request
+from typing import ClassVar
 
 FIXTURE_SENTINEL = "END-OF-ZSTD-TRUNCATION-FIXTURE-9f4c3d1b"
 
@@ -43,6 +46,11 @@ def parse_args() -> argparse.Namespace:
         type=int,
         default=18080,
         help="Local TCP port for the temporary nginx instance.",
+    )
+    parser.add_argument(
+        "--backend-port",
+        type=int,
+        help="Local TCP port for the temporary Cache-Control upstream.",
     )
     parser.add_argument(
         "--zstd-bin",
@@ -137,6 +145,7 @@ def write_config(
     conf_path: pathlib.Path,
     root_dir: pathlib.Path,
     port: int,
+    backend_port: int,
     gzip_vary: str,
     modules: list[pathlib.Path],
 ) -> None:
@@ -175,6 +184,46 @@ http {{
             zstd_types application/javascript;
             access_log logs/zstd_ratio.log zstd_ratio_fmt;
         }}
+        location = /cache-control-public.js {{
+            types {{
+                application/javascript js;
+            }}
+            default_type application/javascript;
+            zstd on;
+            zstd_min_length 1;
+            zstd_types application/javascript;
+            proxy_pass http://127.0.0.1:{backend_port}/cache-control-public.js;
+        }}
+        location = /cache-control-no-transform-comma.js {{
+            types {{
+                application/javascript js;
+            }}
+            default_type application/javascript;
+            zstd on;
+            zstd_min_length 1;
+            zstd_types application/javascript;
+            proxy_pass http://127.0.0.1:{backend_port}/cache-control-no-transform-comma.js;
+        }}
+        location = /cache-control-no-transform-ows.js {{
+            types {{
+                application/javascript js;
+            }}
+            default_type application/javascript;
+            zstd on;
+            zstd_min_length 1;
+            zstd_types application/javascript;
+            proxy_pass http://127.0.0.1:{backend_port}/cache-control-no-transform-ows.js;
+        }}
+        location = /cache-control-no-transform-repeat.js {{
+            types {{
+                application/javascript js;
+            }}
+            default_type application/javascript;
+            zstd on;
+            zstd_min_length 1;
+            zstd_types application/javascript;
+            proxy_pass http://127.0.0.1:{backend_port}/cache-control-no-transform-repeat.js;
+        }}
     }}
 }}
 """.lstrip(),
@@ -182,9 +231,40 @@ http {{
     )
 
 
+class CacheControlHandler(http.server.BaseHTTPRequestHandler):
+    payload = b""
+    cache_control: ClassVar[dict[str, list[str]]] = {
+        "/cache-control-public.js": ["public"],
+        "/cache-control-no-transform-comma.js": ["public, no-transform"],
+        "/cache-control-no-transform-ows.js": [" public ; max-age=60 , No-Transform "],
+        "/cache-control-no-transform-repeat.js": ["public", "no-transform"],
+    }
+
+    def do_GET(self) -> None:
+        values = self.cache_control.get(self.path)
+        if values is None:
+            self.send_error(404)
+            return
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/javascript")
+        self.send_header("Content-Length", str(len(self.payload)))
+        for value in values:
+            self.send_header("Cache-Control", value)
+        self.end_headers()
+        self.wfile.write(self.payload)
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        return
+
+
 def fetch_response(port: int) -> tuple[bytes, str, str]:
+    return fetch_path(port, "/test.js")
+
+
+def fetch_path(port: int, path: str) -> tuple[bytes, str, str]:
     request = urllib.request.Request(
-        f"http://127.0.0.1:{port}/test.js",
+        f"http://127.0.0.1:{port}{path}",
         headers={"Accept-Encoding": "zstd", "User-Agent": "zstd-ci-smoke-test/1.0"},
     )
     with urllib.request.urlopen(request, timeout=10) as response:
@@ -192,6 +272,31 @@ def fetch_response(port: int) -> tuple[bytes, str, str]:
         content_encoding = response.headers.get("Content-Encoding", "")
         vary = response.headers.get("Vary", "")
     return compressed, content_encoding, vary
+
+
+def validate_cache_control_no_transform(port: int, expected: bytes) -> None:
+    public_body, public_encoding, _ = fetch_path(port, "/cache-control-public.js")
+    if public_encoding.lower() != "zstd":
+        raise RuntimeError(
+            "Cache-Control public negative control did not compress: "
+            f"Content-Encoding={public_encoding!r}"
+        )
+
+    for path in (
+        "/cache-control-no-transform-comma.js",
+        "/cache-control-no-transform-ows.js",
+        "/cache-control-no-transform-repeat.js",
+    ):
+        body, encoding, _ = fetch_path(port, path)
+        if encoding:
+            raise RuntimeError(
+                f"{path}: expected no Content-Encoding for no-transform, got {encoding!r}"
+            )
+        if body != expected:
+            raise RuntimeError(f"{path}: identity response body changed")
+
+    if public_body == expected:
+        raise RuntimeError("Cache-Control public negative control was not transformed")
 
 
 def decompress_payload(zstd_bin: str, compressed: bytes) -> bytes:
@@ -302,6 +407,7 @@ def main() -> int:
         raise ValueError(
             f"concurrent-requests must be >= 1, got {args.concurrent_requests}"
         )
+    backend_port = args.backend_port or args.port + 1
 
     filter_module = detect_module_path(
         args.filter_module,
@@ -342,7 +448,16 @@ def main() -> int:
         fixture_path = html_dir / "test.js"
         expected = build_fixture(fixture_path, args.fixture_lines)
         conf_path = conf_dir / "nginx.conf"
-        write_config(conf_path, html_dir, args.port, args.gzip_vary, modules)
+        write_config(
+            conf_path, html_dir, args.port, backend_port, args.gzip_vary, modules
+        )
+
+        CacheControlHandler.payload = expected
+        backend = http.server.ThreadingHTTPServer(
+            ("127.0.0.1", backend_port), CacheControlHandler
+        )
+        backend_thread = threading.Thread(target=backend.serve_forever, daemon=True)
+        backend_thread.start()
 
         process = subprocess.Popen(
             [
@@ -388,6 +503,8 @@ def main() -> int:
                     for future in futures:
                         future.result()
 
+            validate_cache_control_no_transform(args.port, expected)
+
             validate_ratio_log(
                 pathlib.Path(temp_dir) / "logs" / "zstd_ratio.log",
                 args.request_count,
@@ -410,6 +527,8 @@ def main() -> int:
             )
             return 0
         finally:
+            backend.shutdown()
+            backend.server_close()
             process.terminate()
             try:
                 # 30s, not 5: gcov-instrumented nginx flushing .gcda

--- a/ci/tools/test_encoding.py
+++ b/ci/tools/test_encoding.py
@@ -194,6 +194,16 @@ http {{
             zstd_types application/javascript;
             proxy_pass http://127.0.0.1:{backend_port}/cache-control-public.js;
         }}
+        location = /cache-control-quoted-no-transform.js {{
+            types {{
+                application/javascript js;
+            }}
+            default_type application/javascript;
+            zstd on;
+            zstd_min_length 1;
+            zstd_types application/javascript;
+            proxy_pass http://127.0.0.1:{backend_port}/cache-control-quoted-no-transform.js;
+        }}
         location = /cache-control-no-transform-comma.js {{
             types {{
                 application/javascript js;
@@ -235,6 +245,7 @@ class CacheControlHandler(http.server.BaseHTTPRequestHandler):
     payload = b""
     cache_control: ClassVar[dict[str, list[str]]] = {
         "/cache-control-public.js": ["public"],
+        "/cache-control-quoted-no-transform.js": ['public, extension="no-transform"'],
         "/cache-control-no-transform-comma.js": ["public, no-transform"],
         "/cache-control-no-transform-ows.js": [" public ; max-age=60 , No-Transform "],
         "/cache-control-no-transform-repeat.js": ["public", "no-transform"],
@@ -280,6 +291,18 @@ def validate_cache_control_no_transform(port: int, expected: bytes) -> None:
         raise RuntimeError(
             "Cache-Control public negative control did not compress: "
             f"Content-Encoding={public_encoding!r}"
+        )
+    quoted_body, quoted_encoding, _ = fetch_path(
+        port, "/cache-control-quoted-no-transform.js"
+    )
+    if quoted_encoding.lower() != "zstd":
+        raise RuntimeError(
+            "Cache-Control quoted no-transform parameter was treated as a "
+            f"directive: Content-Encoding={quoted_encoding!r}"
+        )
+    if quoted_body == expected:
+        raise RuntimeError(
+            "Cache-Control quoted no-transform negative control was not transformed"
         )
 
     for path in (

--- a/ci/tools/test_terminal_frame.py
+++ b/ci/tools/test_terminal_frame.py
@@ -152,7 +152,9 @@ def main() -> int:
         fixture_path = html_dir / "test.js"
         expected = build_terminal_fixture(fixture_path)
         conf_path = conf_dir / "nginx.conf"
-        test_encoding.write_config(conf_path, html_dir, args.port, "off", modules)
+        test_encoding.write_config(
+            conf_path, html_dir, args.port, args.port + 1, "off", modules
+        )
 
         process = subprocess.Popen(
             [

--- a/ci/tools/test_test_encoding.py
+++ b/ci/tools/test_test_encoding.py
@@ -75,6 +75,7 @@ class WriteConfigTests(unittest.TestCase):
                 conf_path,
                 html_dir,
                 18080,
+                18081,
                 "on",
                 [filter_module, static_module],
             )
@@ -100,7 +101,7 @@ class WriteConfigTests(unittest.TestCase):
             html_dir = root / "html"
             html_dir.mkdir()
 
-            test_encoding.write_config(conf_path, html_dir, 18080, "off", [])
+            test_encoding.write_config(conf_path, html_dir, 18080, 18081, "off", [])
 
             config = conf_path.read_text(encoding="utf-8")
             self.assertTrue(config.startswith("worker_processes  1;\n"))

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -1382,6 +1382,96 @@ ngx_module_t  ngx_http_zstd_filter_module = {
 
 
 static ngx_int_t
+ngx_http_zstd_cache_control_value_no_transform(ngx_table_elt_t *cc)
+{
+    u_char  *p, *last, *start, *end, *semi;
+
+    if (cc->value.len == 0) {
+        return 0;
+    }
+
+    p = cc->value.data;
+    last = p + cc->value.len;
+
+    while (p < last) {
+        start = p;
+        while (start < last && (*start == ' ' || *start == '\t')) {
+            start++;
+        }
+
+        end = start;
+        while (end < last && *end != ',') {
+            end++;
+        }
+
+        semi = start;
+        while (semi < end && *semi != ';') {
+            semi++;
+        }
+        end = semi;
+
+        while (end > start && (end[-1] == ' ' || end[-1] == '\t')) {
+            end--;
+        }
+
+        if ((size_t) (end - start) == sizeof("no-transform") - 1
+            && ngx_strncasecmp(start, (u_char *) "no-transform",
+                               sizeof("no-transform") - 1) == 0)
+        {
+            return 1;
+        }
+
+        p = semi;
+        while (p < last && *p != ',') {
+            p++;
+        }
+        if (p < last) {
+            p++;
+        }
+    }
+
+    return 0;
+}
+
+
+static ngx_int_t
+ngx_http_zstd_cache_control_no_transform(ngx_http_request_t *r)
+{
+    ngx_uint_t        i;
+    ngx_list_part_t  *part;
+    ngx_table_elt_t  *h;
+
+    part = &r->headers_out.headers.part;
+    h = part->elts;
+
+    for (i = 0; /* void */; i++) {
+        if (i >= part->nelts) {
+            if (part->next == NULL) {
+                break;
+            }
+
+            part = part->next;
+            h = part->elts;
+            i = 0;
+        }
+
+        if (h[i].hash == 0 || h[i].key.len != sizeof("Cache-Control") - 1) {
+            continue;
+        }
+
+        if (ngx_strncasecmp(h[i].key.data, (u_char *) "Cache-Control",
+                            sizeof("Cache-Control") - 1) == 0
+            && ngx_http_zstd_cache_control_value_no_transform(&h[i]))
+        {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+
+static ngx_int_t
 ngx_http_zstd_header_filter(ngx_http_request_t *r)
 {
     ngx_table_elt_t           *h;
@@ -1486,6 +1576,12 @@ ngx_http_zstd_header_filter(ngx_http_request_t *r)
         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                        "zstd: skip, content type \"%V\" not in zstd_types",
                        &r->headers_out.content_type);
+        return ngx_http_next_header_filter(r);
+    }
+
+    if (ngx_http_zstd_cache_control_no_transform(r)) {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "zstd: skip, Cache-Control no-transform");
         return ngx_http_next_header_filter(r);
     }
 


### PR DESCRIPTION
## Summary
- decline zstd/dcz before header commitment when upstream Cache-Control contains no-transform
- parse comma-separated directives, OWS, parameters, and repeated Cache-Control fields
- add proxy-backed smoke coverage so Cache-Control is present before the zstd header filter runs

## Queue
- A29-F4

## Local evidence
- NO_CACHE=1 MODE=normal ci/tools/ci-build.sh nginx 1.29.1
- ci/tools/test_encoding.py --nginx-binary .build/nginx-1.29.1/objs/nginx --filter-module <abs filter .so> --static-module <abs static .so> --port 18134 --backend-port 18135
- negative control: temporarily disabled the no-transform gate; same smoke test failed on /cache-control-no-transform-comma.js with Content-Encoding=zstd
- python3 -m py_compile ci/tools/test_encoding.py
- ruff check/format ci/tools/test_encoding.py
- git diff --check
- commit-time staged lint hook

CodeRabbit CLI: confirmed and fixed major findings about add_header timing and pre-1.23 ngx_table_elt_t traversal; final rerun hit waived rate_limit.