### PR TITLE
ci: bootstrap fork fallback dependencies

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -44,6 +44,13 @@ jobs:
         with:
           persist-credentials: false
 
+      # `vars.POOL` is absent in forks, so do not rely on the hosted image
+      # carrying curl before the full dependency installation below.
+      - name: Install bootstrap dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl
+
       - name: Resolve latest mainline nginx
         run: |
           set -euo pipefail
@@ -65,7 +72,8 @@ jobs:
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
           sudo apt-get install -y \
-            build-essential curl libpcre2-dev libzstd-dev pkg-config wget zstd
+            build-essential curl gnupg libpcre2-dev libzstd-dev openssl pkg-config \
+            wget zlib1g-dev zstd
 
       - name: Cache nginx source tarball
         id: nginx-tarball

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -69,6 +69,13 @@ jobs:
       nginx_version: ${{ steps.v.outputs.nginx_version }}
       matrix: ${{ steps.v.outputs.matrix }}
     steps:
+      # `vars.POOL` is unavailable in forks; curl is needed by the very next
+      # step, before any job-specific package installation can run.
+      - name: Install bootstrap dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl
+
       - name: Resolve latest mainline nginx
         id: v
         run: |
@@ -99,6 +106,12 @@ jobs:
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
+
+      # actionlint is downloaded in the next step, so install curl before it.
+      - name: Install bootstrap dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl
 
       # Lint the workflow files themselves. actionlint validates GitHub
       # Actions expression contexts (e.g. "env is not allowed in a job
@@ -164,6 +177,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
+            curl \
+            git \
             gcc-multilib \
             libpcre2-dev \
             zlib1g-dev \
@@ -212,6 +227,9 @@ jobs:
 
       - name: README/SECURITY/CONTRIBUTING vs live workflows (F7 regression)
         run: bash "$GITHUB_WORKSPACE"/ci/tools/test_docs_ci_drift.sh
+
+      - name: Fork-runner dependency bootstrap regression
+        run: bash "$GITHUB_WORKSPACE"/ci/tools/test_ci_dependency_bootstrap.sh
 
       # Audit sha e289021 F2/F3 regression coverage: exercises ci-build.sh's
       # mv-guard and provenance checks directly (offline cases + one live
@@ -596,6 +614,7 @@ jobs:
             build-essential \
             pkg-config \
             libzstd-dev \
+            gnupg \
             libpcre2-dev \
             zlib1g-dev \
             ccache \
@@ -763,6 +782,7 @@ jobs:
             zlib1g-dev \
             python3 \
             python3-requests \
+            gnupg \
             wget \
             zstd
 
@@ -934,7 +954,7 @@ jobs:
             'Acquire::https::Timeout "20";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config \
+          sudo apt-get install -y build-essential gnupg pkg-config \
             libpcre2-dev zlib1g-dev wget cmake python3 \
             python3-requests zstd
 
@@ -1140,7 +1160,7 @@ jobs:
             'Acquire::https::Timeout "20";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config libzstd-dev \
+          sudo apt-get install -y build-essential gnupg pkg-config libzstd-dev \
             libpcre2-dev zlib1g-dev wget binutils
 
       - name: Cache nginx source tarball
@@ -1374,7 +1394,7 @@ jobs:
             'Acquire::https::Timeout "10";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
-          sudo apt-get install -y build-essential libzstd-dev \
+          sudo apt-get install -y build-essential git gnupg libzstd-dev \
             libpcre2-dev zlib1g-dev wget curl
 
       - name: Cache nginx source tarball
@@ -1524,7 +1544,7 @@ jobs:
             'Acquire::https::Timeout "20";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config libzstd-dev \
+          sudo apt-get install -y build-essential gnupg pkg-config libzstd-dev \
             libpcre2-dev zlib1g-dev wget
 
       - name: Cache nginx source tarball

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -47,6 +47,12 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      # This scheduled workflow also falls back to ubuntu-latest for forks.
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl gh git gnupg python3
+
       - name: Run bump script
         id: bump
         env:

--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -158,7 +158,7 @@ jobs:
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
           sudo apt-get install -y \
