### PR TITLE
perf(dcz): reuse EVP digest context

### DIFF
--- a/ci/tools/sha256-unit/openssl/evp.h
+++ b/ci/tools/sha256-unit/openssl/evp.h
@@ -15,9 +15,12 @@
 #include <stddef.h>
 
 typedef struct fake_evp_md_st  EVP_MD;
+typedef struct evp_md_ctx_st EVP_MD_CTX;
+typedef struct engine_st ENGINE;
 
 const EVP_MD *EVP_sha256(void);
-int EVP_Digest(const void *data, size_t count, unsigned char *md,
-    unsigned int *size, const EVP_MD *type, void *impl);
+int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl);
+int EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *data, size_t count);
+int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *size);
 
 #endif /* NGX_SHIM_FAKE_EVP_H */

--- a/ci/tools/test_sha256_unit.c
+++ b/ci/tools/test_sha256_unit.c
@@ -61,16 +61,12 @@ to_hex(const u_char digest[NGX_HTTP_ZSTD_SHA256_DIGEST_LEN], char out[65])
 #if (NGX_HTTP_ZSTD_HAVE_LIBCRYPTO)
 
 /*
- * Scripted fake EVP. Modes:
- *   0 — scribble a partial digest, return failure: the wrapper must
- *       fall back and the portable finaliser must overwrite every byte.
- *   1 — fill the digest, report a WRONG length, return success: the
- *       wrapper's mdlen guard must reject and fall back.
- *   2 — fill the digest with a marker, report the right length, return
- *       success: the wrapper must hand the marker back untouched.
+ * Scripted fake EVP. Modes 0/1/2 fail init/update/final, mode 3 reports a
+ * wrong digest length, and mode 4 succeeds.
  */
 static int  fake_evp_mode;
 static int  fake_evp_calls;
+static unsigned char fake_evp_ctx;
 
 /* Fake EVP_sha256(): an opaque non-NULL token — the wrapper under test
    only passes it through, never dereferences it. */
@@ -80,35 +76,43 @@ EVP_sha256(void)
     return (const EVP_MD *) "fake-sha256";
 }
 
-/* Fake EVP_Digest(): behaves per fake_evp_mode (see above) and counts
-   invocations so the tests can assert the wrapper consulted EVP. */
 int
-EVP_Digest(const void *data, size_t count, unsigned char *md,
-    unsigned int *size, const EVP_MD *type, void *impl)
+EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
 {
-    (void) data;
-    (void) count;
+    (void) ctx;
     (void) type;
     (void) impl;
-
     fake_evp_calls++;
+    return fake_evp_mode != 0;
+}
 
-    switch (fake_evp_mode) {
+int
+EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *data, size_t count)
+{
+    (void) ctx;
+    (void) data;
+    (void) count;
+    fake_evp_calls++;
+    return fake_evp_mode != 1;
+}
 
-    case 0:
-        memset(md, 0x5a, 17);           /* partial scribble, then fail */
+int
+EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *size)
+{
+    (void) ctx;
+    fake_evp_calls++;
+    if (fake_evp_mode == 2) {
+        memset(md, 0x5a, 17);
         return 0;
-
-    case 1:
+    }
+    if (fake_evp_mode == 3) {
         memset(md, 0x5a, NGX_HTTP_ZSTD_SHA256_DIGEST_LEN);
-        *size = 16;                     /* "success" with a wrong length */
-        return 1;
-
-    default:
-        memset(md, 0xaa, NGX_HTTP_ZSTD_SHA256_DIGEST_LEN);
-        *size = NGX_HTTP_ZSTD_SHA256_DIGEST_LEN;
+        *size = 16;
         return 1;
     }
+    memset(md, 0xaa, NGX_HTTP_ZSTD_SHA256_DIGEST_LEN);
+    *size = NGX_HTTP_ZSTD_SHA256_DIGEST_LEN;
+    return 1;
 }
 
 /* EVP-fallback build: drive the wrapper through the three scripted EVP
@@ -125,30 +129,34 @@ main(void)
         "ba7816bf8f01cfea414140de5dae2223"
         "b00361a396177a9cb410ff61f20015ad";
 
-    /* Mode 0: failure after a partial write -> portable result. */
-    fake_evp_mode = 0;
     fake_evp_calls = 0;
     memset(digest, 0, sizeof(digest));
