### PR TITLE
refactor(filter): extract the no-transform detection into one authoritative header (#270)

### DIFF
--- a/ci/tools/test_probe_header_seam.sh
+++ b/ci/tools/test_probe_header_seam.sh
@@ -43,6 +43,19 @@ for fn in ngx_http_zstd_static_probe_frame ngx_http_zstd_static_probe_reuse; do
 		"$root"
 done
 
+# Same seam, second family: the Cache-Control no-transform helpers
+# moved to their own authoritative header; production must include it
+# and each helper must keep exactly one definition.
+grep -Fq '#include "ngx_http_zstd_cache_control.h"' \
+	"$root/src/ngx_http_zstd_filter_module.c"
+
+for fn in ngx_http_zstd_cache_control_directive_end \
+	ngx_http_zstd_cache_control_value_no_transform \
+	ngx_http_zstd_cache_control_no_transform; do
+	check_definition "$root/src/ngx_http_zstd_cache_control.h" "$fn" \
+		"$root"
+done
+
 # Detection control: redirect the real unit fixture to a copied probe
 # implementation under ci/. The fixture must stay green while the seam
 # check turns red, reproducing the drift this gate exists to catch.
@@ -72,6 +85,22 @@ cc=${CC:-cc}
 if check_definition "$tmp/src/ngx_http_zstd_frame_probe.h" \
 	ngx_http_zstd_static_probe_frame "$tmp" >/dev/null 2>&1; then
 	echo 'probe seam: detection control missed a copied CI implementation' >&2
+	exit 1
+fi
+
+# Cache-control control: the same staged-drift shape -- the header
+# copied back under ci/ (no unit fixture exists for this family, so
+# the copy alone is the scenario) -- must turn the definition count
+# red.
+cp "$root/src/ngx_http_zstd_cache_control.h" \
+	"$tmp/src/ngx_http_zstd_cache_control.h"
+cp "$root/src/ngx_http_zstd_cache_control.h" \
+	"$tmp/ci/tools/copied_cache_control.h"
+
+if check_definition "$tmp/src/ngx_http_zstd_cache_control.h" \
+	ngx_http_zstd_cache_control_value_no_transform "$tmp" \
+	>/dev/null 2>&1; then
+	echo 'probe seam: detection control missed a copied cache-control header' >&2
 	exit 1
 fi
 

--- a/filter/config
+++ b/filter/config
@@ -11,6 +11,7 @@ HTTP_ZSTD_SRCS="$ngx_addon_dir/ngx_http_zstd_filter_module.c"
 # generation) rebuilds the object whenever a header changes; without
 # this, edits to them leave stale .o files behind.
 HTTP_ZSTD_DEPS="$ngx_addon_dir/ngx_http_zstd_common.h \
+                $ngx_addon_dir/ngx_http_zstd_cache_control.h \
                 $ngx_addon_dir/ngx_http_zstd_sha256.h"
 
 ngx_addon_name=ngx_http_zstd_filter_module

--- a/src/ngx_http_zstd_cache_control.h
+++ b/src/ngx_http_zstd_cache_control.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2026 Thijs Eilander
+ *
+ * THE authoritative copy of the Cache-Control no-transform detection
+ * (RFC 9110 section 7.7 / RFC 9111 section 5.2.2.6): the quote-aware
+ * directive-segment walk (#274), the '=' directive-name cut (#254),
+ * and the whole-headers_out-list check (#251). Detection is
+ * deliberately list-wide rather than reading the parsed
+ * headers_out.cache_control chain: only some producers wire that
+ * chain, and a Cache-Control pushed straight onto the list by a
+ * module or an add_header would be invisible there.
+ *
+ * Extracted (#270): the compression branch's chassis and the brotli
+ * hardened fork each carried a synchronized transplant of this exact
+ * logic, and #251 and then #274 were each hand-mirrored into every
+ * copy within days of merging. A consumer includes THIS file instead.
+ *
+ * CONSUMER CONTRACT. Include after the nginx headers; everything here
+ * resolves against ngx_core/ngx_http types (the detection reads the
+ * live headers_out list, so unlike ngx_http_zstd_frame_probe.h there
+ * is no nginx-free consumer to shim for). ngx_inline keeps a consumer
+ * that calls only part of the family warning-clean. The function
+ * bodies are the filter module's, moved verbatim.
+ */
+
+#ifndef NGX_HTTP_ZSTD_CACHE_CONTROL_H
+#define NGX_HTTP_ZSTD_CACHE_CONTROL_H
+
+
+static ngx_inline u_char *
+ngx_http_zstd_cache_control_directive_end(u_char *p, u_char *last)
+{
+    while (p < last) {
+        if (*p == '"') {
+            p++;
+
+            while (p < last && *p != '"') {
+                if (*p == '\\' && p + 1 < last) {
+                    p++;
+                }
+                p++;
+            }
+
+            if (p < last) {
+                p++;
+            }
+
+        } else if (*p == ',') {
+            break;
+
+        } else {
+            p++;
+        }
+    }
+
+    return p;
+}
+
+
+static ngx_inline ngx_int_t
+ngx_http_zstd_cache_control_value_no_transform(ngx_table_elt_t *cc)
+{
+    u_char  *p, *last, *start, *end, *directive_end, *semi;
+
+    if (cc->value.len == 0) {
+        return 0;
+    }
+
+    p = cc->value.data;
+    last = p + cc->value.len;
+
+    while (p < last) {
+        start = p;
+        while (start < last && (*start == ' ' || *start == '\t')) {
+            start++;
+        }
+
+        directive_end = ngx_http_zstd_cache_control_directive_end(start, last);
+
+        /*
+         * Cut at '=' as well as ';': the compared token is then the
+         * directive NAME, so "no-transform=arg" -- malformed, since the
+         * directive defines no argument (RFC 9111 §5.2.2.6), but clear
+         * in intent -- is honored rather than transformed. The quoted
+         * parameter-value control is unaffected: extension="no-transform"
+         * cuts to "extension" and still does not match.
+         */
+        semi = start;
+        while (semi < directive_end && *semi != ';' && *semi != '=') {
+            semi++;
+        }
+        end = semi;
+
+        while (end > start && (end[-1] == ' ' || end[-1] == '\t')) {
+            end--;
+        }
+
+        if ((size_t) (end - start) == sizeof("no-transform") - 1
+            && ngx_strncasecmp(start, (u_char *) "no-transform",
+                               sizeof("no-transform") - 1) == 0)
+        {
+            return 1;
+        }
+
+        p = directive_end;
+        if (p < last) {
+            p++;
+        }
+    }
+
+    return 0;
+}
+
+
+static ngx_inline ngx_int_t
+ngx_http_zstd_cache_control_no_transform(ngx_http_request_t *r)
+{
+    ngx_uint_t        i;
+    ngx_list_part_t  *part;
+    ngx_table_elt_t  *h;
+
+    part = &r->headers_out.headers.part;
+    h = part->elts;
+
+    for (i = 0; /* void */; i++) {
+        if (i >= part->nelts) {
+            if (part->next == NULL) {
+                break;
+            }
+
+            part = part->next;
+            h = part->elts;
+            i = 0;
+        }
+
+        if (h[i].hash == 0 || h[i].key.len != sizeof("Cache-Control") - 1) {
+            continue;
+        }
+
+        if (ngx_strncasecmp(h[i].key.data, (u_char *) "Cache-Control",
+                            sizeof("Cache-Control") - 1) == 0
+            && ngx_http_zstd_cache_control_value_no_transform(&h[i]))
+        {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+
+#endif /* NGX_HTTP_ZSTD_CACHE_CONTROL_H */

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -15,6 +15,7 @@
 #include <stdint.h>  /* SIZE_MAX — saturating dcz window-log arithmetic */
 
 #include "ngx_http_zstd_common.h"
+#include "ngx_http_zstd_cache_control.h"
 #include "ngx_http_zstd_sha256.h"
 #include "ngx_http_zstd_version.h"
 
@@ -1508,128 +1509,6 @@ ngx_module_t  ngx_http_zstd_filter_module = {
     NULL,                                   /* exit master */
     NGX_MODULE_V1_PADDING
 };
-
-
-static u_char *
-ngx_http_zstd_cache_control_directive_end(u_char *p, u_char *last)
-{
-    while (p < last) {
-        if (*p == '"') {
-            p++;
-
-            while (p < last && *p != '"') {
-                if (*p == '\\' && p + 1 < last) {
-                    p++;
-                }
-                p++;
-            }
-
-            if (p < last) {
-                p++;
-            }
-
-        } else if (*p == ',') {
-            break;
-
-        } else {
-            p++;
-        }
-    }
-
-    return p;
-}
-
-
-static ngx_int_t
-ngx_http_zstd_cache_control_value_no_transform(ngx_table_elt_t *cc)
-{
-    u_char  *p, *last, *start, *end, *directive_end, *semi;
-
-    if (cc->value.len == 0) {
-        return 0;
-    }
-
-    p = cc->value.data;
-    last = p + cc->value.len;
-
-    while (p < last) {
-        start = p;
-        while (start < last && (*start == ' ' || *start == '\t')) {
-            start++;
-        }
-
-        directive_end = ngx_http_zstd_cache_control_directive_end(start, last);
-
-        /*
-         * Cut at '=' as well as ';': the compared token is then the
-         * directive NAME, so "no-transform=arg" -- malformed, since the
-         * directive defines no argument (RFC 9111 §5.2.2.6), but clear
-         * in intent -- is honored rather than transformed. The quoted
-         * parameter-value control is unaffected: extension="no-transform"
-         * cuts to "extension" and still does not match.
-         */
-        semi = start;
-        while (semi < directive_end && *semi != ';' && *semi != '=') {
-            semi++;
-        }
-        end = semi;
-
-        while (end > start && (end[-1] == ' ' || end[-1] == '\t')) {
-            end--;
-        }
-
-        if ((size_t) (end - start) == sizeof("no-transform") - 1
-            && ngx_strncasecmp(start, (u_char *) "no-transform",
-                               sizeof("no-transform") - 1) == 0)
-        {
-            return 1;
-        }
-
-        p = directive_end;
-        if (p < last) {
-            p++;
-        }
-    }
-
-    return 0;
-}
-
-
-static ngx_int_t
-ngx_http_zstd_cache_control_no_transform(ngx_http_request_t *r)
-{
-    ngx_uint_t        i;
-    ngx_list_part_t  *part;
-    ngx_table_elt_t  *h;
-
-    part = &r->headers_out.headers.part;
-    h = part->elts;
-
-    for (i = 0; /* void */; i++) {
-        if (i >= part->nelts) {
-            if (part->next == NULL) {
-                break;
-            }
-
-            part = part->next;
-            h = part->elts;
-            i = 0;
-        }
-
-        if (h[i].hash == 0 || h[i].key.len != sizeof("Cache-Control") - 1) {
-            continue;
-        }
-
-        if (ngx_strncasecmp(h[i].key.data, (u_char *) "Cache-Control",
-                            sizeof("Cache-Control") - 1) == 0
-            && ngx_http_zstd_cache_control_value_no_transform(&h[i]))
-        {
-            return 1;
-        }
-    }
-
-    return 0;
-}
 
 
 static ngx_int_t


### PR DESCRIPTION
## TL;DR

The `ngx_http_zstd_frame_probe.h` pattern (#270/#278) applied to the next shared surface: the Cache-Control no-transform detection moves verbatim into `src/ngx_http_zstd_cache_control.h`, so its next fix lands once instead of being ported three times.

## Why this family next

It is the most recently drift-prone surface in the tree. #251 (the detection itself) and then #274 (the quoted-comma segment fix) were each hand-mirrored into the compression branch and the brotli hardened fork within days of merging here — three parallel patches per fix. The copies have already taken different shapes while staying behaviourally equivalent: lizard counts the pair at CCN 15+8 here (quote-awareness in the `directive_end` helper) against CCN 22+9 in the compression branch's transplant (quote-awareness inlined in the segment scan). The same fixtures pass on both, but every future fix pays the same triple port and the same equivalence review.

## What moved

- `ngx_http_zstd_cache_control_directive_end()` — the quote-aware segment walk (#274)
- `ngx_http_zstd_cache_control_value_no_transform()` — the whole-segment token compare with the `=` directive-name cut (#254)
- `ngx_http_zstd_cache_control_no_transform()` — the whole-`headers_out`-list check (#251), with the list-wide-not-chain rationale in the header preamble

All three bodies are byte-identical to the ones deleted from the filter module (verified mechanically against the pre-move blob); the single delta is `static` → `static ngx_inline` on the signatures so a consumer using part of the family stays warning-clean, same as the frame-probe header. The header joins `HTTP_ZSTD_DEPS` so incremental builds rebuild on edits.

## Keeping the #270 conditions from day one

Per the review note on #270: the compression branch commits to adopting this header at its next sync, deleting its transplant the way it adopted the frame-probe header today (#117 at 9ee9a2b) and already consumes `ngx_http_zstd_sha256.h` and `ngx_http_zstd_version.h`; the brotli fork follows at handover. The seam script now covers this family too (rebased onto #307's master): production must include the header, each of the three helpers keeps exactly one column-0 definition, and a staged copied-header control proves the gate goes red on the drift.

## Testing

Local build against nginx 1.31.4 plus the full `ci/t/00-filter.t` run — all green, unchanged. Correction from review: the no-transform coverage itself lives in `ci/tools/test_encoding.py` (the quoted/comma/OWS cases), not 00-filter.t; CI runs it and is green on the extraction. No behaviour change intended or observed.

