### PR TITLE
fix(probe): narrow the #278 seam claims; guard the seam in CI (#270)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -252,6 +252,9 @@ jobs:
       - name: Build configuration policy regressions
         run: bash "$GITHUB_WORKSPACE"/ci/tools/test_build_config_policy.sh
 
+      - name: Frame-probe header seam regressions
+        run: bash "$GITHUB_WORKSPACE"/ci/tools/test_probe_header_seam.sh
+
       - name: nginx tarball PGP verifier controls
         run: bash "$GITHUB_WORKSPACE"/ci/tools/test_verify_nginx_tarball.sh
 

--- a/ci/tools/test_probe_header_seam.sh
+++ b/ci/tools/test_probe_header_seam.sh
@@ -7,28 +7,42 @@ root=$(cd "$(dirname "$0")/../.." && pwd)
 grep -Fq '#include "ngx_http_zstd_frame_probe.h"' \
     "$root/src/ngx_http_zstd_static_module.c"
 
+check_definition() {
+    expected=$1
+    fn=$2
+    shift 2
+
+    defs=$(grep -r -n -h "^$fn(" "$@" || true)
+    sites=$(grep -r -l "^$fn(" "$@" | sort || true)
+    count=$(printf '%s\n' "$defs" | grep -c . || true)
+
+    if [ "$count" -ne 1 ] || [ "$sites" != "$expected" ]; then
+        echo "probe seam: unexpected definition sites for $fn:" >&2
+        echo "$sites" >&2
+        echo "probe seam: expected 1 definition, found $count" >&2
+        return 1
+    fi
+}
+
 # Each probe function is defined exactly once in the tree. A second
 # column-0 definition anywhere in the module sources is the
 # synchronized-copy drift #270 removed coming back -- possible while
 # the unit tests keep exercising only the header.
 for fn in ngx_http_zstd_static_probe_frame ngx_http_zstd_static_probe_reuse
 do
-    defs=$(grep -r -l "^$fn(" \
-               "$root/src" "$root/filter" "$root/static" | sort)
-    if [ "$defs" != "$root/src/ngx_http_zstd_frame_probe.h" ]; then
-        echo "probe seam: unexpected definition sites for $fn:" >&2
-        echo "$defs" >&2
-        exit 1
-    fi
+    check_definition "$root/src/ngx_http_zstd_frame_probe.h" "$fn" \
+        "$root/src" "$root/filter" "$root/static"
 done
 
 # Detection control: the definition pattern must actually catch a
 # planted duplicate, or the checks above pass vacuously.
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
-printf 'static ngx_inline ngx_int_t\nngx_http_zstd_static_probe_frame(const u_char *hdr, size_t n)\n{\n}\n' \
-    > "$tmp/planted.c"
-if ! grep -q "^ngx_http_zstd_static_probe_frame(" "$tmp/planted.c"; then
+cp "$root/src/ngx_http_zstd_frame_probe.h" "$tmp/planted.h"
+printf '\nngx_http_zstd_static_probe_frame(const u_char *hdr, size_t n)\n' \
+    >> "$tmp/planted.h"
+if check_definition "$tmp/planted.h" ngx_http_zstd_static_probe_frame \
+        "$tmp/planted.h" >/dev/null 2>&1; then
     echo 'probe seam: detection control failed to match a duplicate' >&2
     exit 1
 fi

--- a/ci/tools/test_probe_header_seam.sh
+++ b/ci/tools/test_probe_header_seam.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -eu
+
+root=$(cd "$(dirname "$0")/../.." && pwd)
+
+# Production must consume the authoritative header, not a copy.
+grep -Fq '#include "ngx_http_zstd_frame_probe.h"' \
+    "$root/src/ngx_http_zstd_static_module.c"
+
+# Each probe function is defined exactly once in the tree. A second
+# column-0 definition anywhere in the module sources is the
+# synchronized-copy drift #270 removed coming back -- possible while
+# the unit tests keep exercising only the header.
+for fn in ngx_http_zstd_static_probe_frame ngx_http_zstd_static_probe_reuse
+do
+    defs=$(grep -r -l "^$fn(" \
+               "$root/src" "$root/filter" "$root/static" | sort)
+    if [ "$defs" != "$root/src/ngx_http_zstd_frame_probe.h" ]; then
+        echo "probe seam: unexpected definition sites for $fn:" >&2
+        echo "$defs" >&2
+        exit 1
+    fi
+done
+
+# Detection control: the definition pattern must actually catch a
+# planted duplicate, or the checks above pass vacuously.
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+printf 'static ngx_inline ngx_int_t\nngx_http_zstd_static_probe_frame(const u_char *hdr, size_t n)\n{\n}\n' \
+    > "$tmp/planted.c"
+if ! grep -q "^ngx_http_zstd_static_probe_frame(" "$tmp/planted.c"; then
+    echo 'probe seam: detection control failed to match a duplicate' >&2
+    exit 1
+fi
+
+echo 'probe header seam: PASS'

