### PR TITLE
filter: honor a no-transform directive that carries an argument

### DIFF
--- a/ci/tools/test_encoding.py
+++ b/ci/tools/test_encoding.py
@@ -224,6 +224,16 @@ http {{
             zstd_types application/javascript;
             proxy_pass http://127.0.0.1:{backend_port}/cache-control-no-transform-ows.js;
         }}
+        location = /cache-control-no-transform-arg.js {{
+            types {{
+                application/javascript js;
+            }}
+            default_type application/javascript;
+            zstd on;
+            zstd_min_length 1;
+            zstd_types application/javascript;
+            proxy_pass http://127.0.0.1:{backend_port}/cache-control-no-transform-arg.js;
+        }}
         location = /cache-control-no-transform-repeat.js {{
             types {{
                 application/javascript js;
@@ -249,6 +259,7 @@ class CacheControlHandler(http.server.BaseHTTPRequestHandler):
         "/cache-control-no-transform-comma.js": ["public, no-transform"],
         "/cache-control-no-transform-ows.js": [" public ; max-age=60 , No-Transform "],
         "/cache-control-no-transform-repeat.js": ["public", "no-transform"],
+        "/cache-control-no-transform-arg.js": ["public, no-transform=1"],
     }
 
     def do_GET(self) -> None:
@@ -309,6 +320,11 @@ def validate_cache_control_no_transform(port: int, expected: bytes) -> None:
         "/cache-control-no-transform-comma.js",
         "/cache-control-no-transform-ows.js",
         "/cache-control-no-transform-repeat.js",
+        # Malformed but intent-clear: the directive defines no argument
+        # (RFC 9111 5.2.2.6), so an origin writing no-transform=1 gets
+        # honored, not transformed -- the walker compares the directive
+        # name, cut at '='.
+        "/cache-control-no-transform-arg.js",
     ):
         body, encoding, _ = fetch_path(port, path)
         if encoding:

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -1404,8 +1404,16 @@ ngx_http_zstd_cache_control_value_no_transform(ngx_table_elt_t *cc)
             end++;
         }
 
+        /*
+         * Cut at '=' as well as ';': the compared token is then the
+         * directive NAME, so "no-transform=arg" -- malformed, since the
+         * directive defines no argument (RFC 9111 §5.2.2.6), but clear
+         * in intent -- is honored rather than transformed. The quoted
+         * parameter-value control is unaffected: extension="no-transform"
+         * cuts to "extension" and still does not match.
+         */
         semi = start;
-        while (semi < end && *semi != ';') {
+        while (semi < end && *semi != ';' && *semi != '=') {
             semi++;
         }
         end = semi;


### PR DESCRIPTION
Follow-up to #251, found while porting it to the compression branch.

## Problem

The walker cuts each comma-separated segment at `;` only, so the whole-token compare sees `no-transform=1` as a 14-byte token and does not match — the response is transformed. RFC 9111's ABNF allows an argument on any cache directive (`token [ "=" ( token / quoted-string ) ]`), and §5.2.2.6 defines none for no-transform, so an origin emitting one is malformed but unambiguous in intent. Since the directive is a prohibition, honoring it is the conservative reading of the ambiguity.

## Fix

Cut the segment at `=` as well as `;`, so the compare runs against the directive NAME. One line plus a comment.

The quoted parameter-value control is unaffected, just resolved one step earlier: `extension="no-transform"` now cuts to `extension` instead of relying on the trailing quote to break the length match — same verdict either way, and the existing quoted-value vector still passes.

## Testing

`test_encoding.py` gains the vector `"public, no-transform=1"` → identity. Fail-first verified locally against 9c65227: the vector fails with `expected no Content-Encoding for no-transform, got 'zstd'` before the src change and the full harness passes with it (`OK: verified zstd response integrity for 639306-byte JavaScript fixture`).