### PR TITLE
perf: reduce compressor allocation overhead

### DIFF
--- a/ci/t/03-dcz.t
+++ b/ci/t/03-dcz.t
@@ -64,6 +64,7 @@ our $bad_b64  = encode_base64("\x01" x 32, "");
 # $zstd_dcz_dicts_hashed counts every loaded dictionary by default
 # (TESTs 21-23), but excludes trusted literals (TESTs 41-42).
 our $dict_hex = unpack("H*", sha256($dict_raw));
+our $dict_hex_upper = uc($dict_hex);
 our $odd_hex  = "01" x 32;
 our $odd_b64  = encode_base64("\x01" x 32, "");
 
@@ -505,6 +506,27 @@ qr/does not match the supplied hash "0101010101010101010101010101010101010101010
         zstd on;
         zstd_min_length 16;
         zstd_dcz_dict_file \$TEST_NGINX_PERL_PATH/suite/dcz-dict $::dict_hex;
+        default_type text/plain;
+        return 200 \"dcz negotiation body: shared-boilerplate compute render\n\";
+    }"
+--- request
+GET /t
+--- more_headers eval
+"Accept-Encoding: zstd, dcz\nAvailable-Dictionary: :$::dict_b64:"
+--- response_headers
+Content-Encoding: dcz
+--- no_error_log
+[error]
+
+
+
+=== TEST 50: an uppercase supplied hash loads and negotiates
+# Pins the case-folding branch in ngx_http_zstd_hex_nibble().
+--- config eval
+"    location /t {
+        zstd on;
+        zstd_min_length 16;
+        zstd_dcz_dict_file \$TEST_NGINX_PERL_PATH/suite/dcz-dict $::dict_hex_upper;
         default_type text/plain;
         return 200 \"dcz negotiation body: shared-boilerplate compute render\n\";
     }"

--- a/ci/t/harness-scenarios/fault-arms/driver.sh
+++ b/ci/t/harness-scenarios/fault-arms/driver.sh
@@ -282,7 +282,8 @@ fi
 # zero-length last_buf (the suppression arm lets it through on purpose), and
 # nginx's writer only tolerates a zero-size buffer that ngx_buf_special()
 # accepts: `(flush||last_buf||sync) && !ngx_buf_in_memory(b) && !b->in_file`.
-# out_buf comes from ngx_create_temp_buf(), so `temporary` stays set and
+# out_buf comes from ngx_http_zstd_create_temp_buf(), so `temporary` stays set
+# and
 # ngx_buf_in_memory() stays true even when the buffer is fully drained. That
 # made ngx_http_write_filter log "zero size buf in writer" and abort the
 # response mid-stream.

--- a/ci/t/harness-scenarios/fault-palloc/driver.sh
+++ b/ci/t/harness-scenarios/fault-palloc/driver.sh
@@ -4,8 +4,8 @@
 #
 # Reachable only through the harness's TEST_HARNESS build (see the requires
 # gate): the per-request allocation sites in the filter go through the
-# ngx_http_zstd_{palloc,pnalloc,pcalloc,alloc_chain_link,create_temp_buf,
-# list_push,pool_cleanup_add} wrappers, which consult the PALLOC fault site
+# ngx_http_zstd_{palloc,pnalloc,pcalloc,alloc_chain_link,list_push,
+# pool_cleanup_add} wrappers, which consult the PALLOC fault site
 # before delegating to the real allocator. Armed via
 # GET /__probe?fault_palloc=<n>: the n-th WRAPPED allocation since the arm
 # returns NULL. Negative disarms.
@@ -27,7 +27,7 @@
 #    2    Content-Encoding ngx_list_push, header filter  no
 #    3    CCtx cleanup ngx_pool_cleanup_add              no
 #    4    incoming-chain link, body filter               no
-#    5    out_buf ngx_create_temp_buf                    no
+#    5    out_buf combined allocation                    no
 #    6-8  incoming-chain link, body filter               no
 #    9    emit chain link                                no
 #   10-12 incoming-chain link, body filter               YES

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -140,6 +140,25 @@ ngx_http_zstd_ceil_log2(size_t x)
 }
 
 
