### PR TITLE
fix: enforce runtime libzstd feature floors

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ load_module modules/ngx_http_zstd_static_module.so;
 
 Notes on the libzstd floor — these are enforced in code, not assumed:
 
+* At startup, dynamically linked builds compare the loaded libzstd version
+  with the headers used to compile the module and warn on any mismatch. Normal
+  ABI-compatible skew remains supported. Startup is refused only when a
+  configured compile-gated feature crosses its runtime floor: a negative
+  `zstd_comp_level` below 1.4.0, or `zstd_target_cblock_size` below 1.5.6.
+
 * **< 1.4.0**: the streaming API the module uses (`ZSTD_compressStream2`)
   is unavailable; this is the hard minimum. Negative `zstd_comp_level`
   values are also unsupported and are clamped to `1` with a warning

--- a/ci/tests/unit/run.sh
+++ b/ci/tests/unit/run.sh
@@ -49,9 +49,10 @@ BIN="$DIR/test_accept_encoding"
 LEGACY_BIN="$DIR/test_accept_encoding_legacy"
 CHAIN_BIN="$DIR/test_accept_encoding_chain"
 PROBE_BIN="$DIR/test_static_probe"
+VERSION_BIN="$DIR/test_version_policy"
 
 if [ "${1:-}" = "clean" ]; then
-	rm -f "$BIN" "$LEGACY_BIN" "$CHAIN_BIN" "$PROBE_BIN" "$DIR"/*.o "$DIR"/*.gcda "$DIR"/*.gcno
+	rm -f "$BIN" "$LEGACY_BIN" "$CHAIN_BIN" "$PROBE_BIN" "$VERSION_BIN" "$DIR"/*.o "$DIR"/*.gcda "$DIR"/*.gcno
 	echo "unit test binary removed"
 	exit 0
 fi
@@ -135,3 +136,13 @@ echo "==> Running"
 # away, but a timeout costs nothing and keeps the layer's failure mode
 # uniform.
 timeout 60s "$PROBE_BIN"
+
+echo "==> Building $VERSION_BIN with ${CC}"
+# shellcheck disable=SC2086
+$CC "${OWN_CFLAGS[@]}" -c "$DIR/test_version_policy.c" \
+	-o "$DIR/test_version_policy.o"
+# shellcheck disable=SC2086
+$CC "${LINK_EXTRA[@]}" -o "$VERSION_BIN" "$DIR/test_version_policy.o"
+
+echo "==> Running libzstd version policy checks"
+timeout 60s "$VERSION_BIN"

--- a/ci/tests/unit/test_version_policy.c
+++ b/ci/tests/unit/test_version_policy.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+
+#include "../../../src/ngx_http_zstd_version.h"
+
+
+int
+main(void)
+{
+    assert(ngx_http_zstd_version_policy(10507, 10507, 1, 1)
+           == NGX_HTTP_ZSTD_VERSION_OK);
+    assert(ngx_http_zstd_version_policy(10507, 10506, 0, 0)
+           == NGX_HTTP_ZSTD_VERSION_WARN);
+    assert(ngx_http_zstd_version_policy(10507, 10505, 0, 0)
+           == NGX_HTTP_ZSTD_VERSION_WARN);
+    assert(ngx_http_zstd_version_policy(10507, 10505, 1, 0)
+           == NGX_HTTP_ZSTD_VERSION_REFUSE_TARGET_CBLOCK);
+    assert(ngx_http_zstd_version_policy(10507, 10309, 0, 1)
+           == NGX_HTTP_ZSTD_VERSION_REFUSE_NEGATIVE_LEVEL);
+    assert(ngx_http_zstd_version_policy(10309, 10308, 1, 1)
+           == NGX_HTTP_ZSTD_VERSION_WARN);
+
+    return 0;
+}

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -16,6 +16,7 @@
 
 #include "ngx_http_zstd_common.h"
 #include "ngx_http_zstd_sha256.h"
+#include "ngx_http_zstd_version.h"
 
 #ifdef NGX_TEST_HARNESS
 #include "ngx_http_zstd_probe_hooks.h"
@@ -546,6 +547,8 @@ typedef struct {
      * own per-call no_cacheable flag -- see that function's comment).
      */
     ngx_flag_t                   any_enabled;
