### PR TITLE
gitattributes: repair reorg-stale byte-exact patterns; gen_dict CRLF gate

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,21 +14,21 @@ auto/* text eol=lf
 # Byte-exact fixtures: fuzz corpus entries are raw Accept-Encoding header
 # bytes and .zst files are compressed frames — any EOL conversion corrupts
 # them.
-fuzz/corpus/* -text
-fuzz/fuzz.dict -text
+ci/fuzz/corpus/* -text
+ci/fuzz/fuzz.dict -text
+*.dict -text
 *.zst binary
 
 # t/suite/test's byte length is asserted verbatim by the static suite
 # (Content-Length and the size half of the ETag) — CRLF smudging changes
 # the on-disk size and fails every identity-response assertion.
-t/suite/* -text
+ci/t/suite/* -text
 
-# CI-only stub modules (linkage-isolation job, vary-suppression witness);
-# keep them out of release tarballs (git archive). The vary stub claims a
-# real third-party module's name and must never ship.
-/tools/ci-linkcheck-module export-ignore
-/tools/ci-compression-vary-stub export-ignore
+# CI-only stub module (linkage-isolation job); keep it out of release
+# tarballs (git archive). Its former sibling, the vary-suppression
+# stub, no longer exists in the tree.
+/ci/tools/ci-linkcheck-module export-ignore
 
 # Patches are applied with git apply against LF checkouts; CRLF
 # smudging would make every context line mismatch.
-tools/patches/** text eol=lf
+ci/tools/patches/** text eol=lf

--- a/ci/fuzz/gen_dict.sh
+++ b/ci/fuzz/gen_dict.sh
@@ -38,10 +38,10 @@ DICT="$DIR/fuzz.dict"
 # would faithfully preserve the CR bytes on the lines it rewrites
 # around. Refuse CR up front, in both modes, with the real diagnosis.
 if [ -f "$DICT" ] && grep -q $'\r' "$DICT"; then
-    echo "✗ gen_dict: $DICT contains CRLF line endings. The dictionary" \
-        "is byte-exact; restore the LF version (git checkout with its" \
-        "-text attribute honored) before regenerating or checking." >&2
-    exit 1
+	echo "✗ gen_dict: $DICT contains CRLF line endings. The dictionary" \
+		"is byte-exact; restore the LF version (git checkout with its" \
+		"-text attribute honored) before regenerating or checking." >&2
+	exit 1
 fi
 
 START_MARK="# BEGIN generated coding tokens (ci/fuzz/gen_dict.sh)"

--- a/ci/fuzz/gen_dict.sh
+++ b/ci/fuzz/gen_dict.sh
@@ -31,6 +31,19 @@ DICT="$DIR/fuzz.dict"
 # shellcheck source=ci/linter/lib.sh
 . "$ROOT/ci/linter/lib.sh"
 
+# The dictionary is byte-exact (its .gitattributes rule is -text), and
+# every consumer of this script compares LINES: a CRLF-contaminated
+# dict makes --check's marker match fail and report "stale tokens" --
+# a misleading diagnosis for a line-ending problem -- while regeneration
+# would faithfully preserve the CR bytes on the lines it rewrites
+# around. Refuse CR up front, in both modes, with the real diagnosis.
+if [ -f "$DICT" ] && grep -q $'\r' "$DICT"; then
+    echo "✗ gen_dict: $DICT contains CRLF line endings. The dictionary" \
+        "is byte-exact; restore the LF version (git checkout with its" \
+        "-text attribute honored) before regenerating or checking." >&2
+    exit 1
+fi
+
 START_MARK="# BEGIN generated coding tokens (ci/fuzz/gen_dict.sh)"
 END_MARK="# END generated coding tokens"
 

--- a/ci/linter/selftest.sh
+++ b/ci/linter/selftest.sh
@@ -76,6 +76,33 @@ case_ 23 "lint work list rejects partial output followed by failure" \
     env MAPFILE_CHECKED_FAULT=partial-error ci/linter/lint-sh.sh ci/linter/lib.sh
 case_ 23 "dictionary work list rejects partial output followed by failure" \
     env MAPFILE_CHECKED_FAULT=partial-error ci/fuzz/gen_dict.sh --check
+
+# shellcheck disable=SC2317  # Invoked indirectly through case_ below.
+dict_crlf_rejected_() (
+    local backup out got mode
+    backup="$(mktemp "${TMPDIR:-/tmp}/fuzz-dict.XXXXXX")" || exit 2
+    cp ci/fuzz/fuzz.dict "$backup" || exit 2
+    trap 'cp "$backup" ci/fuzz/fuzz.dict; rm -f "$backup"' EXIT INT TERM
+    while IFS= read -r line || [ -n "$line" ]; do
+        printf '%s\r\n' "$line"
+    done <"$backup" >ci/fuzz/fuzz.dict
+
+    for mode in check regenerate; do
+        if [ "$mode" = check ]; then
+            out="$(ci/fuzz/gen_dict.sh --check 2>&1)"; got=$?
+        else
+            out="$(ci/fuzz/gen_dict.sh 2>&1)"; got=$?
+        fi
+        if [ "$got" -ne 1 ] ||
+            ! printf '%s\n' "$out" | grep -qF 'contains CRLF line endings'; then
+            printf '%s: expected exit 1 with CRLF diagnosis, got %d\n%s\n' \
+                "$mode" "$got" "$out" >&2
+            exit 1
+        fi
+    done
+)
+case_ 0 "dictionary CRLF rejection covers check and regeneration" \
+    dict_crlf_rejected_
 case_ 23 "coverage work list rejects partial output followed by failure" \
     env MAPFILE_CHECKED_FAULT=partial-error ci/tools/coverage.sh \
         --selftest-work-list "$ROOT"


### PR DESCRIPTION
Found while sweeping CRLF hazards on our side. **Every path-anchored byte-exact rule in .gitattributes went stale when the #127–#141 skeleton reorg moved fuzz/, t/suite/ and tools/ under ci/** — the patterns are directory-anchored, so they silently stopped matching, and `git check-attr` reports `unspecified` on all of them today.

Unprotected since the reorg:

- `ci/fuzz/corpus/*` — raw crafted Accept-Encoding bytes; an autocrlf checkout can corrupt seeds silently.
- `ci/fuzz/fuzz.dict` — byte-exact dictionary (this is how we noticed: a Windows checkout smudged it, and `git add --renormalize` was one keystroke from committing the `\r` bytes).
- `ci/t/suite/*` — the byte-length-asserted static fixtures: a CRLF smudge changes on-disk size and fails every Content-Length/ETag assertion, which is precisely what the rule's own comment warns about.
- `ci/tools/patches/**` (git-apply context lines) and the linkcheck stub's `export-ignore`.

All repointed at their `ci/` homes; the vary-suppression stub's line is dropped (that path no longer exists in the tree); `*.dict -text` added so the next dictionary fixture is protected by default.

**gen_dict.sh** additionally refuses a CRLF-contaminated dictionary up front, in both modes, with the true diagnosis: `--check` compares lines, so a smudged dict previously failed as *"stale coding tokens"* — a misleading report for a line-ending problem — while regeneration would have faithfully preserved the CR bytes on the lines it rewrites around. Proven both directions locally (clean dict passes; a sed-CRLF'd copy fails naming the real cause; restored dict passes again).

Sibling-branch note: the compression branch went further with a `* text=auto eol=lf` catch-all on top of the same repairs — happy to bring that here too if you want it, but this PR keeps to restoring the protection the file already claims to provide.