+static ngx_inline u_char
+ngx_http_zstd_hex_nibble(u_char c)
+{
+    u_char  lower;
+
+    if (c >= '0' && c <= '9') {
+        return (u_char) (c - '0');
+    }
+
+    lower = (u_char) (c | 0x20);
+
+    if (lower >= 'a' && lower <= 'f') {
+        return (u_char) (lower - 'a' + 10);
+    }
+
+    return 0xff;
+}
+
+
 /*
  * The ONLY sanctioned way to hash a dcz dictionary at config load: the
  * $zstd_dcz_dicts_hashed accounting is inseparable from the operation.
@@ -5908,16 +5927,10 @@ ngx_http_zstd_dcz_dict_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         for (i = 0; i < NGX_HTTP_ZSTD_SHA256_DIGEST_LEN; i++) {
 
             c = value[2].data[2 * i];
-            hi = (c >= '0' && c <= '9') ? (u_char) (c - '0')
-                 : (c >= 'a' && c <= 'f') ? (u_char) (c - 'a' + 10)
-                 : (c >= 'A' && c <= 'F') ? (u_char) (c - 'A' + 10)
-                 : 0xff;
+            hi = ngx_http_zstd_hex_nibble(c);
 
             c = value[2].data[2 * i + 1];
-            lo = (c >= '0' && c <= '9') ? (u_char) (c - '0')
-                 : (c >= 'a' && c <= 'f') ? (u_char) (c - 'a' + 10)
-                 : (c >= 'A' && c <= 'F') ? (u_char) (c - 'A' + 10)
-                 : 0xff;
+            lo = ngx_http_zstd_hex_nibble(c);
 
             if (hi == 0xff || lo == 0xff) {
                 ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -37,16 +37,16 @@
  * with an internal guard: a function would still be a call the optimizer
  * has to reason about, and the hot path must not pay for a test feature.
  *
- * There is no ngx_http_zstd_palloc(): every raw ngx_palloc() in this file
- * is a cf->pool call, and those are deliberately not wrapped (below). A
- * wrapper nothing calls would be dead code that looks like coverage.
- *
  * CONFIG-TIME sites (cf->pool) are deliberately NOT wrapped. They run once
  * at startup, their failure mode is "nginx refuses to start" rather than a
  * mid-request branch, and arming a fault that fires during configuration
  * would break the probe endpoint itself before any test could use it.
  */
 #ifdef NGX_TEST_HARNESS
