### PR TITLE
ci: invalidate builds for every module input

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -219,6 +219,9 @@ jobs:
       - name: ci-build.sh clean-root + provenance regressions (F2/F3)
         run: bash "$GITHUB_WORKSPACE"/ci/tools/test_ci_build_provenance.sh
 
+      - name: Persistent build-input invalidation regressions
+        run: bash "$GITHUB_WORKSPACE"/ci/tools/test_build_input_manifest.sh
+
       - name: nginx tarball PGP verifier controls
         run: bash "$GITHUB_WORKSPACE"/ci/tools/test_verify_nginx_tarball.sh
 
@@ -603,11 +606,15 @@ jobs:
           echo "/usr/lib/ccache" >> "$GITHUB_PATH"
           echo "CCACHE_DIR=$HOME/.ccache" >> "$GITHUB_ENV"
 
+      - name: Hash module build inputs
+        id: build-inputs
+        run: echo "hash=$(bash ci/tools/build-input-hash.sh)" >> "$GITHUB_OUTPUT"
+
       - name: Cache ccache objects
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.ccache
-          key: ccache-${{ runner.os }}-${{ matrix.flavor }}-${{ matrix.version }}-${{ hashFiles('filter/*.c', 'static/*.c', '*.h', 'config') }}
+          key: ccache-${{ runner.os }}-${{ matrix.flavor }}-${{ matrix.version }}-${{ steps.build-inputs.outputs.hash }}
           restore-keys: |
             ccache-${{ runner.os }}-${{ matrix.flavor }}-${{ matrix.version }}-
             ccache-${{ runner.os }}-

--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -161,11 +161,15 @@ jobs:
             build-essential curl libpcre2-dev libzstd-dev pkg-config \
             wget zstd libperl-dev cpanminus ccache mold
 
+      - name: Hash module build inputs
+        id: build-inputs
+        run: echo "hash=$(bash ci/tools/build-input-hash.sh)" >> "$GITHUB_OUTPUT"
+
       - name: Cache ccache objects
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.ccache
-          key: ccache-ci-deep-${{ runner.os }}-${{ matrix.flavor }}-${{ matrix.version }}-${{ hashFiles('ci/tools/ci-build.sh', 'config', 'src/**') }}
+          key: ccache-ci-deep-${{ runner.os }}-${{ matrix.flavor }}-${{ matrix.version }}-${{ steps.build-inputs.outputs.hash }}
           restore-keys: |
             ccache-ci-deep-${{ runner.os }}-${{ matrix.flavor }}-${{ matrix.version }}-
             ccache-ci-deep-${{ runner.os }}-
@@ -182,7 +186,7 @@ jobs:
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: .build/${{ matrix.flavor }}-${{ matrix.version }}
-          key: build-tree-${{ runner.os }}-${{ matrix.flavor }}-${{ matrix.version }}-${{ hashFiles('ci/tools/ci-build.sh', 'config', 'src/**') }}
+          key: build-tree-${{ runner.os }}-${{ matrix.flavor }}-${{ matrix.version }}-${{ steps.build-inputs.outputs.hash }}
 
       - name: Build server and dynamic modules
         # No CCACHE_DIR override: ccache's own default (~/.ccache) already

--- a/ci/build-inputs.manifest
+++ b/ci/build-inputs.manifest
@@ -1,0 +1,11 @@
+# Paths are relative to the repository root. Directories include every regular
+# file below them. Keep this as the single source of truth for persistent build
+# trees and ccache keys.
+ci/build-inputs.manifest
+ci/tools/build-input-hash.sh
+ci/tools/ci-build.sh
+config
+auto/zstd
+filter/config
+static/config
+src

