### PR TITLE
ci: share nginx tarball verification

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -219,6 +219,9 @@ jobs:
       - name: ci-build.sh clean-root + provenance regressions (F2/F3)
         run: bash "$GITHUB_WORKSPACE"/ci/tools/test_ci_build_provenance.sh
 
+      - name: nginx tarball PGP verifier controls
+        run: bash "$GITHUB_WORKSPACE"/ci/tools/test_verify_nginx_tarball.sh
+
       - name: Shell script linting (shellcheck)
         run: |
           # Gate on error-severity findings (real bugs); style/info noise does
@@ -610,17 +613,7 @@ jobs:
         env:
           MATRIX_DIR: ${{ matrix.dir }}
           MATRIX_URL: ${{ matrix.url }}
-        run: |
-          set -euo pipefail
-          wget -q -O "$MATRIX_DIR.tar.gz.asc" "$MATRIX_URL.asc"
-          gnupghome="$(mktemp -d)"
-          export GNUPGHOME="$gnupghome"
-          chmod 700 "$gnupghome"
-          for keyfile in ci/tools/keys/*.key; do
-            gpg --quiet --import "$keyfile" 2>/dev/null
-          done
-          gpg --quiet --verify "$MATRIX_DIR.tar.gz.asc" "$MATRIX_DIR.tar.gz"
-          rm -rf "$gnupghome"
+        run: ci/tools/verify-nginx-tarball.sh "$MATRIX_DIR.tar.gz" "$MATRIX_URL.asc"
 
       - name: Configure (full debug build)
         env:
@@ -760,18 +753,7 @@ jobs:
         run: wget -q "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz"
 
       - name: Verify nginx tarball PGP signature
-        run: |
-          set -euo pipefail
-          wget -q "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz.asc" \
-            -O "nginx-${NGINX_VERSION}.tar.gz.asc"
-          gnupghome="$(mktemp -d)"
-          export GNUPGHOME="$gnupghome"
-          chmod 700 "$gnupghome"
-          for keyfile in ci/tools/keys/*.key; do
-            gpg --quiet --import "$keyfile" 2>/dev/null
-          done
-          gpg --quiet --verify "nginx-${NGINX_VERSION}.tar.gz.asc" "nginx-${NGINX_VERSION}.tar.gz"
-          rm -rf "$gnupghome"
+        run: ci/tools/verify-nginx-tarball.sh "nginx-${NGINX_VERSION}.tar.gz"
 
       - name: Configure arm64 build
         run: |
@@ -1006,18 +988,7 @@ jobs:
         run: wget -q "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz"
 
       - name: Verify nginx tarball PGP signature
-        run: |
-          set -euo pipefail
-          wget -q "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz.asc" \
-            -O "nginx-${NGINX_VERSION}.tar.gz.asc"
-          gnupghome="$(mktemp -d)"
-          export GNUPGHOME="$gnupghome"
-          chmod 700 "$gnupghome"
-          for keyfile in ci/tools/keys/*.key; do
-            gpg --quiet --import "$keyfile" 2>/dev/null
-          done
-          gpg --quiet --verify "nginx-${NGINX_VERSION}.tar.gz.asc" "nginx-${NGINX_VERSION}.tar.gz"
-          rm -rf "$gnupghome"
+        run: ci/tools/verify-nginx-tarball.sh "nginx-${NGINX_VERSION}.tar.gz"
 
       - name: Configure & build nginx with module against libzstd 1.4.x
         run: |
@@ -1164,18 +1135,7 @@ jobs:
         run: wget -q "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz"
 
       - name: Verify nginx tarball PGP signature
-        run: |
-          set -euo pipefail
-          wget -q "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz.asc" \
-            -O "nginx-${NGINX_VERSION}.tar.gz.asc"
-          gnupghome="$(mktemp -d)"
-          export GNUPGHOME="$gnupghome"
-          chmod 700 "$gnupghome"
-          for keyfile in ci/tools/keys/*.key; do
-            gpg --quiet --import "$keyfile" 2>/dev/null
-          done
-          gpg --quiet --verify "nginx-${NGINX_VERSION}.tar.gz.asc" "nginx-${NGINX_VERSION}.tar.gz"
-          rm -rf "$gnupghome"
+        run: ci/tools/verify-nginx-tarball.sh "nginx-${NGINX_VERSION}.tar.gz"
 
       - name: Configure with zstd + stubs as dynamic modules, build
         # Full build (not just `make modules`): the vary-suppression
@@ -1409,18 +1369,7 @@ jobs:
         run: wget -q "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz"
 
       - name: Verify nginx tarball PGP signature
-        run: |
-          set -euo pipefail
-          wget -q "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz.asc" \
-            -O "nginx-${NGINX_VERSION}.tar.gz.asc"
-          gnupghome="$(mktemp -d)"
-          export GNUPGHOME="$gnupghome"
-          chmod 700 "$gnupghome"
-          for keyfile in ci/tools/keys/*.key; do
-            gpg --quiet --import "$keyfile" 2>/dev/null
-          done
-          gpg --quiet --verify "nginx-${NGINX_VERSION}.tar.gz.asc" "nginx-${NGINX_VERSION}.tar.gz"
-          rm -rf "$gnupghome"
+        run: ci/tools/verify-nginx-tarball.sh "nginx-${NGINX_VERSION}.tar.gz"
 
       - name: Clone compression_vary module at the pin
         run: |
@@ -1570,18 +1519,7 @@ jobs:
         run: wget -q "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz"
 
       - name: Verify nginx tarball PGP signature
-        run: |
-          set -euo pipefail
-          wget -q "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz.asc" \
-            -O "nginx-${NGINX_VERSION}.tar.gz.asc"
-          gnupghome="$(mktemp -d)"
-          export GNUPGHOME="$gnupghome"
-          chmod 700 "$gnupghome"
-          for keyfile in ci/tools/keys/*.key; do
-            gpg --quiet --import "$keyfile" 2>/dev/null
-          done
-          gpg --quiet --verify "nginx-${NGINX_VERSION}.tar.gz.asc" "nginx-${NGINX_VERSION}.tar.gz"
-          rm -rf "$gnupghome"
+        run: ci/tools/verify-nginx-tarball.sh "nginx-${NGINX_VERSION}.tar.gz"
 
       - name: Configure & build nginx with ASAN + UBSAN
         env:
@@ -2323,18 +2261,7 @@ jobs:
         run: wget -q "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz"
 
       - name: Verify nginx tarball PGP signature
-        run: |
-          set -euo pipefail
-          wget -q "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz.asc" \
-            -O "nginx-${NGINX_VERSION}.tar.gz.asc"
-          gnupghome="$(mktemp -d)"
-          export GNUPGHOME="$gnupghome"
-          chmod 700 "$gnupghome"
-          for keyfile in ci/tools/keys/*.key; do
-            gpg --quiet --import "$keyfile" 2>/dev/null
-          done
-          gpg --quiet --verify "nginx-${NGINX_VERSION}.tar.gz.asc" "nginx-${NGINX_VERSION}.tar.gz"
-          rm -rf "$gnupghome"
+        run: ci/tools/verify-nginx-tarball.sh "nginx-${NGINX_VERSION}.tar.gz"
 
       - name: Configure & build nginx with --coverage instrumentation
         env:

--- a/ci/linter/fixtures/policy/provenance-verify-helper-after-extract/.github/workflows/ci.yml
+++ b/ci/linter/fixtures/policy/provenance-verify-helper-after-extract/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+---
+name: ci
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: wget -q https://nginx.org/download/nginx-1.2.3.tar.gz
+      - run: |
+          tar -xzf nginx-1.2.3.tar.gz
+          ci/tools/verify-nginx-tarball.sh nginx-1.2.3.tar.gz

--- a/ci/linter/fixtures/policy/provenance-verify-helper-after-extract/README.md
+++ b/ci/linter/fixtures/policy/provenance-verify-helper-after-extract/README.md
@@ -1,0 +1,7 @@
+# fixture: provenance-verify-helper-after-extract
+
+The same-step ordering bypass: the job downloads and extracts an nginx archive,
+then invokes the shared verification helper after extraction. Merely naming the
+reviewed helper must not anchor commands that already consumed untrusted bytes.
+
+Workflow: `.github/workflows/ci.yml`.

--- a/ci/linter/selftest.sh
+++ b/ci/linter/selftest.sh
@@ -234,6 +234,9 @@ policy_ 0 secrets-typed-ok secrets
 # not equally consistent with "any download in a job is flagged".
 policy_ 1 provenance-unverified-extract provenance
 policy_ 0 provenance-verified-ok provenance
+# A reviewed verification helper named later in the SAME run block cannot
+# retroactively protect extraction that occurred earlier in that block.
+policy_ 1 provenance-verify-helper-after-extract provenance
 # The trap this check exists to close: the download step is gated
 # `cache-hit != 'true'`, so a cache HIT skips it entirely and a checker that
 # only looks for a download step present would read the job as having

--- a/ci/linter/workflow_policy.py
+++ b/ci/linter/workflow_policy.py
@@ -645,7 +645,8 @@ EXTRACT_OR_EXEC_RE = re.compile(
 #   - a checksum COMPARISON -- `sha256sum -c`, or a digest captured into a
 #     variable that is then tested against a pinned `*_SHA256`
 #   - delegating to a helper this repo already verified for the SAME
-#     property (ci-build.sh, fetch-verified-nginx.sh)
+#     property (ci-build.sh, fetch-verified-nginx.sh,
+#     verify-nginx-tarball.sh)
 #
 # A bare `sha256sum tool.tgz` PRINTS a digest and compares nothing, and a
 # lone `FOO_SHA256:` env declaration is a pinned value nothing tests. Both
@@ -667,7 +668,7 @@ TRUST_ANCHOR_RE = re.compile(
     r"|(?:\bif\b|\btest\b|\[|!=|==)[^\n]*_SHA256\b"
     r"|_SHA256\b[^\n]*(?:!=|==|\|\||&&)"
     # helpers whose own verification this repo already reviewed
-    r"|ci-build\.sh|fetch-verified-nginx\.sh"
+    r"|ci-build\.sh|fetch-verified-nginx\.sh|verify-nginx-tarball\.sh"
 )
 
 # A step that only DOWNLOADS and does not itself extract or execute is not a
@@ -723,21 +724,25 @@ def check_provenance() -> int:
                 continue
             anchored = False
             for i, run in enumerate(runs):
-                if TRUST_ANCHOR_RE.search(run):
-                    anchored = True
                 extract = EXTRACT_OR_EXEC_RE.search(run)
-                if extract is not None:
-                    # Same-step trust anchor still counts: a script/step
-                    # written as one shell block can verify then extract in
-                    # sequence, same as the ordering check's same-step case.
-                    if anchored or TRUST_ANCHOR_RE.search(run[: extract.start()]):
-                        continue
+                # Same-step trust anchors count only before extraction, in
+                # the same order the shell consumes the commands.
+                if (
+                    extract is not None
+                    and not anchored
+                    and not TRUST_ANCHOR_RE.search(run[: extract.start()])
+                ):
                     errors.append(
                         f"{path.name}:{job} step {i + 1} extracts or executes "
                         "a downloaded artifact with no gpg/sha256 trust-anchor "
                         "assertion earlier in the job -- verify before "
                         "extraction/execution, cache-hit path included"
                     )
+                # A same-step anchor only protects later commands. Recording
+                # it before the extraction check lets `tar ...; verify ...`
+                # satisfy the gate after untrusted bytes already executed.
+                if TRUST_ANCHOR_RE.search(run):
+                    anchored = True
     return report(
         "lint-ci-provenance",
         errors,

--- a/ci/tools/fetch-verified-nginx.sh
+++ b/ci/tools/fetch-verified-nginx.sh
@@ -20,32 +20,18 @@ set -euo pipefail
 
 VERSION="${1:?usage: fetch-verified-nginx.sh <version>}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-KEYRING_DIR="$SCRIPT_DIR/keys"
 
 DIR="nginx-${VERSION}"
 TARBALL="${DIR}.tar.gz"
 URL="https://nginx.org/download/${TARBALL}"
 
 if [ ! -f "$TARBALL" ]; then
-    wget -q -O "$TARBALL" "$URL"
+	wget -q -O "$TARBALL" "$URL"
 fi
-wget -q -O "${TARBALL}.asc" "${URL}.asc"
-
-gnupghome="$(mktemp -d)"
-export GNUPGHOME="$gnupghome"
-chmod 700 "$gnupghome"
-for keyfile in "$KEYRING_DIR"/*.key; do
-    gpg --quiet --import "$keyfile" 2>/dev/null
-done
-
-if gpg --quiet --verify "${TARBALL}.asc" "$TARBALL"; then
-    echo "✓ PGP signature verified for ${TARBALL}"
-else
-    echo "✗ PGP signature verification FAILED for ${TARBALL}" >&2
-    rm -rf "$gnupghome" "$TARBALL" "${TARBALL}.asc"
-    exit 1
+if ! "$SCRIPT_DIR/verify-nginx-tarball.sh" "$TARBALL" "${URL}.asc"; then
+	echo "PGP signature verification failed for ${TARBALL}" >&2
+	rm -f "$TARBALL" "${TARBALL}.asc"
+	exit 1
 fi
-rm -rf "$gnupghome"
-unset GNUPGHOME
 
 tar -xzf "$TARBALL"

--- a/ci/tools/test_verify_nginx_tarball.sh
+++ b/ci/tools/test_verify_nginx_tarball.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Offline positive and negative controls for verify-nginx-tarball.sh.
+# Usage: ci/tools/test_verify_nginx_tarball.sh
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+verifier="$script_dir/verify-nginx-tarball.sh"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/bin"
+
+cat >"$work/bin/wget" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+output=""
+url=""
+for arg in "$@"; do
+    case "$arg" in
+        --output-document=*) output="${arg#*=}" ;;
+        http://*|https://*) url="$arg" ;;
+    esac
+done
+printf '%s\n' "$url" >"${FAKE_WGET_LOG:?}"
+printf 'detached signature\n' >"$output"
+EOF
+
+cat >"$work/bin/gpg" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\t%s\n' "${GNUPGHOME:?}" "$*" >>"${FAKE_GPG_LOG:?}"
+if [[ " $* " == *" --verify "* ]] && [ "${FAKE_GPG_VERIFY:-ok}" = "fail" ]; then
+    exit 1
+fi
+EOF
+chmod +x "$work/bin/wget" "$work/bin/gpg"
+
+run_verifier() {
+	PATH="$work/bin:$PATH" \
+		FAKE_WGET_LOG="$work/wget.log" \
+		FAKE_GPG_LOG="$work/gpg.log" \
+		"$verifier" "$@"
+}
+
+tarball="$work/nginx-1.2.3.tar.gz"
+printf 'tarball\n' >"$tarball"
+run_verifier "$tarball"
+grep -qx 'https://nginx.org/download/nginx-1.2.3.tar.gz.asc' "$work/wget.log"
+grep -q -- '--verify' "$work/gpg.log"
+test "$(grep -c -- '--import' "$work/gpg.log")" -eq \
+	"$(find "$script_dir/keys" -maxdepth 1 -name '*.key' -type f | wc -l)"
+gnupghome="$(head -1 "$work/gpg.log" | cut -f1)"
+test ! -e "$gnupghome"
+
+if FAKE_GPG_VERIFY=fail run_verifier "$tarball" \
+	'https://example.invalid/nginx.sig' >/dev/null 2>&1; then
+	echo 'verifier accepted a rejected signature' >&2
+	exit 1
+fi
+grep -qx 'https://example.invalid/nginx.sig' "$work/wget.log"
+gnupghome="$(tail -1 "$work/gpg.log" | cut -f1)"
+test ! -e "$gnupghome"
+
+if run_verifier "$work/missing.tar.gz" >/dev/null 2>&1; then
+	echo 'verifier accepted a missing tarball' >&2
+	exit 1
+fi
+"$verifier" --help | grep -q '^Usage:'
+
+workflow="${WORKFLOW_FILE:-$script_dir/../../.github/workflows/build-test.yml}"
+python3 - "$workflow" <<'PY'
+import re
+import sys
+
+import yaml
+
+with open(sys.argv[1], encoding="utf-8") as stream:
+    workflow = yaml.safe_load(stream)
+
+verify_steps = []
+inline = []
+for job_name, job in workflow.get("jobs", {}).items():
+    for step in job.get("steps", []):
+        if not isinstance(step, dict):
+            continue
+        run = step.get("run", "")
+        name = step.get("name", "")
+        if name == "Verify nginx tarball PGP signature":
+            verify_steps.append((job_name, run))
+        if "nginx" in run and re.search(r"gpg\b[\s\S]*--\S*verify", run):
+            inline.append(job_name)
+
+if not verify_steps:
+    raise SystemExit("no nginx tarball verification steps found")
+wrong = [job for job, run in verify_steps if "verify-nginx-tarball.sh" not in run]
+if wrong:
+    raise SystemExit(f"nginx verification bypasses shared helper in: {', '.join(wrong)}")
+if inline:
+    raise SystemExit(f"inline nginx PGP verification reintroduced in: {', '.join(inline)}")
+PY
+
+echo 'verify-nginx-tarball controls passed'

--- a/ci/tools/verify-nginx-tarball.sh
+++ b/ci/tools/verify-nginx-tarball.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Verify an existing nginx source tarball against nginx.org's detached PGP
+# signature and the vendored signer keys in ci/tools/keys.
+#
+# Usage: verify-nginx-tarball.sh <tarball> [signature-url]
+# Inputs: an existing tarball and, optionally, its detached-signature URL.
+# Output: a verified <tarball>.asc file beside the tarball.
+# Side effects: downloads only the signature and uses a temporary GNUPGHOME.
+# Dry-run: none; the offline test script replaces wget and gpg with fakes.
+# Limits: wget uses three attempts and a 20-second network timeout.
+# Extend here when nginx changes its signature transport or trusted key set.
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage: verify-nginx-tarball.sh <tarball> [signature-url]
+
+Verify an existing nginx source tarball with the vendored nginx signing keys.
+The default signature URL is https://nginx.org/download/<tarball>.asc.
+EOF
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+	usage
+	exit 0
+fi
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+	usage >&2
+	exit 2
+fi
+
+tarball="$1"
+if [ ! -f "$tarball" ]; then
+	echo "missing nginx tarball: $tarball" >&2
+	exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+keyring_dir="$script_dir/keys"
+signature="${tarball}.asc"
+signature_url="${2:-https://nginx.org/download/$(basename "$signature")}"
+
+keys=("$keyring_dir"/*.key)
+if [ ! -e "${keys[0]}" ]; then
+	echo "no vendored nginx signing keys found in $keyring_dir" >&2
+	exit 1
+fi
+
+gnupghome="$(mktemp -d)"
+cleanup() {
+	rm -rf "$gnupghome"
+}
+trap cleanup EXIT
+export GNUPGHOME="$gnupghome"
+chmod 700 "$gnupghome"
+
+wget --quiet --timeout=20 --tries=3 --output-document="$signature" \
+	-- "$signature_url"
+for keyfile in "${keys[@]}"; do
+	gpg --batch --quiet --import "$keyfile" 2>/dev/null
+done
+gpg --batch --quiet --verify "$signature" "$tarball"
+echo "PGP signature verified for $tarball"


### PR DESCRIPTION
> This is the currently eligible narrow extraction from deferred audit row A29-F12. The broader workflow cleanup remains outside this sweep.

## TL;DR

Seven CI jobs carried separate copies of the same download-signature check. Keeping those copies aligned made security fixes easy to miss in one job while updating another.

All nginx source jobs now call `ci/tools/verify-nginx-tarball.sh`; `workflow_policy.py` also rejects an anchor that appears after extraction.

**Severity:** `Low` (`maintainability - duplicated CI security logic`)

## Mechanism

- The verifier downloads only the detached signature with bounded retries, imports the vendored nginx signer keys into a temporary keyring, verifies the existing tarball, and cleans the keyring on success or failure.
- `fetch-verified-nginx.sh` delegates to the same verifier, so the repository has one PGP implementation.
- An offline test covers accepted and rejected signatures, missing input, cleanup, default and custom signature URLs, and rejects the pre-change workflow shape.
- The provenance policy now recognizes the helper only in command order; a red fixture proves extract-then-verify cannot pass.

## Testing

- `bash ci/tools/test_verify_nginx_tarball.sh`
- `bash ci/linter/selftest.sh`
- `bash ci/linter/run-all.sh`
- `.claude/skills/_shared/review-lint.sh --branch origin/master`
- `actionlint .github/workflows/*.yml`
- `zizmor .github/workflows/build-test.yml`
- Live PGP verification of `nginx-1.31.4.tar.gz` against nginx.org
- CodeRabbit CLI completed; its ordering finding is covered by `provenance-verify-helper-after-extract`