-            build-essential curl libpcre2-dev libzstd-dev pkg-config \
+            build-essential curl gnupg libpcre2-dev libzstd-dev pkg-config \
             wget zstd libperl-dev cpanminus ccache mold
 
       - name: Hash module build inputs
@@ -301,7 +301,7 @@ jobs:
             'Acquire::https::Timeout "20";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
-          sudo apt-get install -y clang
+          sudo apt-get install -y clang curl python3
 
       - name: Select fuzz duration
         env:
@@ -404,6 +404,10 @@ jobs:
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
+      - name: Install bootstrap dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl
       - name: Resolve latest mainline nginx
         run: |
           set -euo pipefail
@@ -424,8 +428,8 @@ jobs:
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
           sudo apt-get install -y \
-            build-essential curl libpcre2-dev libzstd-dev pkg-config \
-            valgrind wget zlib1g-dev zstd
+            build-essential curl gnupg libpcre2-dev libzstd-dev openssl pkg-config \
+            python3 valgrind wget zlib1g-dev zstd
       - name: Build debug nginx + zstd module
         run: |
           set -euo pipefail
@@ -504,8 +508,8 @@ jobs:
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
           sudo apt-get install -y \
-            build-essential curl libnghttp2-dev libpcre2-dev libssl-dev \
-            libzstd-dev openssl pkg-config valgrind wget zlib1g-dev zstd
+            build-essential curl gnupg libnghttp2-dev libpcre2-dev libssl-dev \
+            libzstd-dev openssl pkg-config python3 valgrind wget zlib1g-dev zstd
       - name: Build harness nginx tree
         run: |
           set -euo pipefail
@@ -596,6 +600,10 @@ jobs:
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
+      - name: Install bootstrap dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl
       - name: Resolve latest mainline nginx
         run: |
           set -euo pipefail
@@ -616,8 +624,8 @@ jobs:
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
           sudo apt-get install -y \
-            build-essential curl libpcre2-dev libzstd-dev pkg-config \
-            valgrind wget zlib1g-dev zstd
+            build-essential curl gnupg libpcre2-dev libzstd-dev openssl pkg-config \
+            python3 valgrind wget zlib1g-dev zstd
       - name: Build debug nginx + zstd module
         run: |
           set -euo pipefail
@@ -723,7 +731,7 @@ jobs:
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
           sudo apt-get install -y \
-            build-essential cpanminus curl gcovr libnghttp2-dev libpcre2-dev \
+            build-essential cpanminus curl gcovr gnupg libnghttp2-dev libpcre2-dev \
             libperl-dev libssl-dev libzstd-dev openssl pkg-config \
             python3 python3-requests strace wget zlib1g-dev zstd
       - name: Cache Perl modules

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -75,7 +75,7 @@ jobs:
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
           sudo apt-get install -y build-essential gnupg pkg-config libzstd-dev \
-            libpcre2-dev zlib1g-dev wget
+            libpcre2-dev python3 unzip wget zlib1g-dev
 
       - name: Cache nginx source tarball
         id: nginx-tarball

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,6 +38,12 @@ jobs:
         with:
           persist-credentials: false
 
+      # Required before resolving nginx on an ephemeral fork runner.
+      - name: Install bootstrap dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl
+
       - name: Resolve latest mainline nginx
         run: |
           set -euo pipefail
@@ -68,7 +74,7 @@ jobs:
             'Acquire::https::Timeout "10";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config libzstd-dev \
+          sudo apt-get install -y build-essential gnupg pkg-config libzstd-dev \
             libpcre2-dev zlib1g-dev wget
 
       - name: Cache nginx source tarball

--- a/.github/workflows/harness-fault-arms.yml
+++ b/.github/workflows/harness-fault-arms.yml
@@ -65,7 +65,7 @@ jobs:
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
           sudo apt-get install -y \
-            build-essential curl libnghttp2-dev libpcre2-dev libssl-dev \
+            build-essential curl gnupg libnghttp2-dev libpcre2-dev libssl-dev \
             libzstd-dev pkg-config wget zlib1g-dev
 
       - name: Fetch verified nginx source