-    ngx_http_zstd_sha256((const u_char *) abc, 3, digest);
+    ngx_http_zstd_sha256((const u_char *) abc, 3, digest, NULL);
     to_hex(digest, hexdigest);
-    check("EVP failure falls back to the portable implementation",
+    check("missing cycle EVP context falls back to portable SHA-256",
           strcmp(hexdigest, abc_hex) == 0, hexdigest);
-    check("fallback path consulted EVP exactly once",
-          fake_evp_calls == 1, NULL);
+    check("missing cycle EVP context makes no EVP calls",
+          fake_evp_calls == 0, NULL);
 
-    /* Mode 1: success with a wrong mdlen -> guard rejects, fallback. */
-    fake_evp_mode = 1;
-    memset(digest, 0, sizeof(digest));
-    ngx_http_zstd_sha256((const u_char *) abc, 3, digest);
-    to_hex(digest, hexdigest);
-    check("wrong EVP output length is rejected and falls back",
-          strcmp(hexdigest, abc_hex) == 0, hexdigest);
+    for (fake_evp_mode = 0; fake_evp_mode < 4; fake_evp_mode++) {
+        fake_evp_calls = 0;
+        memset(digest, 0, sizeof(digest));
+        ngx_http_zstd_sha256((const u_char *) abc, 3, digest,
+                             (EVP_MD_CTX *) &fake_evp_ctx);
+        to_hex(digest, hexdigest);
+        check("EVP failure falls back to the portable implementation",
+              strcmp(hexdigest, abc_hex) == 0, hexdigest);
+        check("fallback consulted the expected EVP stages",
+              fake_evp_calls == (fake_evp_mode < 3 ? fake_evp_mode + 1 : 3),
+              NULL);
+    }
 
     /* Mode 2: scripted success -> the EVP digest is used verbatim,
        proving the accelerated path is actually taken on success. */
-    fake_evp_mode = 2;
+    fake_evp_mode = 4;
     memset(digest, 0, sizeof(digest));
-    ngx_http_zstd_sha256((const u_char *) abc, 3, digest);
+    ngx_http_zstd_sha256((const u_char *) abc, 3, digest,
+                         (EVP_MD_CTX *) &fake_evp_ctx);
     all_aa = 1;
     for (i = 0; i < NGX_HTTP_ZSTD_SHA256_DIGEST_LEN; i++) {
         if (digest[i] != 0xaa) {
@@ -207,7 +215,7 @@ main(void)
     /* One-shot API against the published vectors. */
     for (i = 0; i < sizeof(vectors) / sizeof(vectors[0]); i++) {
         ngx_http_zstd_sha256((const u_char *) vectors[i].input,
-                             vectors[i].len, digest);
+                             vectors[i].len, digest, NULL);
         to_hex(digest, hexdigest);
         snprintf(name, sizeof(name), "NIST vector (%zu bytes)",
                  vectors[i].len);
@@ -230,7 +238,7 @@ main(void)
             "e9b0a925a5258e241c9f1e910f734318";
 
         memset(a55, 'a', sizeof(a55));
-        ngx_http_zstd_sha256(a55, sizeof(a55), digest);
+        ngx_http_zstd_sha256(a55, sizeof(a55), digest, NULL);
         to_hex(digest, hexdigest);
         check("padding-boundary vector (55 x 'a', remainder 55 mod 64)",
               strcmp(hexdigest, a55_hex) == 0, hexdigest);
@@ -271,7 +279,7 @@ main(void)
         buf[i] = (u_char) (lcg >> 24);
     }
 
-    ngx_http_zstd_sha256(buf, buf_len, ref);
+    ngx_http_zstd_sha256(buf, buf_len, ref, NULL);
 
     for (i = 0; i < sizeof(splits) / sizeof(splits[0]); i++) {
         ngx_http_zstd_sha256_init(&c);

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -171,9 +171,10 @@ ngx_http_zstd_hex_nibble(u_char c)
  */
 static ngx_inline void
 ngx_http_zstd_dcz_dict_hash(const u_char *data, size_t len,
-    u_char digest[NGX_HTTP_ZSTD_SHA256_DIGEST_LEN], ngx_uint_t *hashed)
+    u_char digest[NGX_HTTP_ZSTD_SHA256_DIGEST_LEN], ngx_uint_t *hashed,
+    void *evp_md_ctx)
 {
-    ngx_http_zstd_sha256(data, len, digest);
+    ngx_http_zstd_sha256(data, len, digest, evp_md_ctx);
     (*hashed)++;
 }
 
@@ -452,6 +453,10 @@ typedef struct {
      * active cycle's conf. pcalloc zeroes it — no reset hook needed.
      */
     ngx_uint_t                   dcz_dicts_hashed;
+
+    /* Reused only while this candidate configuration is parsed. */
+    void                        *dcz_evp_md_ctx;
+    ngx_flag_t                   dcz_evp_md_ctx_attempted;
 
     /*
      * Preformatted decimal representation of dcz_dicts_hashed,
@@ -876,6 +881,11 @@ static char *ngx_http_zstd_set_enable_slot(ngx_conf_t *cf,
     ngx_command_t *cmd, void *conf);
 static void ngx_http_zstd_cleanup_dict(void *data);
 static void ngx_http_zstd_cleanup_cctx(void *data);
+#if (NGX_HTTP_ZSTD_HAVE_LIBCRYPTO)
+static void ngx_http_zstd_cleanup_evp_md_ctx(void *data);
+static void ngx_http_zstd_init_evp_md_ctx(ngx_conf_t *cf,
+    ngx_http_zstd_main_conf_t *zmcf);
+#endif
 static void ngx_http_zstd_release_cctx(void *data);
 static ngx_int_t ngx_http_zstd_acquire_cctx(ngx_http_request_t *r,
     ngx_http_zstd_ctx_t *ctx, ngx_http_zstd_loc_conf_t *zlcf);
@@ -5783,6 +5793,39 @@ ngx_http_zstd_cleanup_cctx(void *data)
 }
 
 
+#if (NGX_HTTP_ZSTD_HAVE_LIBCRYPTO)
+static void
+ngx_http_zstd_cleanup_evp_md_ctx(void *data)
+{
+    EVP_MD_CTX_free(data);
+}
+
+
+static void
+ngx_http_zstd_init_evp_md_ctx(ngx_conf_t *cf,
+    ngx_http_zstd_main_conf_t *zmcf)
+{
+    ngx_pool_cleanup_t  *cln;
+
+    zmcf->dcz_evp_md_ctx_attempted = 1;
+    zmcf->dcz_evp_md_ctx = EVP_MD_CTX_new();
+    if (zmcf->dcz_evp_md_ctx == NULL) {
+        return;
+    }
+
+    cln = ngx_http_zstd_pool_cleanup_add(cf->pool, 0);
+    if (cln == NULL) {
+        EVP_MD_CTX_free(zmcf->dcz_evp_md_ctx);
+        zmcf->dcz_evp_md_ctx = NULL;
+        return;
+    }
+
+    cln->handler = ngx_http_zstd_cleanup_evp_md_ctx;
+    cln->data = zmcf->dcz_evp_md_ctx;
+}
+#endif
+
+
 /*
  * Return a borrowed worker context to the cache at request end.
  *
@@ -6117,8 +6160,14 @@ ngx_http_zstd_dcz_dict_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
          * Default: the negotiation key is the hash of the bytes this
          * load actually read. See the have_hash note above.
          */
+#if (NGX_HTTP_ZSTD_HAVE_LIBCRYPTO)
+        if (!zmcf->dcz_evp_md_ctx_attempted) {
+            ngx_http_zstd_init_evp_md_ctx(cf, zmcf);
+        }
+#endif
         ngx_http_zstd_dcz_dict_hash(bytes.data, size, hash,
-                                    &zmcf->dcz_dicts_hashed);
+                                    &zmcf->dcz_dicts_hashed,
+                                    zmcf->dcz_evp_md_ctx);
 
         if (have_hash
             && ngx_memcmp(supplied, hash,

--- a/src/ngx_http_zstd_sha256.h
+++ b/src/ngx_http_zstd_sha256.h
@@ -17,8 +17,8 @@
  * (and so nginx -t and every reload) hashes each registered file, which
  * at hundreds of entries turns into seconds of pure CPU with the
  * portable code. The portable implementation stays compiled in as the
- * runtime fallback: EVP_Digest() allocates internally and may fail
- * under memory pressure, and falling back keeps this a total function.
+ * runtime fallback: context allocation or any incremental EVP stage may fail,
+ * and falling back keeps this a total function.
  *
  * Only the filter TU uses these today. The one-shot entry point
  * ngx_http_zstd_sha256() is static ngx_inline; the four helpers it drives
@@ -239,7 +239,7 @@ ngx_http_zstd_sha256_final(ngx_http_zstd_sha256_t *c,
 /* One-shot convenience for the config-load call site. */
 static ngx_inline void
 ngx_http_zstd_sha256(const u_char *data, size_t len,
-    u_char digest[NGX_HTTP_ZSTD_SHA256_DIGEST_LEN])
+    u_char digest[NGX_HTTP_ZSTD_SHA256_DIGEST_LEN], void *evp_md_ctx)
 {
     ngx_http_zstd_sha256_t  c;
 
@@ -248,15 +248,19 @@ ngx_http_zstd_sha256(const u_char *data, size_t len,
 
     mdlen = NGX_HTTP_ZSTD_SHA256_DIGEST_LEN;
 
-    if (EVP_Digest(data, len, digest, &mdlen, EVP_sha256(), NULL) == 1
+    if (evp_md_ctx != NULL
+        && EVP_DigestInit_ex(evp_md_ctx, EVP_sha256(), NULL) == 1
+        && EVP_DigestUpdate(evp_md_ctx, data, len) == 1
+        && EVP_DigestFinal_ex(evp_md_ctx, digest, &mdlen) == 1
         && mdlen == NGX_HTTP_ZSTD_SHA256_DIGEST_LEN)
     {
         return;
     }
 
-    /* EVP_Digest() allocates a context internally and can fail under
-       memory pressure; fall through to the portable implementation. */
+    /* Fall through when the cycle context is unavailable or a stage fails. */
 #endif
+
+    (void) evp_md_ctx;
 
     ngx_http_zstd_sha256_init(&c);
     ngx_http_zstd_sha256_update(&c, data, len);


### PR DESCRIPTION
> Follow-up from the config-load performance queue. This is independent of the deferred phase-0 backend RFC.

## TL;DR

Dictionary hashing currently creates and destroys an OpenSSL digest context for every configured dictionary. Reusing one context for the lifetime of a candidate configuration removes that repeated allocation while preserving the portable fallback.

Reuse one lazily allocated, pool-cleaned digest context across computed dcz dictionary hashes; retain portable SHA-256 for allocation, cleanup-registration, initialization, update, finalization, and output-length failures.

**Severity:** `Low` (`performance — repeated config-load allocation`)

## Verification

- `bash ci/tools/test_sha256_unit.sh`
- `bash ci/tools/test_dcz_window_log_unit.sh`
- `python3 ci/tools/test_dcz.py ... --fixture-lines 128` (31 assertions)
- nginx 1.30.4 dynamic-module build with `-Werror`
- `.claude/skills/_shared/review-lint.sh --diff HEAD`
- CodeRabbit CLI: completed, 0 findings across 4 files

The SHA fixture injects missing-context, init, update, final, and wrong-length failures. The real dcz suite verifies the embedded SHA-256 and byte-exact decode with OpenSSL 3.5.6.

## Measurement

A five-run, interleaved 4 KiB EVP microbenchmark measured context reuse at 0.8–0.9% faster for one hash and 1.5–2.1% faster at 100, 600, and 3200 hashes. The repository's `config_bench.py` dcz workload is not cited because its synthetic supplied hashes are now verified by default and the current fixture correctly fails its own acceptance gate.
