### PR TITLE
ci: document self-reference waivers

### DIFF
--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -666,7 +666,8 @@ jobs:
         !cancelled()
         && contains(fromJSON('["all","scanners"]'), inputs.jobs || 'all')
       }}
-    uses: ./.github/workflows/security-scanners.yml
+    # actionlint #711 lacks $/; generator parity is superrepo-scoped.
+    uses: ./.github/workflows/security-scanners.yml # zizmor: ignore[self-repository]
     permissions:
       contents: read
 
@@ -754,7 +755,8 @@ jobs:
     name: CodeQL
     needs: coverage
     if: ${{ !cancelled() && (inputs.jobs || 'all') == 'all' }}
-    uses: ./.github/workflows/codeql.yml
+    # actionlint #711 lacks $/; generator parity is superrepo-scoped.
+    uses: ./.github/workflows/codeql.yml # zizmor: ignore[self-repository]
     permissions:
       contents: read
       security-events: write # upload CodeQL SARIF to code scanning
@@ -763,6 +765,7 @@ jobs:
     name: A/UBSan soak
     needs: scanners
     if: ${{ !cancelled() && (inputs.jobs || 'all') == 'all' }}
-    uses: ./.github/workflows/asan.yml
+    # actionlint #711 lacks $/; generator parity is superrepo-scoped.
+    uses: ./.github/workflows/asan.yml # zizmor: ignore[self-repository]
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,14 +37,16 @@ jobs:
   lint:
     name: Lint
     if: github.event_name != 'push'
-    uses: ./.github/workflows/lint.yml
+    # actionlint #711 lacks $/; generator parity is superrepo-scoped.
+    uses: ./.github/workflows/lint.yml # zizmor: ignore[self-repository]
     permissions:
       contents: read
 
   build-test:
     name: Build & Test
     if: github.event_name != 'push'
-    uses: ./.github/workflows/build-test.yml
+    # actionlint #711 lacks $/; generator parity is superrepo-scoped.
+    uses: ./.github/workflows/build-test.yml # zizmor: ignore[self-repository]
     permissions:
       contents: read
 
@@ -52,7 +54,8 @@ jobs:
     # This exact case is part of the existing status-check context.
     name: Security scanners
     if: github.event_name != 'push'
-    uses: ./.github/workflows/security-scanners.yml
+    # actionlint #711 lacks $/; generator parity is superrepo-scoped.
+    uses: ./.github/workflows/security-scanners.yml # zizmor: ignore[self-repository]
     permissions:
       contents: read
 
@@ -60,13 +63,15 @@ jobs:
     # Kept in the fast gate because it reaches module-internal fault/resource
     # paths that Test::Nginx and ordinary sanitizers cannot observe.
     name: Harness Fault Arms
-    uses: ./.github/workflows/harness-fault-arms.yml
+    # actionlint #711 lacks $/; generator parity is superrepo-scoped.
+    uses: ./.github/workflows/harness-fault-arms.yml # zizmor: ignore[self-repository]
     permissions:
       contents: read
 
   windows-build:
     name: Windows build
     if: github.event_name != 'push'
-    uses: ./.github/workflows/windows-build.yml
+    # actionlint #711 lacks $/; generator parity is superrepo-scoped.
+    uses: ./.github/workflows/windows-build.yml # zizmor: ignore[self-repository]
     permissions:
       contents: read


### PR DESCRIPTION
> Required CI started failing when zizmor 1.30 added its `self-repository` audit. The canonical migration also needs actionlint #711 and a matching superrepo generator update, so those stay outside this module-only PR.

## TL;DR

A new workflow security check rejects local references that the current syntax checker still requires. This keeps the rest of the security scan live and records eight temporary exceptions; removing any one of them makes the new check fail again.

In precise terms, `.github/workflows/ci.yml` and `.github/workflows/ci-deep.yml` retain `uses: ./...` and add line-scoped `zizmor: ignore[self-repository]` annotations pending actionlint #711 and generator parity.

**Severity:** `Blocker` (`CI compatibility - the required Lint job fails on every pull request`)

## Testing

- zizmor 1.30 passes in pedantic offline mode with all other audits enabled.
- actionlint, `ci/linter/lint-yaml.sh`, and the linter self-test pass unchanged.
- A mutation that removes one waiver fails on the expected `self-repository` finding, then the restored tree passes.

## Compatibility

The workflow call syntax and runtime behavior do not change. The annotations affect only zizmor's static audit and can be removed when actionlint accepts `$/...` references and the generated pre-commit configuration can migrate with its source template.
