### PR TITLE
ci: harden assurance sweep

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -186,6 +186,7 @@ jobs:
             cppcheck \
             clang-tools \
             python3 \
+            python3-yaml \
             nginx-dev
 
       - name: Validate tool scripts (syntax only)

--- a/.github/workflows/ci-deep.yml
+++ b/.github/workflows/ci-deep.yml
@@ -344,6 +344,7 @@ jobs:
           [ -z "$FUZZ_DICT_ARG" ] || extra+=("$FUZZ_DICT_ARG")
           "./$FUZZ_BINARY" \
             -max_total_time="$FUZZ_SECS" \
+            -max_len=65536 \
             "${extra[@]}" \
             -print_final_stats=1 \
             -artifact_prefix="$FUZZ_ARTIFACT_PREFIX" \

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -127,9 +127,13 @@ jobs:
         run: |
           set -euo pipefail
           cd ci/fuzz
+          for size in 4095 4096 4097 65535 65536; do
+            head -c "$size" /dev/zero >"corpus/boundary-$size"
+          done
           set +e
           ./fuzz_accept_encoding \
             -max_total_time=120 \
+            -max_len=65536 \
             -dict=fuzz.dict \
             -print_final_stats=1 \
             -artifact_prefix=crash- \
@@ -143,9 +147,13 @@ jobs:
         run: |
           set -euo pipefail
           cd ci/fuzz
+          for size in 4095 4096 4097 65535 65536; do
+            head -c "$size" /dev/zero >"corpus_dcz/boundary-$size"
+          done
           set +e
           ./fuzz_dcz \
             -max_total_time=120 \
+            -max_len=65536 \
             -print_final_stats=1 \
             -artifact_prefix=crash-dcz- \
             corpus_dcz/

--- a/.github/workflows/security-scanners.yml
+++ b/.github/workflows/security-scanners.yml
@@ -86,8 +86,10 @@ jobs:
         # lint-c.sh in the SAME commit.
         run: |
           set -o pipefail
-          mapfile -d '' files < <(find "$GITHUB_WORKSPACE/src" "$GITHUB_WORKSPACE/ci" \
-            -type f \( -name '*.c' -o -name '*.h' \) -print0)
+          source "$GITHUB_WORKSPACE/ci/linter/lib.sh"
+          mapfile_checked files find "$GITHUB_WORKSPACE/src" "$GITHUB_WORKSPACE/ci" \
+            -type f \( -name '*.c' -o -name '*.h' \) -print
+          [ "${#files[@]}" -gt 0 ] || { echo 'no C scanner targets found' >&2; exit 1; }
           flawfinder --minlevel=4 --error-level=4 "${files[@]}" \
             2>&1 | tee flawfinder.log
       - name: clang-tidy (cert-*, security.*)
@@ -118,10 +120,14 @@ jobs:
         # this step could never fail on a real finding.
         run: |
           set -o pipefail
+          source "$GITHUB_WORKSPACE/ci/linter/lib.sh"
+          mapfile_checked files find "$GITHUB_WORKSPACE/src" "$GITHUB_WORKSPACE/ci" \
+            -type f \( -name '*.c' -o -name '*.h' \) -print
+          [ "${#files[@]}" -gt 0 ] || { echo 'no C scanner targets found' >&2; exit 1; }
           semgrep scan --config p/c --config p/security-audit \
             --severity=WARNING --severity=ERROR --error \
             --jobs=1 --metrics=off \
-            "$GITHUB_WORKSPACE/src/" "$GITHUB_WORKSPACE/ci/" 2>&1 | tee semgrep.log
+            "${files[@]}" 2>&1 | tee semgrep.log
       - name: Upload reports
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/security-scanners.yml
+++ b/.github/workflows/security-scanners.yml
@@ -86,9 +86,10 @@ jobs:
         # lint-c.sh in the SAME commit.
         run: |
           set -o pipefail
