### PR TITLE
ci: check docs work-list errors

### DIFF
--- a/ci/linter/selftest.sh
+++ b/ci/linter/selftest.sh
@@ -77,6 +77,12 @@ case_ 23 "dictionary work list rejects partial output followed by failure" \
 case_ 23 "coverage work list rejects partial output followed by failure" \
     env MAPFILE_CHECKED_FAULT=partial-error ci/tools/coverage.sh \
         --selftest-work-list "$ROOT"
+case_ 23 "docs directive list rejects partial output followed by failure" \
+    env MAPFILE_CHECKED_FAULT=partial-error ci/tools/test_docs_ci_drift.sh \
+        --selftest-directive-list
+case_ 23 "docs workflow list rejects partial output followed by failure" \
+    env MAPFILE_CHECKED_FAULT=partial-error ci/tools/test_docs_ci_drift.sh \
+        --selftest-workflow-list
 
 # ----------------------------------------------------------------------------
 # workflow_policy.py -- the red path of each policy check.

--- a/ci/tools/test_docs_ci_drift.sh
+++ b/ci/tools/test_docs_ci_drift.sh
@@ -30,6 +30,34 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # below would then report every workflow undocumented.
 MODULE_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 cd "$MODULE_DIR" || exit 1
+# shellcheck source=ci/linter/lib.sh
+. "$MODULE_DIR/ci/linter/lib.sh"
+
+collect_directives() {
+    mapfile_checked DIRECTIVES sed -n \
+        's/^### \(zstd[_a-z]*\)$/\1/p' README.md
+}
+
+produce_readme_workflows() {
+    grep -oE 'workflows/[A-Za-z0-9_-]+\.yml' README.md \
+        | sed 's#workflows/##' \
+        | sort -u
+}
+
+collect_readme_workflows() {
+    mapfile_checked README_WORKFLOWS produce_readme_workflows
+}
+
+case "${1:-}" in
+    --selftest-directive-list)
+        collect_directives || exit $?
+        exit 0
+        ;;
+    --selftest-workflow-list)
+        collect_readme_workflows || exit $?
+        exit 0
+        ;;
+esac
 
 fail=0
 toc="$(sed -n '/^# Table of Contents$/,/^# Status$/p' README.md)"
@@ -37,12 +65,13 @@ local_suites="$(sed -n '/^Run the suites locally:/,/^# Unit tests/p' README.md)"
 deep_suite_step="$(sed -n '/name: Run ci\/t\//,/^  fuzz:/p' .github/workflows/ci-deep.yml)"
 
 # Every public directive heading must be reachable from the README index.
-while IFS= read -r directive; do
+collect_directives || exit $?
+for directive in "${DIRECTIVES[@]}"; do
     if ! grep -Fq -- "[$directive](#$directive)" <<<"$toc"; then
         echo "FAIL: README directive section $directive is missing from the table of contents"
         fail=1
     fi
-done < <(sed -n 's/^### \(zstd[_a-z]*\)$/\1/p' README.md)
+done
 
 # Commands advertised as the local/deep full suite must include every Perl suite.
 for suite in ci/t/*.t; do
@@ -68,12 +97,13 @@ for wf in .github/workflows/*.yml; do
 done
 
 # --- every workflow filename README.md references actually exists ---
-while IFS= read -r name; do
+collect_readme_workflows || exit $?
+for name in "${README_WORKFLOWS[@]}"; do
     [ -f ".github/workflows/$name" ] || {
         echo "FAIL: README.md references .github/workflows/$name, which does not exist (stale/dead link or badge)"
         fail=1
     }
-done < <(grep -oE 'workflows/[A-Za-z0-9_-]+\.yml' README.md | sed 's#workflows/##' | sort -u)
+done
 
 # --- SECURITY.md must not link the removed AGENTS.md ---
 if [ -f SECURITY.md ] && grep -q 'AGENTS\.md' SECURITY.md; then


### PR DESCRIPTION
TL;DR: The documentation drift test could check only part of its directive or workflow list if a producer failed after printing some entries. Both lists are now complete before the test starts comparing them.

`test_docs_ci_drift.sh` uses the shared checked work-list helper for README directive headings and referenced workflow names. Dedicated self-test modes let the lint gate inject a partial list followed by exit 23 through each real collector.

Testing:
- `bash ci/tools/test_docs_ci_drift.sh`
- `ci/linter/selftest.sh`
- full `ci/linter/lint-sh.sh` over 61 shell files
- shared `review-lint.sh --branch master` (shellcheck, secrets, SAST, shell-gate rules, complexity, duplication clean; no `.editorconfig` contract)
- CodeRabbit CLI completed with zero findings

Queue: HZ-A30-second-pass final work-list variants.