--- a/ci/tools/build-input-hash.sh
+++ b/ci/tools/build-input-hash.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Print a stable digest of every path in ci/build-inputs.manifest.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_MODULE_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+MODULE_DIR="${1:-$DEFAULT_MODULE_DIR}"
+MANIFEST="$MODULE_DIR/ci/build-inputs.manifest"
+
+if [ ! -f "$MANIFEST" ]; then
+    echo "ERROR: build-input manifest not found: $MANIFEST" >&2
+    exit 1
+fi
+
+hash_file() {
+    local relative="$1"
+    local digest
+
+    digest="$(sha256sum "$MODULE_DIR/$relative" | cut -d' ' -f1)"
+    printf '%s  %s\n' "$digest" "$relative"
+}
+
+while IFS= read -r input || [ -n "$input" ]; do
+    case "$input" in
+        '' | \#*) continue ;;
+    esac
+
+    if [ -f "$MODULE_DIR/$input" ]; then
+        hash_file "$input"
+    elif [ -d "$MODULE_DIR/$input" ]; then
+        while IFS= read -r -d '' file; do
+            hash_file "${file#"$MODULE_DIR/"}"
+        done < <(find "$MODULE_DIR/$input" -type f -print0 | sort -z)
+    else
+        echo "ERROR: build input does not exist: $input" >&2
+        exit 1
+    fi
+done < "$MANIFEST" | sha256sum | cut -d' ' -f1

--- a/ci/tools/ci-build.sh
+++ b/ci/tools/ci-build.sh
@@ -137,28 +137,13 @@ if [ "$NO_CACHE" = "1" ]; then
     rm -rf "$SRCDIR" "$TARBALL"
 fi
 
-# Input stamp. A build tree is keyed by flavor/version/mode only, but its OBJECTS
-# also depend on the module sources, the config file and this script. On a
-# persistent self-hosted runner the directory outlives all three, so without a
+# Input stamp. A build tree is keyed by flavor/version/mode only, but its objects
+# also depend on every path in ci/build-inputs.manifest. On a
+# persistent self-hosted runner the directory outlives these inputs, so without a
 # stamp a changed src/ silently reuses the old objects and CI reports on a binary
 # that no longer matches the tree. The Actions cache does not save us: a cache
 # MISS still finds the retained local directory.
-# Every command here must succeed even when its input is absent. A bare
-# `[ -f x ] && cat x` as the LAST command of the group makes the whole
-# substitution exit non-zero when x is missing, and `set -e` then kills the
-# build before it has downloaded anything -- which reads as "rejected" to any
-# caller checking only the exit status.
-STAMP_INPUTS="$(
-    {
-        cat "${BASH_SOURCE[0]}"
-        if [ -f "$ZSTD_MODULE_DIR/config" ]; then
-            cat "$ZSTD_MODULE_DIR/config"
-        fi
-        find "$ZSTD_MODULE_DIR/src" -type f \( -name '*.c' -o -name '*.h' \) \
-            -print0 2>/dev/null | sort -z | xargs -0 -r cat
-        :
-    } | sha256sum | cut -d" " -f1
-)"
+STAMP_INPUTS="$(bash "$SCRIPT_DIR/build-input-hash.sh" "$ZSTD_MODULE_DIR")"
 STAMP_FILE="$SRCDIR/.myguard-build-inputs"
 if [ -d "$SRCDIR" ] && [ "$(cat "$STAMP_FILE" 2>/dev/null || true)" != "$STAMP_INPUTS" ]; then
     echo "Build inputs changed since this tree was built -- rebuilding from scratch."