-          flawfinder --minlevel=4 --error-level=4 \
-            "$GITHUB_WORKSPACE/src/ngx_http_zstd_filter_module.c" \
-            "$GITHUB_WORKSPACE/src/ngx_http_zstd_static_module.c" 2>&1 | tee flawfinder.log
+          mapfile -d '' files < <(find "$GITHUB_WORKSPACE/src" "$GITHUB_WORKSPACE/ci" \
+            -type f \( -name '*.c' -o -name '*.h' \) -print0)
+          flawfinder --minlevel=4 --error-level=4 "${files[@]}" \
+            2>&1 | tee flawfinder.log
       - name: clang-tidy (cert-*, security.*)
         run: |
           set -euo pipefail
@@ -120,7 +121,7 @@ jobs:
           semgrep scan --config p/c --config p/security-audit \
             --severity=WARNING --severity=ERROR --error \
             --jobs=1 --metrics=off \
-            "$GITHUB_WORKSPACE/src/" 2>&1 | tee semgrep.log
+            "$GITHUB_WORKSPACE/src/" "$GITHUB_WORKSPACE/ci/" 2>&1 | tee semgrep.log
       - name: Upload reports
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -153,7 +153,7 @@ repos:
         name: flawfinder (gate on >=4)
         entry: flawfinder --minlevel=4 --error-level=4 --quiet
         language: system
-        files: '^src/.*\.[ch]$'
+        files: '^(src|ci)/.*\.[ch]$'
         pass_filenames: true
 
       # Mirrors the CI "semgrep (gate on >=WARNING)" step, same configs and
@@ -187,7 +187,7 @@ repos:
         entry: semgrep scan --jobs=1 --config p/c --config p/security-audit
                --severity=WARNING --severity=ERROR --error
         language: system
-        files: '^src/.*\.[ch]$'
+        files: '^(src|ci)/.*\.[ch]$'
         pass_filenames: true
         require_serial: true
 
@@ -215,7 +215,7 @@ repos:
                --suppress=normalCheckLevelMaxBranches --suppress=unusedFunction
                --suppress=unusedStructMember -I src -DNGX_PTR_SIZE=8
         language: system
-        files: '^src/.*\.[ch]$'
+        files: '^(src|ci)/.*\.[ch]$'
         pass_filenames: true
 
       # Structural sink sweep: this superrepo's own c-* / nginx-* rules plus

--- a/ci/linter/fixtures/semgrep-blocking.c.fixture
+++ b/ci/linter/fixtures/semgrep-blocking.c.fixture
@@ -1,0 +1,7 @@
+#include <string.h>
+
+void
+copy_untrusted(char *destination, const char *source)
+{
+    strcpy(destination, source);
+}

--- a/ci/linter/lint-c.sh
+++ b/ci/linter/lint-c.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# ci/linter/lint-c.sh -- C static analysis for src/*.[ch].
+# ci/linter/lint-c.sh -- C static analysis for src/ and ci/ *.[ch].
 #
 # Mirrors .github/workflows/security-scanners.yml exactly:
 #   flawfinder  gate at >=4   (below 4 is risky-API grep noise; gating on it
@@ -26,7 +26,7 @@
 # shellcheck source=ci/linter/lib.sh
 . "$(git rev-parse --show-toplevel)/ci/linter/lib.sh"
 
-mapfile_checked FILES lint_files '^src/.*\.[ch]$' "$@"
+mapfile_checked FILES lint_files '^(src|ci)/.*\.[ch]$' "$@"
 [ "${#FILES[@]}" -gt 0 ] || { echo "lint-c: no C files to check"; exit 0; }
 
 echo "lint-c: ${#FILES[@]} file(s)"

--- a/ci/tools/lsan_log_verdict.sh
+++ b/ci/tools/lsan_log_verdict.sh
@@ -21,7 +21,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=ci/tools/lsan_positive_control.sh
 . "$SCRIPT_DIR/lsan_positive_control.sh"
 
-LSAN_FINDING_RE='ERROR: (Address|Leak)Sanitizer|SUMMARY: (Address|Leak)Sanitizer'
+LSAN_FINDING_RE='ERROR: (Address|Leak|UndefinedBehavior)Sanitizer|SUMMARY: (Address|Leak|UndefinedBehavior)Sanitizer|runtime error:'
 LSAN_FAILURE_RE='Failed suspending threads|Failed spawning a tracer thread|Waiting on the tracer thread failed|LeakSanitizer has encountered a fatal error'
 LSAN_PREFLIGHT_RE='ptrace appears to be blocked|LeakSanitizer may hang|Child exited with signal'
 