+
+#define ngx_http_zstd_palloc(pool, size)                                     \
+    (ngx_http_zstd_probe_palloc_should_fail()                                \
+        ? NULL : ngx_palloc(pool, size))
 
 #define ngx_http_zstd_pnalloc(pool, size)                                    \
     (ngx_http_zstd_probe_palloc_should_fail()                                \
@@ -60,10 +60,6 @@
     (ngx_http_zstd_probe_palloc_should_fail()                                \
         ? NULL : ngx_alloc_chain_link(pool))
 
-#define ngx_http_zstd_create_temp_buf(pool, size)                            \
-    (ngx_http_zstd_probe_palloc_should_fail()                                \
-        ? NULL : ngx_create_temp_buf(pool, size))
-
 #define ngx_http_zstd_list_push(list)                                        \
     (ngx_http_zstd_probe_palloc_should_fail()                                \
         ? NULL : ngx_list_push(list))
@@ -74,11 +70,10 @@
 
 #else
 
+#define ngx_http_zstd_palloc(pool, size)          ngx_palloc(pool, size)
 #define ngx_http_zstd_pnalloc(pool, size)         ngx_pnalloc(pool, size)
 #define ngx_http_zstd_pcalloc(pool, size)         ngx_pcalloc(pool, size)
 #define ngx_http_zstd_alloc_chain_link(pool)      ngx_alloc_chain_link(pool)
-#define ngx_http_zstd_create_temp_buf(pool, size)                            \
-    ngx_create_temp_buf(pool, size)
 #define ngx_http_zstd_list_push(list)             ngx_list_push(list)
 #define ngx_http_zstd_pool_cleanup_add(pool, size)                            \
     ngx_pool_cleanup_add(pool, size)
@@ -822,6 +817,7 @@ static ngx_int_t ngx_http_zstd_filter_add_data(ngx_http_request_t *r,
 static ngx_int_t ngx_http_zstd_filter_get_buf(ngx_http_request_t *r,
     ngx_http_zstd_ctx_t *ctx,
     ngx_http_zstd_loc_conf_t *zlcf);
+static ngx_buf_t *ngx_http_zstd_create_temp_buf(ngx_pool_t *pool, size_t size);
 static ngx_int_t ngx_http_zstd_set_param(ngx_http_request_t *r,
     ZSTD_CCtx *cctx, ZSTD_cParameter param, int value, const char *name);
 static ngx_int_t ngx_http_zstd_filter_init_cctx(ngx_http_request_t *r,
@@ -2832,9 +2828,10 @@ ngx_http_zstd_filter_compress(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
      * what the suppression arm above deliberately lets through. But the writer
      * only tolerates a zero-size buffer when ngx_buf_special() accepts it, and
      * that macro requires !ngx_buf_in_memory(b) && !b->in_file. out_buf comes
-     * from ngx_create_temp_buf(), so `temporary` is set and start/end point at
-     * a real allocation: ngx_buf_in_memory() stays true even once the buffer is
-     * fully drained, the special test fails, and ngx_http_write_filter logs
+     * from ngx_http_zstd_create_temp_buf(), so `temporary` is set and
+     * start/end point at a real allocation: ngx_buf_in_memory() stays true
+     * even once the buffer is fully drained, the special test fails, and
+     * ngx_http_write_filter logs
      * "zero size buf in writer" and aborts the response mid-stream.
      *
      * Clearing `temporary` on an empty buffer is exactly what nginx's own gzip
@@ -2971,6 +2968,37 @@ ngx_http_zstd_filter_add_data(ngx_http_request_t *r, ngx_http_zstd_ctx_t *ctx)
     ctx->bytes_in += in_size;
 
     return NGX_OK;
+}
+
+
+static ngx_buf_t *
+ngx_http_zstd_create_temp_buf(ngx_pool_t *pool, size_t size)
+{
+    size_t      data_offset;
+    u_char     *allocation;
+    ngx_buf_t  *b;
+
+    data_offset = ngx_align(sizeof(ngx_buf_t), NGX_ALIGNMENT);
+
+    if (size > NGX_MAX_SIZE_T_VALUE - data_offset) {
+        return NULL;
+    }
+
+    allocation = ngx_http_zstd_palloc(pool, data_offset + size);
+    if (allocation == NULL) {
+        return NULL;
+    }
+
+    b = (ngx_buf_t *) allocation;
+    ngx_memzero(b, sizeof(ngx_buf_t));
+
+    b->start = allocation + data_offset;
+    b->pos = b->start;
+    b->last = b->start;
+    b->end = b->start + size;
+    b->temporary = 1;
+
+    return b;
 }
 
 


### PR DESCRIPTION
## TL;DR

This sweep removes one request-pool allocation from each compressor output buffer and simplifies configuration-time SHA-256 hash decoding. Buffer ownership, malformed-input rejection, and uppercase/lowercase hash support stay unchanged.

## Mechanism

- Allocate the private `ngx_buf_t` and its payload as one aligned pool block while preserving the existing temporary-buffer fields and fault-injection coverage.
- Decode supplied dictionary hashes through one inline nibble helper instead of repeating the range ladder for each half-byte.
- Pin uppercase hash negotiation in the dcz integration suite.

## Testing

`ci/t/03-dcz.t` passes all 179 assertions. The branch lint and pre-commit review gates completed without blocking findings.