--- a/ci/tools/test_build_input_manifest.sh
+++ b/ci/tools/test_build_input_manifest.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Regression coverage for the canonical persistent-build input manifest.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+HASHER="$SCRIPT_DIR/build-input-hash.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# This list is deliberately independent of the manifest under test. Without a
+# separate oracle, deleting an input from the manifest also deletes its test.
+required_inputs=(
+    ci/build-inputs.manifest
+    ci/tools/build-input-hash.sh
+    ci/tools/ci-build.sh
+    config
+    auto/zstd
+    filter/config
+    static/config
+    src
+)
+
+for required in "${required_inputs[@]}"; do
+    if ! grep -Fxq "$required" "$MODULE_DIR/ci/build-inputs.manifest"; then
+        echo "FAIL: required build input missing from manifest: $required" >&2
+        exit 1
+    fi
+done
+
+copy_inputs() {
+    local input
+
+    mkdir -p "$WORK/module"
+    while IFS= read -r input || [ -n "$input" ]; do
+        case "$input" in
+            '' | \#*) continue ;;
+        esac
+        mkdir -p "$WORK/module/$(dirname "$input")"
+        cp -a "$MODULE_DIR/$input" "$WORK/module/$input"
+    done < "$MODULE_DIR/ci/build-inputs.manifest"
+}
+
+assert_mutation_changes_hash() {
+    local input="$1"
+    local file="$WORK/module/$input"
+    local relative="$input"
+    local before after
+
+    if [ -d "$file" ]; then
+        file="$(find "$file" -type f -print -quit)"
+        relative="${file#"$WORK/module/"}"
+    fi
+    before="$(bash "$HASHER" "$WORK/module")"
+    printf '\n# manifest regression mutation\n' >> "$file"
+    after="$(bash "$HASHER" "$WORK/module")"
+    if [ "$before" = "$after" ]; then
+        echo "FAIL: $input mutation did not change build-input hash" >&2
+        exit 1
+    fi
+    cp -a "$MODULE_DIR/$relative" "$WORK/module/$relative"
+}
+
+copy_inputs
+
+while IFS= read -r input || [ -n "$input" ]; do
+    case "$input" in
+        '' | \#*) continue ;;
+    esac
+    assert_mutation_changes_hash "$input"
+done < "$MODULE_DIR/ci/build-inputs.manifest"
+
+before="$(bash "$HASHER" "$WORK/module")"
+printf 'documentation only\n' > "$WORK/module/README.md"
+after="$(bash "$HASHER" "$WORK/module")"
+if [ "$before" != "$after" ]; then
+    echo "FAIL: docs-only mutation changed build-input hash" >&2
+    exit 1
+fi
+
+for specification in \
+    '.github/workflows/build-test.yml:1' \
+    '.github/workflows/ci-deep.yml:2'; do
+    workflow="${specification%:*}"
+    expected="${specification##*:}"
+    actual="$(grep -c 'key: .*steps.build-inputs.outputs.hash' \
+        "$MODULE_DIR/$workflow" || true)"
+    if [ "$actual" -ne "$expected" ]; then
+        echo "FAIL: $workflow uses the canonical hash in $actual/$expected cache keys" >&2
+        exit 1
+    fi
+done
+
+echo "✓ every manifest fragment invalidates build caches; docs-only changes do not"
+
+# Exercise ci-build.sh itself with a tiny offline server tarball. The fake
+# Makefile records a compile/link input in the addon object, making a stale
+# tree directly observable without downloading and compiling nginx.
+integration="$WORK/integration"
+module="$integration/module"
+root="$integration/build"
+source="$integration/angie-9.9.9"
+mkdir -p "$module" "$root" "$source"
+cp -a "$WORK/module/." "$module/"
+cat > "$source/configure" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+for argument in "$@"; do
+    case "$argument" in
+        --add-dynamic-module=*) module="${argument#*=}" ;;
+    esac
+done
+: "${module:?missing addon module path}"
+cat > Makefile <<MAKEFILE
+all:
+	mkdir -p objs
+	sha256sum "$module/filter/config" > objs/ngx_http_zstd_filter_module.o
+	cp objs/ngx_http_zstd_filter_module.o objs/ngx_http_zstd_filter_module.so
+	touch objs/ngx_http_zstd_static_module.so objs/angie
+MAKEFILE
+EOF
+chmod +x "$source/configure"
+tar -czf "$root/angie-9.9.9.tar.gz" -C "$integration" angie-9.9.9
+rm -rf "$source"
+digest="$(sha256sum "$root/angie-9.9.9.tar.gz" | cut -d' ' -f1)"
+sed -i "/declare -A ANGIE_SHA256=(/a\\    [\"9.9.9\"]=\"$digest\"" \
+    "$module/ci/tools/ci-build.sh"
+
+BUILD_ROOT="$root" bash "$module/ci/tools/ci-build.sh" angie 9.9.9 coverage \
+    > "$integration/first.log"
+object="$root/angie-9.9.9-coverage/objs/ngx_http_zstd_filter_module.o"
+first_object="$(cat "$object")"
+printf '\n# compile/link mutation\n' >> "$module/filter/config"
+BUILD_ROOT="$root" bash "$module/ci/tools/ci-build.sh" angie 9.9.9 coverage \
+    > "$integration/second.log"
+second_object="$(cat "$object")"
+
+if [ "$first_object" = "$second_object" ]; then
+    echo "FAIL: compile/link-input mutation reused the stale addon object" >&2
+    exit 1
+fi
+if ! grep -q 'Build inputs changed.*rebuilding from scratch' \
+    "$integration/second.log"; then
+    echo "FAIL: compile/link-input mutation did not invalidate the build tree" >&2
+    exit 1
+fi
+echo "✓ compile/link-input mutation rebuilds the addon object"

