### PR TITLE
fix: keep quoted Cache-Control commas within extensions

### DIFF
--- a/ci/tools/test_encoding.py
+++ b/ci/tools/test_encoding.py
@@ -204,6 +204,16 @@ http {{
             zstd_types application/javascript;
             proxy_pass http://127.0.0.1:{backend_port}/cache-control-quoted-no-transform.js;
         }}
+        location = /cache-control-quoted-comma.js {{
+            types {{
+                application/javascript js;
+            }}
+            default_type application/javascript;
+            zstd on;
+            zstd_min_length 1;
+            zstd_types application/javascript;
+            proxy_pass http://127.0.0.1:{backend_port}/cache-control-quoted-comma.js;
+        }}
         location = /cache-control-no-transform-comma.js {{
             types {{
                 application/javascript js;
@@ -256,6 +266,7 @@ class CacheControlHandler(http.server.BaseHTTPRequestHandler):
     cache_control: ClassVar[dict[str, list[str]]] = {
         "/cache-control-public.js": ["public"],
         "/cache-control-quoted-no-transform.js": ['public, extension="no-transform"'],
+        "/cache-control-quoted-comma.js": ['public, extension="a,no-transform,b"'],
         "/cache-control-no-transform-comma.js": ["public, no-transform"],
         "/cache-control-no-transform-ows.js": [" public ; max-age=60 , No-Transform "],
         "/cache-control-no-transform-repeat.js": ["public", "no-transform"],
@@ -314,6 +325,19 @@ def validate_cache_control_no_transform(port: int, expected: bytes) -> None:
     if quoted_body == expected:
         raise RuntimeError(
             "Cache-Control quoted no-transform negative control was not transformed"
+        )
+
+    quoted_comma_body, quoted_comma_encoding, _ = fetch_path(
+        port, "/cache-control-quoted-comma.js"
+    )
+    if quoted_comma_encoding.lower() != "zstd":
+        raise RuntimeError(
+            "Cache-Control quoted comma extension was split into a directive: "
+            f"Content-Encoding={quoted_comma_encoding!r}"
+        )
+    if quoted_comma_body == expected:
+        raise RuntimeError(
+            "Cache-Control quoted comma negative control was not transformed"
         )
 
     for path in (

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -1408,10 +1408,40 @@ ngx_module_t  ngx_http_zstd_filter_module = {
 };
 
 
+static u_char *
+ngx_http_zstd_cache_control_directive_end(u_char *p, u_char *last)
+{
+    while (p < last) {
+        if (*p == '"') {
+            p++;
+
+            while (p < last && *p != '"') {
+                if (*p == '\\' && p + 1 < last) {
+                    p++;
+                }
+                p++;
+            }
+
+            if (p < last) {
+                p++;
+            }
+
+        } else if (*p == ',') {
+            break;
+
+        } else {
+            p++;
+        }
+    }
+
+    return p;
+}
+
+
 static ngx_int_t
 ngx_http_zstd_cache_control_value_no_transform(ngx_table_elt_t *cc)
 {
-    u_char  *p, *last, *start, *end, *semi;
+    u_char  *p, *last, *start, *end, *directive_end, *semi;
 
     if (cc->value.len == 0) {
         return 0;
@@ -1426,10 +1456,7 @@ ngx_http_zstd_cache_control_value_no_transform(ngx_table_elt_t *cc)
             start++;
         }
 
-        end = start;
-        while (end < last && *end != ',') {
-            end++;
-        }
+        directive_end = ngx_http_zstd_cache_control_directive_end(start, last);
 
         /*
          * Cut at '=' as well as ';': the compared token is then the
@@ -1440,7 +1467,7 @@ ngx_http_zstd_cache_control_value_no_transform(ngx_table_elt_t *cc)
          * cuts to "extension" and still does not match.
          */
         semi = start;
-        while (semi < end && *semi != ';' && *semi != '=') {
+        while (semi < directive_end && *semi != ';' && *semi != '=') {
             semi++;
         }
         end = semi;
@@ -1456,10 +1483,7 @@ ngx_http_zstd_cache_control_value_no_transform(ngx_table_elt_t *cc)
             return 1;
         }
 
-        p = semi;
-        while (p < last && *p != ',') {
-            p++;
-        }
+        p = directive_end;
         if (p < last) {
             p++;
         }


### PR DESCRIPTION
> This is limited to Cache-Control directive scanning; configuration syntax and the module ABI are unchanged.

## TL;DR

A response can include an optional instruction whose quoted text contains a comma. That comma belongs to the instruction, not the next one, so splitting there can create a false compression opt-out.

`ngx_http_zstd_cache_control_directive_end()` skips quoted strings, including escaped characters, before `ngx_http_zstd_cache_control_value_no_transform()` evaluates the Cache-Control directive token.

**Severity:** `Low` (`correctness - quoted extension comma can suppress compression`)

## Testing

- Focused `ci/tools/test_encoding.py` Cache-Control regression and mutation controls passed. The new quoted-comma case remains compressed; comma, OWS, and repeated real `no-transform` directives remain uncompressed.
- `coderabbit review --agent --uncommitted` completed with zero findings.