--- a/src/ngx_http_zstd_frame_probe.h
+++ b/src/ngx_http_zstd_frame_probe.h
@@ -6,13 +6,13 @@
  * limit, ngx_http_zstd_static_probe_frame() and
  * ngx_http_zstd_static_probe_reuse(). Pure arithmetic -- no I/O, no
  * logging, no allocation, no request state -- so every consumer
- * (the static module, the unit fixtures, the fuzz harness, and the
- * compression branch's static module) includes THIS file instead of
- * carrying a synchronized copy or sed-extracting the body.
+ * (the static module, the unit fixtures, and the compression
+ * branch's static module) includes THIS file instead of carrying a
+ * synchronized copy or sed-extracting the body.
  *
  * CONSUMER CONTRACT. Inside nginx, include after the nginx headers
- * and everything below resolves. Outside nginx (unit/fuzz shims),
- * provide before including:
+ * and everything below resolves. Outside nginx (shims like the unit
+ * fixture's), provide before including:
  *     typedef intptr_t   ngx_int_t;
  *     typedef uintptr_t  ngx_uint_t;
  *     typedef unsigned char  u_char;

--- a/src/ngx_http_zstd_static_module.c
+++ b/src/ngx_http_zstd_static_module.c
@@ -20,12 +20,15 @@
 /*
  * The frame probe -- verdicts, window cap, probe_frame(),
  * probe_reuse() -- lives in its own header (#270) so the unit
- * fixtures, the fuzz harness and the compression branch's static
- * module share ONE authoritative copy instead of synchronized ones.
- * It self-defines the RFC-frozen magic constants, which also drops
- * this module's last compile-time libzstd dependency: static sidecar
- * serving is file serving, and now builds on a box with no libzstd
- * headers at all.
+ * fixtures and the compression branch's static module share ONE
+ * authoritative copy instead of synchronized ones. It self-defines
+ * the RFC-frozen magic constants, so this file no longer includes
+ * <zstd.h>. Note the scope of that independence: the supported
+ * configure path still probes libzstd in auto/zstd before any module
+ * here builds -- the header makes the PROBE code library-free, and
+ * the build-without-libzstd property is realized where a build
+ * actually omits the library, in the compression branch's
+ * dependency-free static module.
  */
 #include "ngx_http_zstd_frame_probe.h"
 


### PR DESCRIPTION
## TL;DR

Both follow-ups from the #270 review note, in one small PR: the two #278 comments that were ahead of the code now say only what is true, and a CI check guards the seam so the synchronized-copy drift cannot quietly return.

## Comment corrections

- The header's consumer list drops "the fuzz harness": the repo's fuzz target covers the Accept-Encoding parser, and nothing fuzzes the probe through this header today.
- The static module's include comment no longer claims the module "builds on a box with no libzstd headers at all" — the supported configure path still probes libzstd in `auto/zstd` before any module builds. The header makes the probe *code* library-free; the build-without-libzstd property is realized where a build actually omits the library, in the compression branch's dependency-free static module.

## The seam check

`ci/tools/test_probe_header_seam.sh`, wired beside the build-config policy step: production must include `ngx_http_zstd_frame_probe.h`, and each probe function must have exactly one column-0 definition across `src`/`filter`/`static`. A reintroduced copy fails CI even while the unit fixtures keep exercising only the header's code. A planted-duplicate control proves the definition pattern matches, so the count cannot pass vacuously.

## Status of the other #270 condition

The compression branch adopted the header today (#117 at 9ee9a2b): its probe/reuse copies, verdict set, format constants, window cap and skip bound are deleted — 243 lines — in favour of including the authoritative file, with both function bodies mechanically diffed against the header's beforehand (probe_reuse byte-identical; probe_frame differing only in comments, wrapping, and the C89-guarded index declaration). With this PR and that commit, the central promise holds across both trees.

## Testing

The seam script passes on this tree and its detection control is self-verifying; the comment changes are text-only.