--- a/ci/tools/test_ci_build_provenance.sh
+++ b/ci/tools/test_ci_build_provenance.sh
@@ -21,11 +21,25 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 CI_BUILD="$SCRIPT_DIR/ci-build.sh"
 
 fail=0
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
+
+copy_build_fixture() {
+    local destination="$1"
+    local input
+
+    while IFS= read -r input || [ -n "$input" ]; do
+        case "$input" in
+            '' | \#*) continue ;;
+        esac
+        mkdir -p "$destination/$(dirname "$input")" || return 1
+        cp -a "$MODULE_DIR/$input" "$destination/$input" || return 1
+    done < "$MODULE_DIR/ci/build-inputs.manifest"
+}
 
 # ---------------------------------------------------------------------
 # F3a: wrong sha256 pin must be rejected for a statically-pinned version,
@@ -39,8 +53,17 @@ test_wrong_sha256_rejected() {
     # angie path is simpler to fake: sha256-only, no PGP.
     echo "not a real tarball" >"$root/angie-9.9.9.tar.gz"
 
-    local copy="$WORK/ci-build-badpin.sh"
-    cp "$CI_BUILD" "$copy"
+    local fixture="$WORK/f3-module"
+    if ! copy_build_fixture "$fixture"; then
+        echo "FAIL: could not stage the hermetic ci-build fixture"
+        return 1
+    fi
+    local copy="$fixture/ci/tools/ci-build.sh"
+    if [ ! -f "$fixture/ci/tools/build-input-hash.sh" ] || \
+        [ ! -f "$fixture/ci/build-inputs.manifest" ]; then
+        echo "FAIL: hermetic ci-build fixture is missing canonical hash inputs"
+        return 1
+    fi
     # Force a pin that cannot possibly match the fake tarball's digest.
     sed -i 's/\["1\.11\.5"\]=.*/["9.9.9"]="0000000000000000000000000000000000000000000000000000000000000"/' "$copy"
 


### PR DESCRIPTION
## TL;DR

Persistent build caches could miss module configuration changes and certify stale binaries. One declared input set now drives local build-tree reuse and both workflow cache identities, while documentation-only changes remain cacheable.

`ci/build-inputs.manifest` and `ci/tools/build-input-hash.sh` replace the three divergent input lists used by `ci-build.sh`, CI Deep's build tree and ccache, and the main build workflow's ccache.

**Severity:** `High` (`correctness — stale binaries could pass CI`)

## Mechanism

The manifest covers the build driver, top-level configuration, shared discovery logic, both module declarations, and all module sources and headers. The hash helper fails closed on missing entries, includes path names as well as contents, and is self-invalidating when the manifest or helper changes.

The persistent build stamp and cache keys consume that same digest. Cache reuse still ignores README and other documentation edits.

## Testing

- `bash ci/tools/test_build_input_manifest.sh`
  - checks a separate required-input oracle before reading manifest entries
  - mutates every manifest entry independently
  - confirms a README-only edit leaves the digest unchanged
  - uses an offline fake server tree to prove a configure-fragment mutation replaces the addon object
- `bash ci/tools/test_ci_build_provenance.sh`; its hermetic bad-pin fixture now stages every canonical build input and asserts that rejection occurs specifically through the sha256-mismatch path.
- Negative controls: temporarily excluding `auto/zstd` from the hash helper made its mutation assertion fail; removing it from the manifest made the independent oracle fail with `FAIL: required build input missing from manifest: auto/zstd`; omitting the hash helper from the provenance fixture made that suite fail its fixture-completeness oracle. Restoring each omission returned the tests to green.
- Clean nginx 1.30.4 release build, followed by a `filter/config` mutation: the build reported input invalidation and replaced the filter object (inode `784979` to `786484`).
- `shellcheck --severity=error ci/tools/build-input-hash.sh ci/tools/test_build_input_manifest.sh ci/tools/ci-build.sh`
- `actionlint .github/workflows/build-test.yml .github/workflows/ci-deep.yml`
- MyGuard branch lint roster; its only unavailable lens was EditorConfig because the repository declares no EditorConfig contract. Existing advisory whole-file formatting and `workflow_dispatch` policy findings remain outside this diff.
- CodeRabbit local pre-commit review completed with zero findings across all six changed files.
