### PR TITLE
ci: check LSan log-list errors

### DIFF
--- a/ci/tools/lsan_log_verdict.sh
+++ b/ci/tools/lsan_log_verdict.sh
@@ -16,6 +16,8 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=ci/linter/lib.sh
+. "$SCRIPT_DIR/../linter/lib.sh"
 # shellcheck source=ci/tools/lsan_positive_control.sh
 . "$SCRIPT_DIR/lsan_positive_control.sh"
 
@@ -78,7 +80,10 @@ lsan_check_log_glob() {
     local pattern="$1" control_rc
     local -a logs=()
 
-    mapfile -t logs < <(compgen -G "$pattern" | sort)
+    # The quoted program executes in the child.
+    # shellcheck disable=SC2016
+    mapfile_checked logs env LC_ALL=C bash -c \
+        'compgen -G "$1" || [ $? -eq 1 ]' _ "$pattern" || return $?
     if lsan_positive_control; then
         control_rc=0
     else

--- a/ci/tools/test_lsan_positive_control_unit.sh
+++ b/ci/tools/test_lsan_positive_control_unit.sh
@@ -84,6 +84,22 @@ run_case 0 "clean marker with passing canary passes" 0 "$WORK/clean.log"
 run_case 2 "every process log must contain the exit-hook marker" 0 \
     "$WORK/clean.log" "$WORK/preflight-without-check.log"
 
+MAPFILE_CHECKED_FAULT=partial-error
+export MAPFILE_CHECKED_FAULT
+if lsan_check_log_glob "$WORK/*.log" >/dev/null 2>&1
+then
+    list_rc=0
+else
+    list_rc=$?
+fi
+unset MAPFILE_CHECKED_FAULT
+if [ "$list_rc" -eq 23 ]; then
+    echo "OK: partial log-list producer failure is propagated (rc=23)"
+else
+    echo "FAIL: partial log-list producer failure -- rc=$list_rc, want 23" >&2
+    fail=1
+fi
+
 # Negative control: the old gate failed solely on LLVM's heuristic warning,
 # even when the same log proved the real leak check started and the deliberate
 # leak control passed. Reproduce that exact false-red decision.


### PR DESCRIPTION
TL;DR: The leak checker could inspect only the first few sanitizer logs if its file-list command failed midway. It now rejects that incomplete list before running the leak canary or reporting a clean result.

`lsan_check_log_glob` uses the checked work-list helper merged in #264 and explicitly returns its status, including when a caller invokes the function inside `if` and Bash suppresses `errexit`. No-match globbing still reaches the existing indeterminate verdict.

Testing:
- `bash ci/tools/test_lsan_positive_control_unit.sh`
- `ci/linter/lint-sh.sh ci/tools/lsan_log_verdict.sh ci/tools/test_lsan_positive_control_unit.sh`
- shared `review-lint.sh --branch master` (shellcheck, secrets, SAST, shell-gate rules, complexity, duplication clean; no `.editorconfig` contract)
- CodeRabbit CLI completed with zero findings

Queue: HZ-A30-second-pass terminal finding.