--- a/ci/tools/soak.sh
+++ b/ci/tools/soak.sh
@@ -92,7 +92,7 @@ EOF
 
 export DICT_B64
 
-ASAN_OPTIONS="${ASAN_OPTIONS:-}:detect_leaks=1:abort_on_error=1:exitcode=42:log_path=$WORK/logs/asan"
+ASAN_OPTIONS="${ASAN_OPTIONS:-}:detect_leaks=1:verbosity=1:abort_on_error=1:exitcode=42:log_path=$WORK/logs/asan"
 export ASAN_OPTIONS
 export UBSAN_OPTIONS="${UBSAN_OPTIONS:-}:print_stacktrace=1:halt_on_error=1"
 
@@ -267,16 +267,16 @@ kill -QUIT "$NGINX_PID" 2>/dev/null || true
 wait "$NGINX_PID" 2>/dev/null
 rc=$?
 
-# shellcheck source=ci/tools/soak_asan_verdict.sh
-. "$(cd "$(dirname "$0")" && pwd)/soak_asan_verdict.sh"
+# shellcheck source=ci/tools/lsan_log_verdict.sh
+. "$(cd "$(dirname "$0")" && pwd)/lsan_log_verdict.sh"
 
 problems=0
 indeterminate=0
-if ls "$WORK"/logs/asan* >/dev/null 2>&1; then
+if compgen -G "$WORK/logs/asan*" >/dev/null; then
     echo "ASAN/UBSAN log:"
     cat "$WORK"/logs/asan*
     set +e
-    soak_asan_verdict "$WORK"/logs/asan*
+    lsan_check_log_glob "$WORK/logs/asan*"
     asan_rc=$?
     set -e
     case "$asan_rc" in
@@ -293,6 +293,9 @@ if ls "$WORK"/logs/asan* >/dev/null 2>&1; then
             problems=1
             ;;
     esac
+else
+    echo '::warning::LeakSanitizer produced no verbose exit-hook log; soak leak check INDETERMINATE'
+    indeterminate=1
 fi
 if ls "$WORK"/logs/valgrind.* "$WORK"/logs/helgrind.* >/dev/null 2>&1; then
     if grep -qE 'ERROR SUMMARY: [1-9]|definitely lost: [1-9]' \

--- a/ci/tools/test_ci_dependency_bootstrap.sh
+++ b/ci/tools/test_ci_dependency_bootstrap.sh
@@ -8,8 +8,51 @@
 
 set -euo pipefail
 
-root=$(git rev-parse --show-toplevel)
+root=${CI_DEPENDENCY_ROOT:-$(git rev-parse --show-toplevel)}
 cd "$root"
