### PR TITLE
refactor(vary): share token scanner

### DIFF
--- a/src/ngx_http_zstd_common.h
+++ b/src/ngx_http_zstd_common.h
@@ -742,83 +742,9 @@ ngx_http_zstd_push_header(ngx_http_request_t *r, const char *key,
 }
 
 
-static ngx_inline ngx_uint_t
-ngx_http_zstd_vary_has_token(ngx_http_request_t *r, const char *token,
-    size_t token_len)
-{
-    ngx_uint_t        i;
-    ngx_list_part_t  *part;
-    ngx_table_elt_t  *h;
-
-    for (part = &r->headers_out.headers.part, h = part->elts, i = 0;
-         /* void */;
-         i++)
-    {
-        if (i >= part->nelts) {
-            if (part->next == NULL) {
-                break;
-            }
-
-            part = part->next;
-            h = part->elts;
-            i = 0;
-        }
-
-        if (h[i].hash == 0
-            || h[i].key.len != sizeof("Vary") - 1
-            || ngx_strncasecmp(h[i].key.data, (u_char *) "Vary",
-                               sizeof("Vary") - 1) != 0)
-        {
-            continue;
-        }
-
-        {
-            u_char  *end, *p, *start;
-
-            p = h[i].value.data;
-            end = p + h[i].value.len;
-
-            while (p < end) {
-                while (p < end && (*p == ' ' || *p == '\t' || *p == ',')) {
-                    p++;
-                }
-
-                start = p;
-                while (p < end && *p != ',') {
-                    p++;
-                }
-
-                while (p > start && (p[-1] == ' ' || p[-1] == '\t')) {
-                    p--;
-                }
-
-                if ((size_t) (p - start) == token_len
-                    && ngx_strncasecmp(start, (u_char *) token,
-                                       token_len) == 0)
-                {
-                    return 1;
-                }
-
-                while (p < end && *p != ',') {
-                    p++;
-                }
-            }
-        }
-    }
-
-    return 0;
-}
-
-
-/*
- * Same walk as ngx_http_zstd_vary_has_token(), but checks for two tokens
- * in one pass over r->headers_out.headers instead of two. Used only by
- * ngx_http_zstd_vary_dcz(), whose two calls are adjacent and always want
- * both answers -- folding them avoids a second full header-list walk plus
- * a second per-Vary-line comma-token sub-scan.
- */
+/* token_b and has_b are either both NULL or both non-NULL. */
 static ngx_inline void
-ngx_http_zstd_vary_has_two_tokens(ngx_http_request_t *r,
+ngx_http_zstd_vary_find_tokens(ngx_http_request_t *r,
     const char *token_a, size_t token_a_len,
     const char *token_b, size_t token_b_len,
     ngx_uint_t *has_a, ngx_uint_t *has_b)
@@ -828,7 +754,9 @@ ngx_http_zstd_vary_has_two_tokens(ngx_http_request_t *r,
     ngx_table_elt_t  *h;
 
     *has_a = 0;
-    *has_b = 0;
+    if (has_b != NULL) {
+        *has_b = 0;
+    }
 
     for (part = &r->headers_out.headers.part, h = part->elts, i = 0;
          /* void */;
@@ -880,7 +808,7 @@ ngx_http_zstd_vary_has_two_tokens(ngx_http_request_t *r,
                     *has_a = 1;
                 }
 
-                if (!*has_b
+                if (has_b != NULL && !*has_b
                     && (size_t) (p - start) == token_b_len
                     && ngx_strncasecmp(start, (u_char *) token_b,
                                        token_b_len) == 0)
@@ -888,7 +816,7 @@ ngx_http_zstd_vary_has_two_tokens(ngx_http_request_t *r,
                     *has_b = 1;
                 }
 
-                if (*has_a && *has_b) {
+                if (*has_a && (has_b == NULL || *has_b)) {
                     return;
                 }
 
@@ -901,6 +829,19 @@ ngx_http_zstd_vary_has_two_tokens(ngx_http_request_t *r,
 }
 
 
+static ngx_inline ngx_uint_t
+ngx_http_zstd_vary_has_token(ngx_http_request_t *r, const char *token,
+    size_t token_len)
+{
+    ngx_uint_t  found;
+
+    ngx_http_zstd_vary_find_tokens(r, token, token_len, NULL, 0,
+                                   &found, NULL);
+
+    return found;
+}
+
+
 /*
  * Add the two request-header dimensions that can select a dcz response.
  * The static content handler and the response filter can both reach this
@@ -909,7 +850,7 @@ ngx_http_zstd_vary_has_two_tokens(ngx_http_request_t *r,
  * duplicate-free.
  *
  * The two tokens are looked up together in a single header-list walk
- * (ngx_http_zstd_vary_has_two_tokens()) rather than as two independent
+ * (ngx_http_zstd_vary_find_tokens()) rather than as two independent
  * calls to ngx_http_zstd_vary_has_token() -- the two lookups are always
  * wanted together here, so paying for the walk and the per-line
  * comma-token scan twice was redundant.
@@ -919,7 +860,7 @@ ngx_http_zstd_vary_dcz(ngx_http_request_t *r)
 {
     ngx_uint_t  has_available_dictionary, has_sec_fetch_site;
 
-    ngx_http_zstd_vary_has_two_tokens(
+    ngx_http_zstd_vary_find_tokens(
         r, "Available-Dictionary", sizeof("Available-Dictionary") - 1,
         "Sec-Fetch-Site", sizeof("Sec-Fetch-Site") - 1,
         &has_available_dictionary, &has_sec_fetch_site);


### PR DESCRIPTION
## TL;DR

The code that checks whether a response already names cache-selection inputs had two copies of the same scanner. This keeps one scanner, so future fixes cannot drift between the one-name and two-name cases.

## What changed

- Route the single-token and paired-token Vary checks through `ngx_http_zstd_vary_find_tokens()`.
- Preserve the paired lookup's one-pass early exit and the existing single-token API.
- Ship the final runnable TODO nit as the terminal singleton sweep authorized by the mechanically recounted queue.

## Testing

- Rebuilt nginx 1.30.4 with `-Werror`.
- `ci/tests/unit/run.sh`: 1073 parser checks and 46 frame-probe checks passed.
- `ci/t/03-dcz.t`: all 179 assertions passed.
- Negative control: swapping the paired outputs makes TEST 48 fail on the exact duplicated/missing Vary token assertion; restoring the outputs returns the suite to green.

## Risk

Internal refactor only. Header parsing, output order, allocation behavior, and module configuration remain unchanged.