--- a/.github/workflows/security-scanners.yml
+++ b/.github/workflows/security-scanners.yml
@@ -45,7 +45,9 @@ jobs:
             'Acquire::https::Timeout "20";' \
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
-          sudo apt-get install -y flawfinder clang-tidy python3 python3-pip pipx nginx-dev
+          sudo apt-get install -y \
+            build-essential clang-tidy curl flawfinder gnupg libzstd-dev \
+            nginx-dev pkg-config python3 python3-pip pipx wget
           # semgrep: isolate via pipx (PEP 668 blocks a bare pip3 install into the
           # system Python on the Ubuntu 24.04 self-hosted runner). Fall back to a
           # user pip install with --break-system-packages if pipx is unavailable.

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -34,6 +34,12 @@ jobs:
         with:
           persist-credentials: false
 
+      # Required before resolving nginx on an ephemeral fork runner.
+      - name: Install bootstrap dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl
+
       - name: Resolve latest mainline nginx
         run: |
           set -euo pipefail
@@ -56,7 +62,7 @@ jobs:
             | sudo tee /etc/apt/apt.conf.d/99-ci-net > /dev/null
           sudo apt-get update
           sudo apt-get install -y \
-            build-essential curl libpcre2-dev libzstd-dev pkg-config \
+            build-essential curl gnupg libpcre2-dev libzstd-dev openssl pkg-config \
             valgrind wget zlib1g-dev zstd
 
       - name: Build debug nginx + zstd module

--- a/ci/linter/fixtures/policy/provenance-apt-chained-unzip/.github/workflows/ci.yml
+++ b/ci/linter/fixtures/policy/provenance-apt-chained-unzip/.github/workflows/ci.yml
@@ -1,0 +1,10 @@
+---
+name: ci
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: wget -q -O payload https://example.invalid/payload
+      - run: apt-get install -y unzip && unzip payload -d tool

--- a/ci/linter/fixtures/policy/provenance-apt-chained-unzip/README.md
+++ b/ci/linter/fixtures/policy/provenance-apt-chained-unzip/README.md
@@ -1,0 +1,6 @@
+# fixture: provenance-apt-chained-unzip
+
+An `apt-get install unzip` package token must not hide a separate unverified
+archive extraction chained after it. `provenance` must go red.
+
+Workflow: `.github/workflows/ci.yml`.

--- a/ci/linter/fixtures/policy/provenance-chained-unzip/.github/workflows/ci.yml
+++ b/ci/linter/fixtures/policy/provenance-chained-unzip/.github/workflows/ci.yml
@@ -1,0 +1,9 @@
+---
+name: ci
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl -fsSL -o payload https://example.invalid/payload && unzip payload -d tool

--- a/ci/linter/fixtures/policy/provenance-chained-unzip/README.md
+++ b/ci/linter/fixtures/policy/provenance-chained-unzip/README.md
@@ -1,0 +1,6 @@
+# fixture: provenance-chained-unzip
+
+An unverified ZIP extraction chained after a download with `&&` remains an
+extraction boundary. `provenance` must go red.
+
+Workflow: `.github/workflows/ci.yml`.

--- a/ci/linter/fixtures/policy/provenance-mixed-codeql-unzip/.github/workflows/ci.yml
+++ b/ci/linter/fixtures/policy/provenance-mixed-codeql-unzip/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+---
+name: ci
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl -fsSL -o payload https://example.invalid/payload
+      - run: |
+          unzip payload -d tool
+          unzip -qq "$db/src.zip" -d "$src"

--- a/ci/linter/fixtures/policy/provenance-mixed-codeql-unzip/README.md
+++ b/ci/linter/fixtures/policy/provenance-mixed-codeql-unzip/README.md
@@ -1,0 +1,6 @@
+# fixture: provenance-mixed-codeql-unzip
+
+The local CodeQL database exception applies only to its own extraction. It
+must not exempt an unverified ZIP extraction earlier in the same step.
+
+Workflow: `.github/workflows/ci.yml`.

