### PR TITLE
ci: fail closed on sanitizer suite gaps

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1572,13 +1572,19 @@ jobs:
         run: |
           tar -xzf "nginx-${NGINX_VERSION}.tar.gz"
           cd "nginx-${NGINX_VERSION}"
-          SAN="-fsanitize=address,undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g3 -O1"
+          # Recovery is required for the Test::Nginx lane below: upstream
+          # nginx debug logging has known UBSan findings, and a fatal trap
+          # kills its listener before the suite can finish. Reports remain
+          # complete and are graded by module frames after both suites exit.
+          SAN="-fsanitize=address,undefined -fsanitize-recover=undefined -fno-omit-frame-pointer -g3 -O1"
           ./configure \
             --with-compat \
             --with-debug \
             --with-cc-opt="-DZSTD_STATIC_LINKING_ONLY $SAN $(pkg-config --cflags libzstd zlib libpcre2-8)" \
             --with-ld-opt="$SAN $(pkg-config --libs libzstd zlib libpcre2-8)" \
             --with-http_sub_module \
+            --with-http_auth_request_module \
+            --with-http_gzip_static_module \
             --add-module="$GITHUB_WORKSPACE"
           make -j"$(nproc)"
           if grep -q 'NGX_HTTP_ZSTD_HAVE_LIBCRYPTO' objs/ngx_auto_config.h; then
@@ -2095,49 +2101,38 @@ jobs:
       - name: Run Perl suites under ASAN+UBSAN
         # Put the static-file / magic-probe / conditional / HEAD paths (covered
         # only by these Perl suites, audit CI7) through ASan/UBSan. Functional
-        # pass/fail is already gated by the non-ASan `tests` job, so here we
-        # DON'T gate on test results: nginx core
-        # emits benign sanitizer aborts on some Test::Nginx request paths
-        # unrelated to this module. Run non-halting, write ASan reports to
-        # files, and fail ONLY if a sanitizer report names this module's
-        # sources (ngx_http_zstd). detect_leaks=0 because nginx does not free
-        # every allocation at exit by design.
+        # pass/fail is also gated here: a bailout or incomplete TAP stream is
+        # not sanitizer coverage. Upstream nginx core has known UBSan reports
+        # on debug-log paths, so keep recovery enabled, parse complete reports,
+        # and fail when any report contains a zstd-module frame. detect_leaks=0
+        # because nginx does not free every allocation at exit by design.
         env:
           ASAN_OPTIONS: detect_leaks=0:halt_on_error=0:abort_on_error=0:exitcode=0:log_path=/tmp/asan-zstd
-          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=0
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=0:log_path=/tmp/ubsan-zstd
           RUN_ID: ${{ github.run_id }}
           JOB_NAME: ${{ github.job }}
         run: |
           export PERL5LIB="$HOME/perl5/lib/perl5:${PERL5LIB:-}"
-          rm -f /tmp/asan-zstd.*
+          ci/tools/test_sanitizer_suite_verdict.sh
+          rm -f /tmp/asan-zstd.* /tmp/ubsan-zstd.*
           cd "$GITHUB_WORKSPACE"
           export TEST_NGINX_SERVROOT="/tmp/nginx-servroot-asan-${RUN_ID}-${JOB_NAME}"
           mkdir -p "$TEST_NGINX_SERVROOT"
-          perl ci/t/00-filter.t > ci/t/filter-asan.log 2>&1 || true
+          filter_status=0
+          perl ci/t/00-filter.t > ci/t/filter-asan.log 2>&1 || filter_status=$?
           touch -d @1541504307 "$GITHUB_WORKSPACE/ci/t/suite/test" "$GITHUB_WORKSPACE/ci/t/suite/test.zst"
           export TEST_NGINX_SERVROOT="$GITHUB_WORKSPACE/ci/t/servroot-static-${RUN_ID}-${JOB_NAME}"
           mkdir -p "$TEST_NGINX_SERVROOT"
