### PR TITLE
ci: clarify fan-out priority heuristic

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -497,9 +497,10 @@ jobs:
     timeout-minutes: 2
     needs: resolve
     steps:
-      - name: Give mainline first claim on the released lane
-        # GitHub does not promise ready-queue order. Keep mainline as the only
-        # self-hosted candidate briefly, then release the other three chains.
+      - name: Give mainline a best-effort head start before fan-out
+        # GitHub does not promise ready-queue order. This gate delays the three
+        # fan-out chains by ten seconds after resolve, giving build a bounded,
+        # best-effort eligibility lead without guaranteeing scheduler priority.
         run: sleep 10
 
   build:
@@ -892,8 +893,8 @@ jobs:
     name: Build (libzstd 1.4.x — fallback paths)
     runs-on: ${{ fromJSON(vars.POOL || '["ubuntu-latest"]') }}
     timeout-minutes: 25
-    # Released by the hosted barrier after mainline has first claim on the
-    # resolver's lane, then occupies the next lane to become available.
+    # Released after the barrier's bounded best-effort eligibility lead for
+    # build; it may contend with build and validation once the delay expires.
     needs: [resolve, release-build-fanout]
 
     env:

--- a/ci/linter/ci_topology.py
+++ b/ci/linter/ci_topology.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (C) 2026 Thijs Eilander
 # SPDX-License-Identifier: BSD-2-Clause
-"""Protect the measured four-lane PR/deep workflow topology."""
+"""Protect the measured four-lane PR/deep topology and fan-out eligibility lead."""
 
 from __future__ import annotations
 
@@ -102,7 +102,10 @@ def check_build(build: dict) -> list[str]:
         errors.append("build-test.yml fan-out barrier must stay off the four-lane pool")
     steps = fanout.get("steps", [])
     if len(steps) != 1 or steps[0].get("run") != "sleep 10":
-        errors.append("build-test.yml fan-out barrier must preserve mainline priority")
+        errors.append(
+            "build-test.yml fan-out barrier must preserve the ten-second "
+            "best-effort eligibility lead for the delayed fan-out chains"
+        )
     if "coverage" in jobs:
         errors.append("coverage is a deep report, not a PR job")
     return errors
@@ -200,7 +203,7 @@ def selftest(  # pylint: disable=too-many-statements
     cases.append(("invalid hosted arm64 dependency", ci, changed, deep))
     changed = copy.deepcopy(build)
     changed["jobs"]["release-build-fanout"]["steps"][0]["run"] = "true"
-    cases.append(("lost mainline priority", ci, changed, deep))
+    cases.append(("lost best-effort fan-out eligibility lead", ci, changed, deep))
     changed = copy.deepcopy(deep)
     changed["jobs"]["fuzz"]["strategy"]["max-parallel"] = 3
     cases.append(("five-lane deep fan-out", ci, build, changed))


### PR DESCRIPTION
> Found during the A30 CI audit. This is the terminal audit sweep item.

## TL;DR

The ten-second delay gives the main build a head start, but GitHub does not promise which waiting job gets the next runner. The workflow now says exactly that instead of presenting the delay as a scheduling guarantee.

The release-build-fanout comments and ci_topology.py diagnostics now describe a bounded, best-effort eligibility lead over the three delayed build chains; no workflow edges or executable steps changed.

**Severity:** `Low` (`CI scheduling documentation — an unobservable priority guarantee could mislead future workflow changes`)

## Testing

- `python3 ci/linter/ci_topology.py`
- `python3 ci/linter/ci_topology.py --selftest` rejected all 14 topology mutants, including replacing `sleep 10` with `true`
- `ci/linter/lint-ci-topology.sh`
- `ci/linter/selftest.sh`
- `LINT_ONLY='python yaml ci-topology' ci/linter/run-all.sh`
- `/opt/myguard/.claude/skills/_shared/review-lint.sh --branch origin/master`

Live GitHub runner ordering is intentionally not claimed or tested because the scheduler exposes no priority guarantee.