--- a/ci/linter/fixtures/policy/provenance-pipe-unzip/.github/workflows/ci.yml
+++ b/ci/linter/fixtures/policy/provenance-pipe-unzip/.github/workflows/ci.yml
@@ -1,0 +1,9 @@
+---
+name: ci
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: wget -q -O payload https://example.invalid/payload | unzip payload -d tool

--- a/ci/linter/fixtures/policy/provenance-pipe-unzip/README.md
+++ b/ci/linter/fixtures/policy/provenance-pipe-unzip/README.md
@@ -1,0 +1,6 @@
+# fixture: provenance-pipe-unzip
+
+A pipe does not remove the unverified ZIP extraction boundary. `provenance`
+must go red.
+
+Workflow: `.github/workflows/ci.yml`.

--- a/ci/linter/fixtures/policy/provenance-subshell-unzip/.github/workflows/ci.yml
+++ b/ci/linter/fixtures/policy/provenance-subshell-unzip/.github/workflows/ci.yml
@@ -1,0 +1,9 @@
+---
+name: ci
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: wget -q -O payload https://example.invalid/payload; (unzip payload -d tool)

--- a/ci/linter/fixtures/policy/provenance-subshell-unzip/README.md
+++ b/ci/linter/fixtures/policy/provenance-subshell-unzip/README.md
@@ -1,0 +1,6 @@
+# fixture: provenance-subshell-unzip
+
+Running an unverified ZIP extraction inside a subshell remains an extraction
+boundary. `provenance` must go red.
+
+Workflow: `.github/workflows/ci.yml`.

--- a/ci/linter/fixtures/policy/provenance-unverified-unzip/.github/workflows/ci.yml
+++ b/ci/linter/fixtures/policy/provenance-unverified-unzip/.github/workflows/ci.yml
@@ -1,0 +1,10 @@
+---
+name: ci
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl -fsSL -o payload https://example.invalid/payload
+      - run: unzip payload -d tool

--- a/ci/linter/fixtures/policy/provenance-unverified-unzip/README.md
+++ b/ci/linter/fixtures/policy/provenance-unverified-unzip/README.md
@@ -1,0 +1,7 @@
+# fixture: provenance-unverified-unzip
+
+An archive's extension is not its format: a downloaded ZIP can be named
+`payload` and `unzip payload` still extracts it. With no trust anchor before
+that extraction, `provenance` must go red.
+
+Workflow: `.github/workflows/ci.yml`.

--- a/ci/linter/selftest.sh
+++ b/ci/linter/selftest.sh
@@ -271,6 +271,7 @@ policy_ 1 provenance-chained-unzip provenance
 policy_ 1 provenance-mixed-codeql-unzip provenance
 policy_ 1 provenance-pipe-unzip provenance
 policy_ 1 provenance-subshell-unzip provenance
+policy_ 1 provenance-apt-chained-unzip provenance
 
 # A mistyped pool label in a schedule-only workflow. The trust half of the
 # runners check does not apply to a workflow no fork can reach, and skipping it

--- a/ci/linter/selftest.sh
+++ b/ci/linter/selftest.sh
@@ -264,6 +264,9 @@ policy_ 1 provenance-noncomparing-sha256 provenance
 # tar/unzip patterns miss this entirely, yet it is the same privilege
 # boundary one step shorter.
 policy_ 1 provenance-exec-downloaded-binary provenance
+# ZIP files need not retain a .zip extension. The detector must still reject
+# an unverified archive passed to unzip under an extensionless local name.
+policy_ 1 provenance-unverified-unzip provenance
 
 # A mistyped pool label in a schedule-only workflow. The trust half of the
 # runners check does not apply to a workflow no fork can reach, and skipping it

--- a/ci/linter/selftest.sh
+++ b/ci/linter/selftest.sh
@@ -269,6 +269,8 @@ policy_ 1 provenance-exec-downloaded-binary provenance
 policy_ 1 provenance-unverified-unzip provenance
 policy_ 1 provenance-chained-unzip provenance
 policy_ 1 provenance-mixed-codeql-unzip provenance
+policy_ 1 provenance-pipe-unzip provenance
+policy_ 1 provenance-subshell-unzip provenance
 
 # A mistyped pool label in a schedule-only workflow. The trust half of the
 # runners check does not apply to a workflow no fork can reach, and skipping it