-          perl ci/t/01-static.t > ci/t/static-asan.log 2>&1 || true
+          static_status=0
+          perl ci/t/01-static.t > ci/t/static-asan.log 2>&1 || static_status=$?
 
-          # NOTE (A29-F7, deferred): this lane still cannot tell "no
-          # sanitizer report" from "the suite never ran". A TAP/executed-
-          # count gate was implemented and DID work -- and immediately
-          # went red here, because nginx under ASan stops accepting on
-          # 127.0.0.1:2024 partway through: 00-filter.t bails at TEST 39
-          # and 01-static.t executed 22 of its 774 assertions
-          # (run 33229149473). That is a real, PRE-EXISTING defect this
-          # lane has been masking via `|| true`, not a gate bug. Fixing
-          # the bind failure is a prerequisite for landing the gate, so
-          # the gate is held back rather than shipped red.
-          # Gate strictly on sanitizer reports attributable to this module.
-          if cat /tmp/asan-zstd.* ci/t/filter-asan.log ci/t/static-asan.log 2>/dev/null \
-               | grep -nE 'ngx_http_zstd' \
-               | grep -iE 'runtime error|AddressSanitizer|Sanitizer|overflow|use-after'; then
-            echo "❌ sanitizer report attributable to the zstd module:"
-            cat /tmp/asan-zstd.* 2>/dev/null | grep -B2 -A15 ngx_http_zstd || true
-            exit 1
-          fi
-          echo "✓ no ASAN/UBSAN report attributable to the zstd module"
+          python3 ci/tools/sanitizer_suite_verdict.py \
+            --suite "00-filter.t:ci/t/filter-asan.log:$filter_status" \
+            --suite "01-static.t:ci/t/static-asan.log:$static_status" \
+            --sanitizer-log '/tmp/asan-zstd.*' \
+            --sanitizer-log '/tmp/ubsan-zstd.*' \
+            --sanitizer-log 'ci/t/filter-asan.log' \
+            --sanitizer-log 'ci/t/static-asan.log'
 
       - name: Run smoke tests under ASAN+UBSAN
         # Leak gating here is NOT free: every harness below starts nginx and

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 An nginx module for [Zstandard (zstd)](https://facebook.github.io/zstd/) compression. Zstandard typically achieves better compression ratios than gzip at comparable or faster speeds, making it a good choice for reducing transmitted response sizes.
 
-This is a hardened fork: every PR is exercised against **nginx mainline**, the full test suite runs under **ASAN/UBSAN**, flawfinder/semgrep/clang-tidy run on every change, and a weekly deep pass fuzzes both parser targets and additionally covers **nginx stable** and **[Angie](https://angie.software/)** (see [Testing & CI](#testing--ci)).
+This is a hardened fork: every PR is exercised against **nginx mainline**, the filter/static suites and runtime regressions run under **ASAN/UBSAN**, flawfinder/semgrep/clang-tidy run on every change, and a weekly deep pass fuzzes both parser targets and additionally covers **nginx stable** and **[Angie](https://angie.software/)** (see [Testing & CI](#testing--ci)).
 
 # Table of Contents
 
@@ -1332,7 +1332,7 @@ documented `ubuntu-latest` fallback instead.
 |---|---|---|
 | **CI** ([`ci.yml`](.github/workflows/ci.yml)) | every PR + focused merged `master` signal + manual | Calls only Lint, Build&Test, Security Scanners, Harness Fault Arms, and the hosted Windows build. Four Linux jobs are initially runnable; dependency chains refill each lane as it becomes free. Only Harness Fault Arms runs on merged `master`. |
 | **Lint** ([`lint.yml`](.github/workflows/lint.yml)) | PR via CI + manual | Runs local deterministic checks, including runner trust, port bands, cadence, provenance, and the enforced four-lane topology. |
-| **Build&Test** ([`build-test.yml`](.github/workflows/build-test.yml)) | PR via CI + manual | Builds nginx mainline with strict warnings, runs the full Test::Nginx and runtime regression suites, tests libzstd 1.4.x fallbacks, linkage variants, arm64, and the full suite under ASAN/UBSAN. Its dependency graph forms four self-hosted lane chains. |
+| **Build&Test** ([`build-test.yml`](.github/workflows/build-test.yml)) | PR via CI + manual | Builds nginx mainline with strict warnings, runs the full functional and runtime regression suites, tests libzstd 1.4.x fallbacks, linkage variants, and arm64. Its sanitizer lane runs the filter and static Test::Nginx suites plus the runtime regressions under ASAN/UBSAN, requiring complete TAP/clean exits and rejecting complete sanitizer reports that contain module frames. Its dependency graph forms four self-hosted lane chains. |
 | **Security Scanners** ([`security-scanners.yml`](.github/workflows/security-scanners.yml)) | PR via CI, weekly deep + manual | Runs flawfinder, clang-tidy, and semgrep over the module sources. |
 | **Harness Fault Arms** ([`harness-fault-arms.yml`](.github/workflows/harness-fault-arms.yml)) | PR and merged `master` via CI + manual, not required | Builds with the shared [`nginx-module-testkit`](https://github.com/myguard-labs/nginx-module-testkit) and runs all six fault, allocation, codec-count, and parameter-count scenarios through one non-vacuous scenario runner. |
 | **Windows build** ([`windows-build.yml`](.github/workflows/windows-build.yml)) | PR via CI + manual | Builds and smoke-checks MSVC x64 static and MinGW-w64 x64 dynamic modules. |

--- a/ci/tools/sanitizer_suite_verdict.py
+++ b/ci/tools/sanitizer_suite_verdict.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Fail closed on incomplete TAP suites and module-attributable sanitizer reports."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import re
+import sys
+from pathlib import Path
+
+FINDING = re.compile(
+    r"(?:(?:Address|Leak|UndefinedBehavior)Sanitizer:|runtime error:)",
+    re.IGNORECASE,
+)
+MODULE = re.compile(r"(?:src/)?ngx_http_zstd(?:_[A-Za-z0-9_]+)?", re.IGNORECASE)
+PLAN = re.compile(r"^1\.\.([0-9]+)(?:\s*#.*)?$")
+RESULT = re.compile(r"^(?:not )?ok\s+([0-9]+)(?:\s|$)")
+LOG_MARKER = re.compile(
+    r"^(?:Bail out!|(?:not )?ok\s|1\.\.[0-9]+|"
+    r"[0-9]{4}/[0-9]{2}/[0-9]{2} [0-9:]+ \[[a-z]+\])"
+)
+
+
+def check_suite(spec: str) -> bool:
+    try:
+        label, path_text, status_text = spec.split(":", 2)
+        status = int(status_text)
+    except ValueError:
+        print(
+            f"invalid --suite value: {spec!r}; expected LABEL:PATH:STATUS",
+            file=sys.stderr,
+        )
+        return False
+
+    path = Path(path_text)
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as exc:
+        print(f"{label}: cannot read TAP log {path}: {exc}", file=sys.stderr)
+        return False
+
+    ok = True
+    if status != 0:
+        print(f"{label}: suite exited {status}, expected 0", file=sys.stderr)
+        ok = False
+    if any(line.startswith("Bail out!") for line in lines):
+        print(f"{label}: TAP bailout reported", file=sys.stderr)
+        ok = False
+    if any(line.startswith("not ok ") for line in lines):
+        print(f"{label}: failing TAP result reported", file=sys.stderr)
+        ok = False
+
+    plans = [int(match.group(1)) for line in lines if (match := PLAN.match(line))]
+    results = [int(match.group(1)) for line in lines if (match := RESULT.match(line))]
+    if len(plans) != 1:
+        print(
+            f"{label}: expected exactly one TAP plan, found {len(plans)}",
+            file=sys.stderr,
+        )
+        return False
+    plan = plans[0]
+    if plan <= 0 or len(results) != plan or sorted(results) != list(range(1, plan + 1)):
+        print(
+            f"{label}: TAP results do not exactly satisfy plan 1..{plan} "
+            f"({len(results)} result lines)",
+            file=sys.stderr,
+        )
+        ok = False
+    if ok:
+        print(f"{label}: suite exit 0 and all {plan} TAP results reported")
+    return ok
+
+
+def finding_blocks(text: str) -> list[str]:
+    lines = text.splitlines()
+    starts = [index for index, line in enumerate(lines) if FINDING.search(line)]
+    blocks = []
+    for pos, start in enumerate(starts):
+        end = starts[pos + 1] if pos + 1 < len(starts) else len(lines)
+        for index in range(start + 1, end):
+            if LOG_MARKER.match(lines[index]):
+                end = index
+                break
+        blocks.append("\n".join(lines[start:end]))
+    return blocks
+
+
+def check_sanitizers(patterns: list[str]) -> bool:
+    paths = sorted({path for pattern in patterns for path in glob.glob(pattern)})
+    if not paths:
+        print("no sanitizer report/log files were produced", file=sys.stderr)
+        return False
+
+    attributable: list[tuple[str, str]] = []
+    findings = 0
+    for path_text in paths:
+        text = Path(path_text).read_text(encoding="utf-8", errors="replace")
+        for block in finding_blocks(text):
+            findings += 1
+            if MODULE.search(block):
+                attributable.append((path_text, block))
+
+    if attributable:
+        print("sanitizer finding attributable to the zstd module:", file=sys.stderr)
+        for path_text, block in attributable:
+            print(f"--- {path_text} ---", file=sys.stderr)
+            print(block, file=sys.stderr)
+        return False
+    print(
+        f"no module-attributable sanitizer finding in {len(paths)} log(s); "
+        f"parsed {findings} report(s)"
+    )
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--suite", action="append", default=[], metavar="LABEL:PATH:STATUS"
+    )
+    parser.add_argument("--sanitizer-log", action="append", default=[], metavar="GLOB")
+    args = parser.parse_args()
+    if not args.suite or not args.sanitizer_log:
+        parser.error("at least one --suite and --sanitizer-log are required")
+    suite_results = [check_suite(spec) for spec in args.suite]
+    suite_ok = all(suite_results)
+    sanitizer_ok = check_sanitizers(args.sanitizer_log)
+    return 0 if suite_ok and sanitizer_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/tools/test_sanitizer_suite_verdict.sh
+++ b/ci/tools/test_sanitizer_suite_verdict.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VERDICT="$ROOT/ci/tools/sanitizer_suite_verdict.py"
+WORK="$(mktemp -d "$ROOT/.sanitizer-verdict-test.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+cat >"$WORK/suite.tap" <<'EOF'
+ok 1 - first
+ok 2 - second
+1..2
+EOF
+cat >"$WORK/core.log" <<'EOF'
+nginx.c:10:3: runtime error: core-only undefined behavior
+    #0 0x123 in ngx_worker_process_cycle nginx/src/os/unix/ngx_process_cycle.c:1
+EOF
+
+python3 "$VERDICT" --suite "fixture:$WORK/suite.tap:0" \
+	--sanitizer-log "$WORK/core.log" >/dev/null
+
+cat >"$WORK/core-with-later-module-log.log" <<'EOF'
+nginx.c:10:3: runtime error: core-only undefined behavior
+    #0 0x123 in ngx_worker_process_cycle nginx/src/os/unix/ngx_process_cycle.c:1
+2026/08/31 12:00:00 [notice] 12#12: harmless ngx_http_zstd_body_filter diagnostic
+EOF
+python3 "$VERDICT" --suite "fixture:$WORK/suite.tap:0" \
+	--sanitizer-log "$WORK/core-with-later-module-log.log" >/dev/null
+
+cat >"$WORK/module.log" <<'EOF'
+==12==ERROR: AddressSanitizer: heap-use-after-free on address 0x123
+    #0 0x123 in memcpy sanitizer_common_interceptors.inc:1
+    #1 0x456 in ngx_http_zstd_body_filter src/ngx_http_zstd_filter_module.c:512
+SUMMARY: AddressSanitizer: heap-use-after-free sanitizer_common_interceptors.inc:1
+EOF
+if python3 "$VERDICT" --suite "fixture:$WORK/suite.tap:0" \
+	--sanitizer-log "$WORK/module.log" >/dev/null 2>&1; then
+	echo "FAIL: split-line-module-frame mutant was not rejected" >&2
+	exit 1
+fi
+
+cat >"$WORK/lsan-module.log" <<'EOF'
+==12==ERROR: LeakSanitizer: detected memory leaks
+
+Direct leak of 64 byte(s) in 1 object(s) allocated from:
+    #0 0x123 in malloc sanitizer_common_interceptors.inc:1
+    #1 0x456 in ngx_http_zstd_body_filter src/ngx_http_zstd_filter_module.c:512
+SUMMARY: AddressSanitizer: 64 byte(s) leaked in 1 allocation(s).
+EOF
+if python3 "$VERDICT" --suite "fixture:$WORK/suite.tap:0" \
+	--sanitizer-log "$WORK/lsan-module.log" >/dev/null 2>&1; then
+	echo "FAIL: split-line LSan module frame was not rejected" >&2
+	exit 1
+fi
+
+cat "$WORK/core.log" "$WORK/module.log" >"$WORK/multiple.log"
+if python3 "$VERDICT" --suite "fixture:$WORK/suite.tap:0" \
+	--sanitizer-log "$WORK/multiple.log" >/dev/null 2>&1; then
+	echo "FAIL: later module-attributable report was not rejected" >&2
+	exit 1
+fi
+
+if python3 "$VERDICT" --suite "fixture:$WORK/suite.tap:23" \
+	--sanitizer-log "$WORK/core.log" >/dev/null 2>&1; then
+	echo "FAIL: ignored-suite-exit mutant was not rejected" >&2
+	exit 1
+fi
+
+sed 's/^1\.\.2$/1..3/' "$WORK/suite.tap" >"$WORK/truncated.tap"
+if python3 "$VERDICT" --suite "fixture:$WORK/truncated.tap:0" \
+	--sanitizer-log "$WORK/core.log" >/dev/null 2>&1; then
+	echo "FAIL: truncated TAP plan was not rejected" >&2
+	exit 1
+fi
+
+echo "sanitizer suite verdict tests passed"


### PR DESCRIPTION
## TL;DR

The deep checks could report success after a test process failed early or produced incomplete results. This makes those checks verify completion and inspect every diagnostic report before accepting the run.

**Severity:** Major — a false-green deep check could hide a module-attributable memory-safety finding.

## What changed

- Preserve each sanitizer test process exit status instead of losing it through output capture.
- Require one complete TAP plan with every expected result present and no bailout or failing result.
- Parse all produced ASan, UBSan, and LSan reports, failing when a report contains a zstd module frame.
- Fail closed when expected report files are absent.
- Correct the README description to match the enforced behavior.

## Testing

- `./ci/tools/test_sanitizer_suite_verdict.sh`
- `/opt/myguard/.claude/skills/_shared/review-lint.sh --branch origin/master`
- Commit hooks: Python formatting, actionlint, shellcheck, secret checks, and staged policy checks passed.
- Local CodeRabbit review completed with zero findings on the final uncommitted diff.
- Three independent review rounds completed; two confirmed report-boundary defects were fixed, and the final round was clean.

Negative controls prove that non-zero suite exits, truncated TAP output, split-line module frames, and later module-attributable reports are rejected. Controls also prove that a core-only report followed by unrelated module diagnostic text remains accepted.

## Security considerations

This changes CI verdict handling only. It does not change runtime module behavior. Report attribution remains format-based and covers the sanitizer and log formats exercised by the workflow tests.