### PR TITLE
fix(static): probe frame after four skips

### DIFF
--- a/ci/t/01-static.t
+++ b/ci/t/01-static.t
@@ -1284,11 +1284,35 @@ Content-Encoding: zstd
 
 
 
-=== TEST 44: a chain of skippable frames longer than the bound is declined
-# NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES caps the walk at 4 leading
-# skippable frames. Five zero-length skippable frames ahead of an
-# otherwise-good regular frame must be declined — the handler gives up
-# rather than searching indefinitely.
+=== TEST 44: exactly four leading skippable frames followed by a regular frame are served
+# NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES permits four leading skippable
+# frames.  The handler must still probe the following regular frame,
+# rather than declining before it reads that frame.
+--- config
+    location /skip/ {
+        zstd_static on;
+        root html;
+    }
+--- user_files eval
+">>> skip/four.js\nfour skips origin\n>>> skip/four.js.zst\n"
+. (pack("C*", 0x50, 0x2A, 0x4D, 0x18, 0x00, 0x00, 0x00, 0x00) x 4)
+. pack("C*", 0x28, 0xB5, 0x2F, 0xFD, 0x00, 0x00, 0x19, 0x00, 0x00)
+. "hi\n"
+--- request
+GET /skip/four.js
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+Content-Encoding: zstd
+--- error_code: 200
+--- no_error_log
+[error]
+
+
+
+=== TEST 44b: a fifth leading skippable frame is declined
+# The cap is enforced only after the fifth skippable frame is observed.
+# This keeps the walk bounded while allowing the regular frame after four.
 --- config
     location /skip/ {
         zstd_static on;
@@ -1309,7 +1333,7 @@ Accept-Encoding: zstd
 too long origin
 --- error_code: 200
 --- error_log
-has at least 4 leading skippable frames
+has at least 5 leading skippable frames
 
 
 

--- a/src/ngx_http_zstd_static_module.c
+++ b/src/ngx_http_zstd_static_module.c
@@ -1173,19 +1173,6 @@ ngx_http_zstd_static_probe_file(ngx_http_request_t *r,
      */
     for (frames = 0; ; frames++) {
 
-        if (frames >= NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES) {
-            ngx_log_error(NGX_LOG_ERR, log, 0,
-                          "zstd static: \"%s\" has at least %ui "
-                          "leading skippable frames -- declining "
-                          "rather than searching further for the "
-                          "first regular frame",
-                          path->data,
-                          (ngx_uint_t)
-                              NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES);
-            probe_rc = NGX_DECLINED;
-            goto probe_done;
-        }
-
         if (of->is_directio) {
             frame_off = (size_t) ((uint64_t) pos % (uint64_t) align);
             base = pos - (off_t) frame_off;
@@ -1290,6 +1277,25 @@ ngx_http_zstd_static_probe_file(ngx_http_request_t *r,
         probe_rc = ngx_http_zstd_static_probe_verdict(frame, avail, of->size,
                                                       &pos, path, log);
         if (probe_rc == NGX_AGAIN) {
+            /*
+             * The first four skips are permitted, so probe the frame
+             * following the fourth one.  Decline only after observing a
+             * fifth skip; rejecting at the top of this loop would reject
+             * the regular frame after exactly four skips without probing it.
+             */
+            if (frames >= NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES) {
+                ngx_log_error(NGX_LOG_ERR, log, 0,
+                              "zstd static: \"%s\" has at least %ui "
+                              "leading skippable frames -- declining "
+                              "rather than searching further for the "
+                              "first regular frame",
+                              path->data,
+                              (ngx_uint_t)
+                                  NGX_HTTP_ZSTD_STATIC_MAX_SKIP_FRAMES + 1);
+                probe_rc = NGX_DECLINED;
+                goto probe_done;
+            }
+
             continue;
         }
 


### PR DESCRIPTION
## TL;DR

The static handler permits a small number of harmless leading records before the actual compressed content. It stopped one record too early, so a valid file at the documented boundary was declined. The walk remains bounded: a fifth leading record is still rejected.

`ngx_http_zstd_static_probe_file()` now declines after observing the fifth `NGX_AGAIN` result, rather than before probing the frame after the fourth skip.

**Severity:** `Low` (`correctness - valid zstd static files with exactly four leading skippable frames are declined`)

## Testing

- `ci/t/01-static.t`: exactly four leading skippable frames return `200` with `Content-Encoding: zstd`.
- The paired five-frame case still returns the uncompressed origin and logs that at least five leading skippable frames were found.
- Focused test and four/five-frame mutation controls passed before this unchanged candidate was pushed. The lint roster completed with `clang-tidy` coverage unavailable until nginx build headers are present; CodeRabbit reported no findings.
