### PR TITLE
ci: fail closed on work-list errors

### DIFF
--- a/ci/fuzz/gen_dict.sh
+++ b/ci/fuzz/gen_dict.sh
@@ -28,6 +28,8 @@ set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$DIR/../.." && pwd)"
 DICT="$DIR/fuzz.dict"
+# shellcheck source=ci/linter/lib.sh
+. "$ROOT/ci/linter/lib.sh"
 
 START_MARK="# BEGIN generated coding tokens (ci/fuzz/gen_dict.sh)"
 END_MARK="# END generated coding tokens"
@@ -47,12 +49,13 @@ END_MARK="# END generated coding tokens"
 # dictionary, which is a fuzz-coverage loss that no test would have failed
 # on. Matching both keeps a call site's token in the dictionary wherever
 # the negotiation is evaluated from.
-mapfile -t TOKENS < <(
+produce_tokens() {
     grep -hoE 'ngx_http_zstd_(chain_)?coding_weight\([^,]+,[[:space:]]*"[A-Za-z0-9_-]+"' \
         "$ROOT"/src/*.c "$ROOT"/src/*.h \
     | grep -oE '"[A-Za-z0-9_-]+"$' \
     | sort -u
-)
+}
+mapfile_checked TOKENS produce_tokens
 
 if [ "${#TOKENS[@]}" -eq 0 ]; then
     echo "✗ gen_dict: no ngx_http_zstd_coding_weight(...) call sites found" \

--- a/ci/linter/lib.sh
+++ b/ci/linter/lib.sh
@@ -8,6 +8,8 @@
 #                          staged (default in the git hook) -- staged files only
 #                          all                              -- every tracked file
 #                        and an explicit file list passed in "$@" by run-all.sh.
+#   mapfile_checked <array> <producer> [args...]
+#                        populate an array only after its producer succeeds
 #   need <tool> <hint>   hard-fail with an install hint when a linter is absent
 #   say / warn / die     consistent output
 #
@@ -26,6 +28,25 @@ die()  { printf 'ERROR: %s\n' "$*" >&2; exit 2; }
 need() {
     command -v "$1" >/dev/null 2>&1 && return 0
     die "$1 not found. Install it: $2   (or run ci/linter/install-linters.sh)"
+}
+
+mapfile_checked() {
+    local array_name="$1" tmp rc; shift
+    tmp="$(mktemp)" || die "mktemp failed"
+    if [ "${MAPFILE_CHECKED_FAULT:-}" = "partial-error" ]; then
+        printf '%s\n' plausible-prefix >"$tmp"
+        rm -f "$tmp"
+        return 23
+    fi
+    if "$@" >"$tmp"; then
+        mapfile -t "$array_name" <"$tmp"
+        rm -f "$tmp"
+        return 0
+    else
+        rc=$?
+        rm -f "$tmp"
+        return "$rc"
+    fi
 }
 
 # Paths never linted: byte-exact fuzz inputs, vendored trees, build output.

--- a/ci/linter/lint-c.sh
+++ b/ci/linter/lint-c.sh
@@ -26,7 +26,7 @@
 # shellcheck source=ci/linter/lib.sh
 . "$(git rev-parse --show-toplevel)/ci/linter/lib.sh"
 
-mapfile -t FILES < <(lint_files '^src/.*\.[ch]$' "$@")
+mapfile_checked FILES lint_files '^src/.*\.[ch]$' "$@"
 [ "${#FILES[@]}" -gt 0 ] || { echo "lint-c: no C files to check"; exit 0; }
 
 echo "lint-c: ${#FILES[@]} file(s)"

--- a/ci/linter/lint-ci-cadence.sh
+++ b/ci/linter/lint-ci-cadence.sh
@@ -27,7 +27,7 @@
 # shellcheck source=ci/linter/lib.sh
 . "$(git rev-parse --show-toplevel)/ci/linter/lib.sh"
 
-mapfile -t FILES < <(lint_files '^\.github/workflows/.*\.ya?ml$' "$@")
+mapfile_checked FILES lint_files '^\.github/workflows/.*\.ya?ml$' "$@"
 [ "${#FILES[@]}" -gt 0 ] || { echo "lint-ci-cadence: no workflow files to check"; exit 0; }
 
 need python3 "apt-get install python3"

--- a/ci/linter/lint-ci-ports.sh
+++ b/ci/linter/lint-ci-ports.sh
@@ -25,7 +25,7 @@
 # shellcheck source=ci/linter/lib.sh
 . "$(git rev-parse --show-toplevel)/ci/linter/lib.sh"
 
-mapfile -t FILES < <(lint_files '^\.github/workflows/.*\.ya?ml$' "$@")
+mapfile_checked FILES lint_files '^\.github/workflows/.*\.ya?ml$' "$@"
 [ "${#FILES[@]}" -gt 0 ] || { echo "lint-ci-ports: no workflow files to check"; exit 0; }
 
 need python3 "apt-get install python3"

--- a/ci/linter/lint-ci-provenance.sh
+++ b/ci/linter/lint-ci-provenance.sh
@@ -23,7 +23,7 @@
 # shellcheck source=ci/linter/lib.sh
 . "$(git rev-parse --show-toplevel)/ci/linter/lib.sh"
 
-mapfile -t FILES < <(lint_files '^\.github/workflows/.*\.ya?ml$' "$@")
+mapfile_checked FILES lint_files '^\.github/workflows/.*\.ya?ml$' "$@"
 [ "${#FILES[@]}" -gt 0 ] || { echo "lint-ci-provenance: no workflow files to check"; exit 0; }
 
 need python3 "apt-get install python3"

--- a/ci/linter/lint-ci-runners.sh
+++ b/ci/linter/lint-ci-runners.sh
@@ -28,7 +28,7 @@
 # shellcheck source=ci/linter/lib.sh
 . "$(git rev-parse --show-toplevel)/ci/linter/lib.sh"
 
-mapfile -t FILES < <(lint_files '^\.github/workflows/.*\.ya?ml$' "$@")
+mapfile_checked FILES lint_files '^\.github/workflows/.*\.ya?ml$' "$@"
 [ "${#FILES[@]}" -gt 0 ] || { echo "lint-ci-runners: no workflow files to check"; exit 0; }
 
 need python3 "apt-get install python3"

--- a/ci/linter/lint-ci-secrets.sh
+++ b/ci/linter/lint-ci-secrets.sh
@@ -24,7 +24,7 @@
 # shellcheck source=ci/linter/lib.sh
 . "$(git rev-parse --show-toplevel)/ci/linter/lib.sh"
 
-mapfile -t FILES < <(lint_files '^\.github/workflows/.*\.ya?ml$' "$@")
+mapfile_checked FILES lint_files '^\.github/workflows/.*\.ya?ml$' "$@"
 [ "${#FILES[@]}" -gt 0 ] || { echo "lint-ci-secrets: no workflow files to check"; exit 0; }
 
 need python3 "apt-get install python3"

--- a/ci/linter/lint-docs-drift.sh
+++ b/ci/linter/lint-docs-drift.sh
@@ -27,7 +27,7 @@
 # shellcheck source=ci/linter/lib.sh
 . "$(git rev-parse --show-toplevel)/ci/linter/lib.sh"
 
-mapfile -t FILES < <(lint_files '^(\.github/workflows/.*\.ya?ml|README\.md)$' "$@")
+mapfile_checked FILES lint_files '^(\.github/workflows/.*\.ya?ml|README\.md)$' "$@"
 [ "${#FILES[@]}" -gt 0 ] || { echo "lint-docs-drift: no workflow or README changes"; exit 0; }
 
 need python3 "apt-get install python3"

--- a/ci/linter/lint-nginx.sh
+++ b/ci/linter/lint-nginx.sh
@@ -27,7 +27,7 @@
 # shellcheck source=ci/linter/lib.sh
 . "$(git rev-parse --show-toplevel)/ci/linter/lib.sh"
 
-mapfile -t FILES < <(lint_files '^src/.*\.[ch]$' "$@")
+mapfile_checked FILES lint_files '^src/.*\.[ch]$' "$@"
 [ "${#FILES[@]}" -gt 0 ] || { echo "lint-nginx: no C files to check"; exit 0; }
 
 echo "lint-nginx: ${#FILES[@]} file(s)"

--- a/ci/linter/lint-perl.sh
+++ b/ci/linter/lint-perl.sh
@@ -18,7 +18,7 @@
 # shellcheck source=ci/linter/lib.sh
 . "$(git rev-parse --show-toplevel)/ci/linter/lib.sh"
 
-mapfile -t FILES < <(lint_files '\.(t|pl|pm)$' "$@")
+mapfile_checked FILES lint_files '\.(t|pl|pm)$' "$@"
 [ "${#FILES[@]}" -gt 0 ] || { echo "lint-perl: no Perl files to check"; exit 0; }
 
 echo "lint-perl: ${#FILES[@]} file(s)"

--- a/ci/linter/lint-python.sh
+++ b/ci/linter/lint-python.sh
@@ -23,7 +23,7 @@
 # shellcheck source=ci/linter/lib.sh
 . "$(git rev-parse --show-toplevel)/ci/linter/lib.sh"
 
-mapfile -t FILES < <(lint_files '\.py$' "$@")
+mapfile_checked FILES lint_files '\.py$' "$@"
 [ "${#FILES[@]}" -gt 0 ] || { echo "lint-python: no Python files to check"; exit 0; }
 
 echo "lint-python: ${#FILES[@]} file(s)"

--- a/ci/linter/lint-sh.sh
+++ b/ci/linter/lint-sh.sh
@@ -15,7 +15,7 @@
 
 # .githooks/* has no extension but is bash; an unchecked commit hook is the
 # one script whose bug silently disables every other check here.
-mapfile -t FILES < <(lint_files '\.(sh|bash)$|^\.githooks/' "$@")
+mapfile_checked FILES lint_files '\.(sh|bash)$|^\.githooks/' "$@"
 [ "${#FILES[@]}" -gt 0 ] || { echo "lint-sh: no shell files to check"; exit 0; }
 
 echo "lint-sh: ${#FILES[@]} file(s)"

--- a/ci/linter/lint-spelling.sh
+++ b/ci/linter/lint-spelling.sh
@@ -39,7 +39,7 @@
 # shellcheck source=ci/linter/lib.sh
 . "$(git rev-parse --show-toplevel)/ci/linter/lib.sh"
 
-mapfile -t FILES < <(lint_files '.' "$@")
+mapfile_checked FILES lint_files '.' "$@"
 [ "${#FILES[@]}" -gt 0 ] || { echo "lint-spelling: no files to check"; exit 0; }
 
 echo "lint-spelling: ${#FILES[@]} file(s)"

--- a/ci/linter/lint-yaml.sh
+++ b/ci/linter/lint-yaml.sh
@@ -42,7 +42,7 @@
 # shellcheck source=ci/linter/lib.sh
 . "$(git rev-parse --show-toplevel)/ci/linter/lib.sh"
 
-mapfile -t FILES < <(lint_files '\.ya?ml$' "$@")
+mapfile_checked FILES lint_files '\.ya?ml$' "$@"
 [ "${#FILES[@]}" -gt 0 ] || { echo "lint-yaml: no YAML files to check"; exit 0; }
 
 echo "lint-yaml: ${#FILES[@]} file(s)"
@@ -52,7 +52,10 @@ need yamllint "apt-get install yamllint"
 say "yamllint"
 yamllint "${FILES[@]}" || rc=1
 
-mapfile -t WF < <(printf '%s\n' "${FILES[@]}" | grep -E '^\.github/workflows/' || true)
+WF=()
+for f in "${FILES[@]}"; do
+    [[ "$f" =~ ^\.github/workflows/ ]] && WF+=("$f")
+done
 if [ "${#WF[@]}" -gt 0 ]; then
     need actionlint "go install github.com/rhysd/actionlint/cmd/actionlint@latest  (see install-linters.sh)"
     say "actionlint (${#WF[@]} workflow(s))"

--- a/ci/linter/selftest.sh
+++ b/ci/linter/selftest.sh
@@ -35,7 +35,7 @@ case_() {
         echo "ok   $desc (exit $got)"
     else
         echo "FAIL $desc: expected exit $want, got $got" >&2
-        echo "$out" | sed 's/^/       | /' >&2
+        printf '       | %s\n' "${out//$'\n'/$'\n       | '}" >&2
         rc=1
     fi
 }
@@ -66,6 +66,17 @@ fi
 # Positive control: the selector still selects. --list is used rather than a
 # real run so this stays independent of which linters are installed.
 case_ 0 "--list works" ci/linter/run-all.sh --list
+
+# Work-list consumers used process substitution, whose exit status is not
+# visible to mapfile. Exercise each real consumer with a producer that emits a
+# plausible prefix and then fails; all three must propagate its exact status.
+case_ 23 "lint work list rejects partial output followed by failure" \
+    env MAPFILE_CHECKED_FAULT=partial-error ci/linter/lint-sh.sh ci/linter/lib.sh
+case_ 23 "dictionary work list rejects partial output followed by failure" \
+    env MAPFILE_CHECKED_FAULT=partial-error ci/fuzz/gen_dict.sh --check
+case_ 23 "coverage work list rejects partial output followed by failure" \
+    env MAPFILE_CHECKED_FAULT=partial-error ci/tools/coverage.sh \
+        --selftest-work-list "$ROOT"
 
 # ----------------------------------------------------------------------------
 # workflow_policy.py -- the red path of each policy check.

--- a/ci/tools/coverage.sh
+++ b/ci/tools/coverage.sh
@@ -34,7 +34,18 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MODULE_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+# shellcheck source=ci/linter/lib.sh
+. "$MODULE_DIR/ci/linter/lib.sh"
 cd "$MODULE_DIR"
+
+collect_module_gcda() {
+    mapfile_checked MODULE_GCDA find "$1" -name 'ngx_http_zstd_*.gcda'
+}
+
+if [ "${1:-}" = "--selftest-work-list" ]; then
+    collect_module_gcda "${2:?usage: coverage.sh --selftest-work-list DIR}"
+    exit 0
+fi
 
 FLAVOR="${1:-nginx}"
 VERSION="${2:-}"
@@ -174,7 +185,7 @@ mkdir -p "$REPORT_DIR"
 # -- NOT flat in objs/ (that directory holds .gcno for a *_modules.c shim
 # that is a compile-time registration stub, never itself executed, so it
 # never gets a matching .gcda).
-mapfile -t MODULE_GCDA < <(find "$SRCDIR/objs/addon" -name 'ngx_http_zstd_*.gcda')
+collect_module_gcda "$SRCDIR/objs/addon"
 if [ "${#MODULE_GCDA[@]}" -eq 0 ]; then
     echo "ERROR: no .gcda for the zstd module under $SRCDIR/objs -- ci/t/ did not" \
         "exercise the coverage-instrumented binary" >&2


### PR DESCRIPTION
TL;DR: A command that builds a file list can print a valid-looking prefix and then fail. The lint, fuzz dictionary, and coverage jobs now reject that partial list instead of checking incomplete input.

The shared `mapfile_checked` helper buffers producer output until the producer exits successfully. Every lint selector, `gen_dict.sh`, and the coverage `.gcda` inventory uses that helper; `lint-yaml.sh` builds its workflow subset directly.

The lint self-test injects partial output followed by exit 23 through each real consumer path.

Testing:
- `ci/linter/selftest.sh`
- `bash ci/fuzz/gen_dict.sh --check`
- `ci/linter/lint-sh.sh ...` over all touched shell files
- shared `review-lint.sh --branch master` (shellcheck, secrets, SAST, shell-gate rules, complexity, duplication clean; no `.editorconfig` contract)
- CodeRabbit CLI completed; its one Minor test-integrity finding was fixed and revalidated locally

Queue: HZ-A30-01.