--- a/ci/linter/selftest.sh
+++ b/ci/linter/selftest.sh
@@ -267,6 +267,8 @@ policy_ 1 provenance-exec-downloaded-binary provenance
 # ZIP files need not retain a .zip extension. The detector must still reject
 # an unverified archive passed to unzip under an extensionless local name.
 policy_ 1 provenance-unverified-unzip provenance
+policy_ 1 provenance-chained-unzip provenance
+policy_ 1 provenance-mixed-codeql-unzip provenance
 
 # A mistyped pool label in a schedule-only workflow. The trust half of the
 # runners check does not apply to a workflow no fork can reach, and skipping it

--- a/ci/linter/workflow_policy.py
+++ b/ci/linter/workflow_policy.py
@@ -627,7 +627,8 @@ def check_cadence() -> int:
 # check): a `tar -xzf` or a direct `./configure`/binary invocation is the
 # actual privilege boundary, not the download line above it.
 EXTRACT_OR_EXEC_RE = re.compile(
-    r"(?<![\w-])tar\s+-?x|(?<![\w-])unzip\b|(?<![\w-])/tmp/actionlint\b"
+    r"(?<![\w-])tar\s+-?x|(?<![\w-])unzip(?:\s+-\S+)*\s+\S+\.zip\b|"
+    r"(?<![\w-])/tmp/actionlint\b"
     # Direct execution of a fetched artifact, without any unpacking step in
     # between: `chmod +x tool && ./tool`, or a bare `./tool` / `./tool/x`
     # invocation. A standalone downloaded executable is the same privilege

--- a/ci/linter/workflow_policy.py
+++ b/ci/linter/workflow_policy.py
@@ -627,7 +627,7 @@ def check_cadence() -> int:
 # check): a `tar -xzf` or a direct `./configure`/binary invocation is the
 # actual privilege boundary, not the download line above it.
 EXTRACT_OR_EXEC_RE = re.compile(
-    r"(?<![\w-])tar\s+-?x|(?m:^[ \t]*unzip(?:\s+-\S+)*\s+\S+)|"
+    r"(?<![\w-])tar\s+-?x|(?m:(?:^[ \t]*|&&[ \t]*|\|\|[ \t]*|;[ \t]*|\bthen[ \t]+)unzip\b)|"
     r"(?<![\w-])/tmp/actionlint\b"
     # Direct execution of a fetched artifact, without any unpacking step in
     # between: `chmod +x tool && ./tool`, or a bare `./tool` / `./tool/x`
@@ -643,7 +643,8 @@ EXTRACT_OR_EXEC_RE = re.compile(
 # CodeQL's pinned analyze action produces this database archive locally. It is
 # not restored by cache or downloaded by the job's wget/curl steps.
 LOCAL_CODEQL_DATABASE_UNZIP_RE = re.compile(
-    r'(?m)^[ \t]*unzip(?:\s+-\S+)*\s+["\']?\$db/src\.zip["\']?\s+-d\s+'
+    r"(?m)(?:^[ \t]*|&&[ \t]*|\|\|[ \t]*|;[ \t]*|\bthen[ \t]+)"
+    r'unzip(?:\s+-\S+)*\s+["\']?\$db/src\.zip["\']?\s+-d\s+'
 )
 
 # What counts as a trust-anchor assertion having been made ON THIS PATH
@@ -731,21 +732,24 @@ def check_provenance() -> int:
                 continue
             anchored = False
             for i, run in enumerate(runs):
-                extract = EXTRACT_OR_EXEC_RE.search(run)
                 # Same-step trust anchors count only before extraction, in
                 # the same order the shell consumes the commands.
-                if (
-                    extract is not None
-                    and not LOCAL_CODEQL_DATABASE_UNZIP_RE.search(run)
-                    and not anchored
-                    and not TRUST_ANCHOR_RE.search(run[: extract.start()])
-                ):
-                    errors.append(
-                        f"{path.name}:{job} step {i + 1} extracts or executes "
-                        "a downloaded artifact with no gpg/sha256 trust-anchor "
-                        "assertion earlier in the job -- verify before "
-                        "extraction/execution, cache-hit path included"
-                    )
+                local_extract_starts = {
+                    match.start()
+                    for match in LOCAL_CODEQL_DATABASE_UNZIP_RE.finditer(run)
+                }
+                for extract in EXTRACT_OR_EXEC_RE.finditer(run):
+                    if extract.start() in local_extract_starts:
+                        continue
+                    if not anchored and not TRUST_ANCHOR_RE.search(
+                        run[: extract.start()]
+                    ):
+                        errors.append(
+                            f"{path.name}:{job} step {i + 1} extracts or executes "
+                            "a downloaded artifact with no gpg/sha256 trust-anchor "
+                            "assertion earlier in the job -- verify before "
+                            "extraction/execution, cache-hit path included"
+                        )
                 # A same-step anchor only protects later commands. Recording
                 # it before the extraction check lets `tar ...; verify ...`
                 # satisfy the gate after untrusted bytes already executed.

--- a/ci/linter/workflow_policy.py
+++ b/ci/linter/workflow_policy.py
@@ -627,7 +627,7 @@ def check_cadence() -> int:
 # check): a `tar -xzf` or a direct `./configure`/binary invocation is the
 # actual privilege boundary, not the download line above it.
 EXTRACT_OR_EXEC_RE = re.compile(
-    r"(?<![\w-])tar\s+-?x|(?<![\w-])unzip(?:\s+-\S+)*\s+\S+\.zip\b|"
+    r"(?<![\w-])tar\s+-?x|(?m:^[ \t]*unzip(?:\s+-\S+)*\s+\S+)|"
     r"(?<![\w-])/tmp/actionlint\b"
     # Direct execution of a fetched artifact, without any unpacking step in
     # between: `chmod +x tool && ./tool`, or a bare `./tool` / `./tool/x`
@@ -638,6 +638,12 @@ EXTRACT_OR_EXEC_RE = re.compile(
     # the network, which is safe here because the whole check is already
     # scoped to jobs that DO fetch something (see DOWNLOAD_RE).
     r"|(?<![\w./-])\./[\w.-]+"
+)
+
+# CodeQL's pinned analyze action produces this database archive locally. It is
+# not restored by cache or downloaded by the job's wget/curl steps.
+LOCAL_CODEQL_DATABASE_UNZIP_RE = re.compile(
+    r'(?m)^[ \t]*unzip(?:\s+-\S+)*\s+["\']?\$db/src\.zip["\']?\s+-d\s+'
 )
 
 # What counts as a trust-anchor assertion having been made ON THIS PATH
@@ -730,6 +736,7 @@ def check_provenance() -> int:
                 # the same order the shell consumes the commands.
                 if (
                     extract is not None
+                    and not LOCAL_CODEQL_DATABASE_UNZIP_RE.search(run)
                     and not anchored
                     and not TRUST_ANCHOR_RE.search(run[: extract.start()])
                 ):

--- a/ci/linter/workflow_policy.py
+++ b/ci/linter/workflow_policy.py
@@ -659,7 +659,8 @@ def is_package_or_comment_token(run: str, token_start: int) -> bool:
     prefix = run[line_start:token_start]
     if prefix.lstrip().startswith("#"):
         return True
-    return bool(re.search(r"\bapt(?:-get)?\s+install\b[^;]*$", prefix))
+    logical_prefix = prefix.replace("\\\n", " ")
+    return bool(re.search(r"\bapt(?:-get)?\s+install\b[^;&|\n]*$", logical_prefix))
 
 
 # What counts as a trust-anchor assertion having been made ON THIS PATH

--- a/ci/linter/workflow_policy.py
+++ b/ci/linter/workflow_policy.py
@@ -627,7 +627,7 @@ def check_cadence() -> int:
 # check): a `tar -xzf` or a direct `./configure`/binary invocation is the
 # actual privilege boundary, not the download line above it.
 EXTRACT_OR_EXEC_RE = re.compile(
-    r"(?<![\w-])tar\s+-?x|(?m:(?:^[ \t]*|&&[ \t]*|\|\|[ \t]*|;[ \t]*|\bthen[ \t]+)unzip\b)|"
+    r"(?<![\w-])tar\s+-?x|(?<![\w-])unzip\b|"
     r"(?<![\w-])/tmp/actionlint\b"
     # Direct execution of a fetched artifact, without any unpacking step in
     # between: `chmod +x tool && ./tool`, or a bare `./tool` / `./tool/x`
@@ -643,9 +643,24 @@ EXTRACT_OR_EXEC_RE = re.compile(
 # CodeQL's pinned analyze action produces this database archive locally. It is
 # not restored by cache or downloaded by the job's wget/curl steps.
 LOCAL_CODEQL_DATABASE_UNZIP_RE = re.compile(
-    r"(?m)(?:^[ \t]*|&&[ \t]*|\|\|[ \t]*|;[ \t]*|\bthen[ \t]+)"
     r'unzip(?:\s+-\S+)*\s+["\']?\$db/src\.zip["\']?\s+-d\s+'
 )
+
+
+def is_package_or_comment_token(run: str, token_start: int) -> bool:
+    """Return whether an extract-token spelling is not a shell invocation."""
+    line_start = run.rfind("\n", 0, token_start) + 1
+    while line_start:
+        previous_end = line_start - 1
+        previous_start = run.rfind("\n", 0, previous_end) + 1
+        if not run[previous_start:previous_end].rstrip().endswith("\\"):
+            break
+        line_start = previous_start
+    prefix = run[line_start:token_start]
+    if prefix.lstrip().startswith("#"):
+        return True
+    return bool(re.search(r"\bapt(?:-get)?\s+install\b[^;]*$", prefix))
+
 
 # What counts as a trust-anchor assertion having been made ON THIS PATH
 # before the extract/exec point. Any one of:
@@ -734,12 +749,11 @@ def check_provenance() -> int:
             for i, run in enumerate(runs):
                 # Same-step trust anchors count only before extraction, in
                 # the same order the shell consumes the commands.
-                local_extract_starts = {
-                    match.start()
-                    for match in LOCAL_CODEQL_DATABASE_UNZIP_RE.finditer(run)
-                }
                 for extract in EXTRACT_OR_EXEC_RE.finditer(run):
-                    if extract.start() in local_extract_starts:
+                    if is_package_or_comment_token(run, extract.start()):
+                        continue
+                    local = LOCAL_CODEQL_DATABASE_UNZIP_RE.search(run, extract.start())
+                    if local is not None and local.start() == extract.start():
                         continue
                     if not anchored and not TRUST_ANCHOR_RE.search(
                         run[: extract.start()]

--- a/ci/tools/test_ci_dependency_bootstrap.sh
+++ b/ci/tools/test_ci_dependency_bootstrap.sh
@@ -93,4 +93,9 @@ require .github/workflows/valgrind.yml 'openssl'
 require .github/workflows/ci-deep.yml 'openssl'
 require .github/workflows/ci-deep.yml 'sudo apt-get install -y clang curl python3'
 
+# CodeQL inspects its database through Python and unpacks src.zip when the
+# action stores extracted sources as an archive.
+require .github/workflows/codeql.yml 'python3'
+require .github/workflows/codeql.yml 'unzip'
+
 echo 'OK: fork fallback dependencies are explicitly bootstrapped'

--- a/ci/tools/test_ci_dependency_bootstrap.sh
+++ b/ci/tools/test_ci_dependency_bootstrap.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# ci/tools/test_ci_dependency_bootstrap.sh -- ensure fork fallbacks install
+# their non-runner dependencies before CI uses them.
+#
+# Usage: ci/tools/test_ci_dependency_bootstrap.sh
+# Inputs: repository .github/workflows/*.yml files.
+# Side effects: none.  Exit non-zero on a missing bootstrap or package.
+
+set -euo pipefail
+
+root=$(git rev-parse --show-toplevel)
+cd "$root"
+
+require() {
+  local file=$1 needle=$2
+  if ! grep -Fq -- "$needle" "$file"; then
+    echo "FAIL: $file must declare $needle for its fork fallback" >&2
+    exit 1
+  fi
+}
+
+require_before() {
+  local file=$1 first=$2 second=$3 first_line second_line
+  first_line=$(grep -n -m1 -F -- "$first" "$file" | cut -d: -f1 || true)
+  second_line=$(grep -n -m1 -F -- "$second" "$file" | cut -d: -f1 || true)
+  if [ -z "$first_line" ] || [ -z "$second_line" ] || [ "$first_line" -ge "$second_line" ]; then
+    echo "FAIL: $file must install curl before resolving nginx" >&2
+    exit 1
+  fi
+}
+
+require_regex() {
+  local file=$1 pattern=$2
+  if ! grep -Eq -- "$pattern" "$file"; then
+    echo "FAIL: $file must declare a matching fork fallback dependency" >&2
+    exit 1
+  fi
+}
+
+# These workflows resolve nginx with curl before their normal package profile.
+# A fork has no vars.POOL, so ubuntu-latest must receive curl explicitly first.
+for file in \
+  .github/workflows/asan.yml \
+  .github/workflows/build-test.yml \
+  .github/workflows/ci-deep.yml \
+  .github/workflows/codeql.yml \
+  .github/workflows/valgrind.yml; do
+  require "$file" 'name: Install bootstrap dependencies'
+done
+
+for file in \
+  .github/workflows/asan.yml \
+  .github/workflows/build-test.yml \
+  .github/workflows/ci-deep.yml \
+  .github/workflows/codeql.yml \
+  .github/workflows/valgrind.yml; do
+  require_before "$file" 'name: Install bootstrap dependencies' \
+    'curl -fsSL https://nginx.org/en/download.html'
+done
+
+# Detached nginx signatures are verified by these fallback workflows.  Do not
+# let their green runs depend on gpg having happened to be in a runner image.
+for file in \
+  .github/workflows/asan.yml \
+  .github/workflows/build-test.yml \
+  .github/workflows/bump.yml \
+  .github/workflows/ci-deep.yml \
+  .github/workflows/codeql.yml \
+  .github/workflows/harness-fault-arms.yml \
+  .github/workflows/security-scanners.yml \
+  .github/workflows/valgrind.yml; do
+  require "$file" 'gnupg'
+done
+
+# Test::Nginx is deliberately installed from its pinned CPAN distribution;
+# semgrep is deliberately installed through pipx/pip.  Keep both paths
+# visible in the workflow rather than assuming a persistent builder carries
+# either tool already.
+require .github/workflows/build-test.yml 'cpanminus'
+# The validation job runs this script through git, while cvary-interop clones
+# the real comparison module.  Check both declarations rather than allowing a
+# package in one job to mask a missing package in the other.
+require_regex .github/workflows/build-test.yml '^[[:space:]]+git[[:space:]]+\\$'
+require .github/workflows/build-test.yml \
+  'sudo apt-get install -y build-essential git gnupg libzstd-dev'
+require .github/workflows/ci-deep.yml 'cpanminus'
+require .github/workflows/security-scanners.yml 'semgrep==1.173.0'
+
+# The soak workers construct their dictionary digest with the openssl CLI;
+# likewise, the deep fuzz failure notification serializes JSON with Python.
+require .github/workflows/asan.yml 'openssl'
+require .github/workflows/valgrind.yml 'openssl'
+require .github/workflows/ci-deep.yml 'openssl'
+require .github/workflows/ci-deep.yml 'sudo apt-get install -y clang curl python3'
+
+echo 'OK: fork fallback dependencies are explicitly bootstrapped'


### PR DESCRIPTION
## TL;DR

Fork-triggered automated checks now install the tools they use instead of relying on builder02 or incidental hosted-runner packages. The fallback setup covers builds, signature verification, tests, scanning, fuzz failure reporting, and scheduled version bumps.

**Severity:** `Low` (`CI reliability — fork fallbacks`)

## Testing

- `ci/linter/run-all.sh`
- `actionlint -color .github/workflows/*.yml`
- `zizmor --no-progress .github/workflows/*.yml`
- `bash ci/tools/test_ci_dependency_bootstrap.sh`
- independent pre-PR review

Checkov still reports its existing CI Deep manual-input policy warning; this change does not alter that workflow input contract.