+
+require_apt_package() {
+  local file=$1 package=$2
+  local base=${CI_DEPENDENCY_ROOT:-$root}
+  python3 - "$base/$file" "$package" <<'PY'
+import pathlib, shlex, sys, yaml
+
+path, wanted = pathlib.Path(sys.argv[1]), sys.argv[2]
+doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+for job in (doc.get("jobs") or {}).values():
+    for step in job.get("steps", []) if isinstance(job, dict) else []:
+        run = step.get("run") if isinstance(step, dict) else None
+        if not isinstance(run, str):
+            continue
+        logical = run.replace("\\\n", " ")
+        for line in logical.splitlines():
+            try:
+                lexer = shlex.shlex(line, posix=True, punctuation_chars=";&|")
+                lexer.whitespace_split = True
+                lexer.commenters = "#"
+                words = list(lexer)
+            except ValueError:
+                continue
+            start = 0
+            for end in [
+                *[i for i, word in enumerate(words) if word in {";", "&&", "||", "|"}],
+                len(words),
+            ]:
+                command = words[start:end]
+                start = end + 1
+                apt = 1 if command[:1] == ["sudo"] else 0
+                if len(command) > apt and command[apt] == "apt-get" \
+                        and "install" in command[apt + 1:]:
+                    install = command.index("install", apt + 1)
+                    packages = {
+                        w for w in command[install + 1:] if not w.startswith("-")
+                    }
+                    if wanted in packages:
+                        raise SystemExit(0)
+print(f"FAIL: {path} must install apt package {wanted}", file=sys.stderr)
+raise SystemExit(1)
+PY
+}
 
 require() {
   local file=$1 needle=$2
@@ -69,33 +112,57 @@ for file in \
   .github/workflows/harness-fault-arms.yml \
   .github/workflows/security-scanners.yml \
   .github/workflows/valgrind.yml; do
-  require "$file" 'gnupg'
+  require_apt_package "$file" gnupg
 done
 
 # Test::Nginx is deliberately installed from its pinned CPAN distribution;
 # semgrep is deliberately installed through pipx/pip.  Keep both paths
 # visible in the workflow rather than assuming a persistent builder carries
 # either tool already.
-require .github/workflows/build-test.yml 'cpanminus'
+require_apt_package .github/workflows/build-test.yml cpanminus
 # The validation job runs this script through git, while cvary-interop clones
 # the real comparison module.  Check both declarations rather than allowing a
 # package in one job to mask a missing package in the other.
 require_regex .github/workflows/build-test.yml '^[[:space:]]+git[[:space:]]+\\$'
 require .github/workflows/build-test.yml \
   'sudo apt-get install -y build-essential git gnupg libzstd-dev'
-require .github/workflows/ci-deep.yml 'cpanminus'
+require_apt_package .github/workflows/ci-deep.yml cpanminus
 require .github/workflows/security-scanners.yml 'semgrep==1.173.0'
 
 # The soak workers construct their dictionary digest with the openssl CLI;
 # likewise, the deep fuzz failure notification serializes JSON with Python.
-require .github/workflows/asan.yml 'openssl'
-require .github/workflows/valgrind.yml 'openssl'
-require .github/workflows/ci-deep.yml 'openssl'
-require .github/workflows/ci-deep.yml 'sudo apt-get install -y clang curl python3'
+require_apt_package .github/workflows/asan.yml openssl
+require_apt_package .github/workflows/valgrind.yml openssl
+require_apt_package .github/workflows/ci-deep.yml openssl
+require_apt_package .github/workflows/ci-deep.yml clang
+require_apt_package .github/workflows/ci-deep.yml curl
+require_apt_package .github/workflows/ci-deep.yml python3
 
 # CodeQL inspects its database through Python and unpacks src.zip when the
 # action stores extracted sources as an archive.
-require .github/workflows/codeql.yml 'python3'
-require .github/workflows/codeql.yml 'unzip'
+require_apt_package .github/workflows/codeql.yml python3
+require_apt_package .github/workflows/codeql.yml unzip
+# The dependency parser itself uses yaml.safe_load; keep that import available
+# in the validation job that executes this script.
+require_apt_package .github/workflows/build-test.yml python3-yaml
+
+# Negative control: comments are not package installations.
+mutant=$(mktemp -d "${TMPDIR:-/tmp}/dependency-bootstrap.XXXXXX")
+trap 'rm -rf "$mutant"' EXIT
+mkdir -p "$mutant/.github/workflows"
+cp .github/workflows/asan.yml "$mutant/.github/workflows/asan.yml"
+sed -i 's/gnupg/libgcrypt20-dev/g' "$mutant/.github/workflows/asan.yml"
+printf '\n# gnupg was removed from the apt install above\n' \
+  >>"$mutant/.github/workflows/asan.yml"
+sed -i '/set -euo pipefail/a\          echo install gnupg' \
+  "$mutant/.github/workflows/asan.yml"
+sed -i '/set -euo pipefail/a\          echo "apt-get install gnupg"' \
+  "$mutant/.github/workflows/asan.yml"
+if CI_DEPENDENCY_ROOT="$mutant" require_apt_package \
+    .github/workflows/asan.yml gnupg >/dev/null 2>&1; then
+  echo 'FAIL: dependency comment mutant was accepted as an installation' >&2
+  exit 1
+fi
+echo 'OK: dependency comment mutant rejected'
 
 echo 'OK: fork fallback dependencies are explicitly bootstrapped'

--- a/ci/tools/test_ci_scanner_fuzz_boundaries.sh
+++ b/ci/tools/test_ci_scanner_fuzz_boundaries.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Gate CI C scanner selectors and the production-sized fuzz domain.
+set -euo pipefail
+
+root=$(git rev-parse --show-toplevel)
+cd "$root"
+
+assert_contract() {
+  local base=${1:-.}
+  grep -Fq "'^(src|ci)/.*\.[ch]$'" "$base/ci/linter/lint-c.sh" || return 1
+  [ "$(grep -Fc "files: '^(src|ci)/.*\.[ch]$'" "$base/.pre-commit-config.yaml")" -ge 3 ] \
+    || return 1
+  # The workflow expression is intentionally literal.
+  # shellcheck disable=SC2016
+  grep -Fq '"$GITHUB_WORKSPACE/ci/"' \
+    "$base/.github/workflows/security-scanners.yml" || return 1
+  # shellcheck disable=SC2016
+  grep -Fq 'find "$GITHUB_WORKSPACE/src" "$GITHUB_WORKSPACE/ci"' \
+    "$base/.github/workflows/security-scanners.yml" || return 1
+  [ "$(grep -Fc -- '-max_len=65536' "$base/.github/workflows/fuzzing.yml")" -ge 2 ] \
+    || return 1
+  grep -Fq -- '-max_len=65536' "$base/.github/workflows/ci-deep.yml" \
+    || return 1
+  grep -Fq 'for size in 4095 4096 4097 65535 65536' \
+    "$base/.github/workflows/fuzzing.yml" || return 1
+}
+
+assert_contract
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/scanner-fuzz-contract.XXXXXX")
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/ci/linter"
+cp ci/linter/lint-c.sh "$work/ci/linter/"
+cp .pre-commit-config.yaml "$work/"
+cp -a .github "$work/"
+sed -i 's/(src|ci)/src/g; s/65536/4096/g' \
+  "$work/ci/linter/lint-c.sh" "$work/.pre-commit-config.yaml" \
+  "$work/.github/workflows/security-scanners.yml" "$work/.github/workflows/fuzzing.yml" \
+  "$work/.github/workflows/ci-deep.yml"
+if assert_contract "$work" >/dev/null 2>&1; then
+  echo 'FAIL: scanner/max_len mutant did not make the contract gate red' >&2
+  exit 1
+fi
+assert_contract
+echo 'OK: CI C scanner selectors and >4096 fuzz boundaries are enforced'

--- a/ci/tools/test_ci_scanner_fuzz_boundaries.sh
+++ b/ci/tools/test_ci_scanner_fuzz_boundaries.sh
@@ -10,13 +10,31 @@ assert_contract() {
   grep -Fq "'^(src|ci)/.*\.[ch]$'" "$base/ci/linter/lint-c.sh" || return 1
   [ "$(grep -Fc "files: '^(src|ci)/.*\.[ch]$'" "$base/.pre-commit-config.yaml")" -ge 3 ] \
     || return 1
-  # The workflow expression is intentionally literal.
-  # shellcheck disable=SC2016
-  grep -Fq '"$GITHUB_WORKSPACE/ci/"' \
-    "$base/.github/workflows/security-scanners.yml" || return 1
-  # shellcheck disable=SC2016
-  grep -Fq 'find "$GITHUB_WORKSPACE/src" "$GITHUB_WORKSPACE/ci"' \
-    "$base/.github/workflows/security-scanners.yml" || return 1
+  # Check each owning step independently: both must use checked discovery and
+  # pass the explicit C-file array rather than a directory to the scanner.
+  python3 - "$base/.github/workflows/security-scanners.yml" <<'PY' || return 1
+import pathlib, re, sys, yaml
+
+doc = yaml.safe_load(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+steps = doc["jobs"]["scanners"]["steps"]
+for name, command in (("flawfinder", "flawfinder"), ("semgrep", "semgrep scan")):
+    run = next(step["run"] for step in steps if step.get("name") == name)
+    required = (
+        'mapfile_checked files find',
+        '"$GITHUB_WORKSPACE/src" "$GITHUB_WORKSPACE/ci"',
+        "-name '*.c'", "-name '*.h'",
+        '[ "${#files[@]}" -gt 0 ]',
+    )
+    if not all(token in run for token in required):
+        raise SystemExit(f"{name} does not discover checked src+ci C/H targets")
+    invocation = rf'^\s*{re.escape(command)}\b.*?"\$\{{files\[@\]\}}".*?\|\s*tee'
+    if re.search(invocation, run, re.MULTILINE | re.DOTALL) is None:
+        raise SystemExit(f"{name} command does not consume the C target array")
+    if name == "flawfinder" and "--error-level=4" not in run:
+        raise SystemExit("flawfinder findings are not blocking at level 4")
+    if name == "semgrep" and re.search(r'(?<![-\w])--error(?![-\w])', run) is None:
+        raise SystemExit("Semgrep findings are not blocking")
+PY
   [ "$(grep -Fc -- '-max_len=65536' "$base/.github/workflows/fuzzing.yml")" -ge 2 ] \
     || return 1
   grep -Fq -- '-max_len=65536' "$base/.github/workflows/ci-deep.yml" \
@@ -42,4 +60,23 @@ if assert_contract "$work" >/dev/null 2>&1; then
   exit 1
 fi
 assert_contract
+
+# The exact CI Semgrep profiles must still block a real C finding. Keep the
+# source under a non-C suffix so the repository's normal widened scan stays
+# clean; copy it to the temporary C target only for this negative control.
+if command -v semgrep >/dev/null 2>&1; then
+	cp ci/linter/fixtures/semgrep-blocking.c.fixture "$work/blocking.c"
+	set +e
+	semgrep scan --config p/c --config p/security-audit \
+		--severity=WARNING --severity=ERROR --error --jobs=1 --metrics=off \
+		"$work/blocking.c" >"$work/semgrep-negative.log" 2>&1
+	semgrep_rc=$?
+	set -e
+	if [ "$semgrep_rc" -ne 1 ]; then
+		echo "FAIL: Semgrep negative control returned $semgrep_rc, want finding status 1" >&2
+		cat "$work/semgrep-negative.log" >&2
+		exit 1
+	fi
+  echo 'OK: Semgrep C finding remains blocking'
+fi
 echo 'OK: CI C scanner selectors and >4096 fuzz boundaries are enforced'


### PR DESCRIPTION
> Audit sweep for four CI assurance gaps. Depends on the sanitizer-suite integrity work merged in #281.

## TL;DR

Several checks could say everything was covered when they had only seen a comment, skipped test code, or stopped at a short input. This makes those checks prove the work happened and pushes parser tests across the relevant size boundaries.

The sweep shell-tokenizes `apt-get install` commands, routes soak verdicts through `lsan_log_verdict.sh`, widens the three C-scanner selectors to `^(src|ci)/`, and sets libFuzzer `-max_len=65536` with 4095/4096/4097/65535/65536-byte seeds.

**Severity:** `Medium` (`CI integrity: false-green dependency, sanitizer, scanner, and parser coverage`)

## What changed

- Dependency checks parse YAML run blocks and accept a package only from an executed `apt-get install` command. Comments and quoted `echo` text are negative controls.
- The sanitizer soak requires verbose leak-check exit markers plus the deliberate-leak canary. Missing or unknown logs are indeterminate.
- Flawfinder, cppcheck, and Semgrep cover the 19 tracked C files under `ci/` as well as module sources.
- Fast and deep fuzz jobs use a 64 KiB input ceiling; the fast job creates seeds on both sides of 4096 bytes and at the ceiling.

## Testing

`test_ci_dependency_bootstrap.sh`, `test_ci_scanner_fuzz_boundaries.sh`, both LSan verdict fixtures, the 27-file flawfinder/cppcheck/Semgrep pass, actionlint, shellcheck, and the staged repository hooks passed. CodeRabbit returned no findings on the final diff.