+    ngx_flag_t                   any_negative_level;
+    ngx_flag_t                   any_target_cblock_size;
 } ngx_http_zstd_main_conf_t;
 
 
@@ -857,6 +860,7 @@ static void *ngx_http_zstd_create_loc_conf(ngx_conf_t *cf);
 static char *ngx_http_zstd_merge_loc_conf(ngx_conf_t *cf, void *parent,
     void *child);
 static ngx_int_t ngx_http_zstd_add_variables(ngx_conf_t *cf);
+static ngx_int_t ngx_http_zstd_init_module(ngx_cycle_t *cycle);
 static ngx_int_t ngx_http_zstd_dcz_dicts_hashed_variable(
     ngx_http_request_t *r, ngx_http_variable_value_t *vv, uintptr_t data);
 static ngx_int_t ngx_http_zstd_ratio_variable(ngx_http_request_t *r,
@@ -1398,7 +1402,7 @@ ngx_module_t  ngx_http_zstd_filter_module = {
     ngx_http_zstd_filter_commands,          /* module directives */
     NGX_HTTP_MODULE,                        /* module type */
     NULL,                                   /* init master */
-    NULL,                                   /* init module */
+    ngx_http_zstd_init_module,              /* init module */
     NULL,                                   /* init process */
     NULL,                                   /* init thread */
     NULL,                                   /* exit thread */
@@ -5898,6 +5902,55 @@ ngx_http_zstd_release_cctx(void *data)
 }
 
 
+/* Warn on ABI-compatible skew, but fail when configured compile-time gates
+ * rely on a feature floor the dynamically loaded library does not meet. */
+static ngx_int_t
+ngx_http_zstd_init_module(ngx_cycle_t *cycle)
+{
+    unsigned                    runtime;
+    ngx_http_zstd_version_result_t  policy;
+    ngx_http_zstd_main_conf_t  *zmcf;
+
+    runtime = ZSTD_versionNumber();
+
+    zmcf = ngx_http_cycle_get_module_main_conf(cycle,
+                                                ngx_http_zstd_filter_module);
+    if (zmcf == NULL) {
+        return NGX_ERROR;
+    }
+
+    policy = ngx_http_zstd_version_policy(ZSTD_VERSION_NUMBER, runtime,
+                                          zmcf->any_target_cblock_size,
+                                          zmcf->any_negative_level);
+    if (policy == NGX_HTTP_ZSTD_VERSION_OK) {
+        return NGX_OK;
+    }
+
+    ngx_log_error(NGX_LOG_WARN, cycle->log, 0,
+                  "zstd module was built with libzstd %ui but loaded "
+                  "libzstd %ui at runtime",
+                  (ngx_uint_t) ZSTD_VERSION_NUMBER, (ngx_uint_t) runtime);
+
+    if (policy == NGX_HTTP_ZSTD_VERSION_REFUSE_TARGET_CBLOCK) {
+        ngx_log_error(NGX_LOG_EMERG, cycle->log, 0,
+                      "configured zstd_target_cblock_size requires runtime "
+                      "libzstd 1.5.6 or newer (loaded %ui)",
+                      (ngx_uint_t) runtime);
+        return NGX_ERROR;
+    }
+
+    if (policy == NGX_HTTP_ZSTD_VERSION_REFUSE_NEGATIVE_LEVEL) {
+        ngx_log_error(NGX_LOG_EMERG, cycle->log, 0,
+                      "a configured negative zstd_comp_level requires "
+                      "runtime libzstd 1.4.0 or newer (loaded %ui)",
+                      (ngx_uint_t) runtime);
+        return NGX_ERROR;
+    }
+
+    return NGX_OK;
+}
+
+
 /*
  * Free every cached context in the worker's slot ring at process exit.
  *
@@ -6275,6 +6328,7 @@ static char *
 ngx_http_zstd_comp_level(ngx_conf_t *cf, void *post, void *data)
 {
     const ngx_int_t  *np = data;
+    ngx_http_zstd_main_conf_t  *zmcf;
 
     (void)post;
 
@@ -6307,6 +6361,12 @@ ngx_http_zstd_comp_level(ngx_conf_t *cf, void *post, void *data)
     }
 #endif
 
+    if (*np < 0) {
+        zmcf = ngx_http_conf_get_module_main_conf(cf,
+                                                  ngx_http_zstd_filter_module);
+        zmcf->any_negative_level = 1;
+    }
+
     return NGX_CONF_OK;
 }
 
@@ -6338,6 +6398,7 @@ ngx_http_zstd_check_size_int_max(ngx_conf_t *cf, void *post, void *data)
 {
     ssize_t  *sp = data;
     char     *rc;
+    ngx_http_zstd_main_conf_t  *zmcf;
 
     (void) post;
 
@@ -6345,6 +6406,12 @@ ngx_http_zstd_check_size_int_max(ngx_conf_t *cf, void *post, void *data)
                                      "zstd_target_cblock_size");
     if (rc != NGX_CONF_OK) {
         return rc;
+    }
+
+    if (*sp > 0) {
+        zmcf = ngx_http_conf_get_module_main_conf(cf,
+                                                  ngx_http_zstd_filter_module);
+        zmcf->any_target_cblock_size = 1;
     }
 
     /*

--- a/src/ngx_http_zstd_version.h
+++ b/src/ngx_http_zstd_version.h
@@ -1,0 +1,31 @@
+#ifndef _NGX_HTTP_ZSTD_VERSION_H_INCLUDED_
+#define _NGX_HTTP_ZSTD_VERSION_H_INCLUDED_
+
+typedef enum {
+    NGX_HTTP_ZSTD_VERSION_OK = 0,
+    NGX_HTTP_ZSTD_VERSION_WARN,
+    NGX_HTTP_ZSTD_VERSION_REFUSE_TARGET_CBLOCK,
+    NGX_HTTP_ZSTD_VERSION_REFUSE_NEGATIVE_LEVEL
+} ngx_http_zstd_version_result_t;
+
+
+static ngx_http_zstd_version_result_t
+ngx_http_zstd_version_policy(unsigned build, unsigned runtime,
+    int any_target_cblock_size, int any_negative_level)
+{
+    if (build == runtime) {
+        return NGX_HTTP_ZSTD_VERSION_OK;
+    }
+
+    if (build >= 10506 && runtime < 10506 && any_target_cblock_size) {
+        return NGX_HTTP_ZSTD_VERSION_REFUSE_TARGET_CBLOCK;
+    }
+
+    if (build >= 10400 && runtime < 10400 && any_negative_level) {
+        return NGX_HTTP_ZSTD_VERSION_REFUSE_NEGATIVE_LEVEL;
+    }
+
+    return NGX_HTTP_ZSTD_VERSION_WARN;
+}
+
+#endif /* _NGX_HTTP_ZSTD_VERSION_H_INCLUDED_ */


### PR DESCRIPTION
> Source-audit finding A31s-F1. This is limited to dependency-version skew at module startup.

## TL;DR

A server can be built against one compression-library version and later load an older one. The module now reports that mismatch and stops only when the active configuration depends on a feature missing from the loaded version.

`ngx_http_zstd_init_module()` compares `ZSTD_versionNumber()` with `ZSTD_VERSION_NUMBER`; parse-time latches tell the version policy whether either compile-gated feature is configured.

**Severity:** `Low` (`hardening - deployment-time library skew can cause repeated HTTP 500 responses`)

## Mechanism

Any version mismatch produces a startup warning. Equal versions return immediately, and ABI-compatible upgrades or downgrades continue to start. The module returns `NGX_ERROR` only for `zstd_target_cblock_size` with a runtime below 1.5.6 or a negative `zstd_comp_level` with a runtime below 1.4.0.

## Compatibility

The supported 1.4.0 floor and older-header fallback builds are unchanged. Dynamic-link deployments gain an explicit warning; a downgrade across one of the two feature floors must remove that feature from the configuration or restore a sufficiently new library.

## Testing

`ci/tests/unit/run.sh` covers exact match, advisory skew, both refusal floors, and builds predating the gates. Its target-block negative control failed at `test_version_policy.c:15` when the refusal result was mutated to a warning, then passed after restoration. A release nginx 1.29.2 build succeeded, and `nginx -t` observed the warning plus both refusal messages through interposed runtime-version reports.