### PR TITLE
fix: harden zstd terminal observability

### DIFF
--- a/ci/t/03-dcz.t
+++ b/ci/t/03-dcz.t
@@ -1347,3 +1347,32 @@ qr/zstd: dcz window log computed once: \d+/
 qr/^zstd: dcz window log computed once: \d+\n?$/
 --- no_error_log
 [error]
+
+
+
+=== TEST 50: missing Available-Dictionary emits its dcz fallback trace
+# The response contract matches TEST 2 (ordinary zstd fallback), but that
+# outcome alone cannot distinguish a missing header from any other dcz
+# negotiation rejection.  The debug line is the operator-facing witness for
+# this specific branch.  A valid dcz coding is required here: without it the
+# earlier Accept-Encoding gate correctly wins and this assertion would be
+# vacuous.
+--- log_level: debug
+--- config
+    location /t {
+        zstd on;
+        zstd_min_length 16;
+        zstd_dcz_dict_file $TEST_NGINX_PERL_PATH/suite/dcz-dict;
+        default_type text/plain;
+        return 200 "dcz missing Available-Dictionary trace body\n";
+    }
+--- request
+GET /t
+--- more_headers
+Accept-Encoding: zstd, dcz
+--- response_headers
+Content-Encoding: zstd
+--- error_log
+zstd dcz: skip, no Available-Dictionary header
+--- no_error_log
+[error]

--- a/ci/t/harness-scenarios/fault-arms/driver.sh
+++ b/ci/t/harness-scenarios/fault-arms/driver.sh
@@ -29,6 +29,7 @@ set -euo pipefail
 HOST=127.0.0.1
 PORT="$PROBER_RESOLVED_PORT"
 ELOG="$PROBER_PREFIX/logs/error.log"
+VLOG="$PROBER_PREFIX/logs/zstd-vars.log"
 
 FAILED=0
 
@@ -75,6 +76,26 @@ fetch() {
         "http://$HOST:$PORT$path" 2>"$out.stderr"
 }
 
+# Wait for the last /body.bin log record to change.  The completed warm-up is
+# the negative control: it must expose all three values.  The faulted request
+# then has to append a distinct all-not-found record; reading a stale warm-up
+# line would otherwise let an unreachable fault path pass.
+wait_body_var_line() {
+    local previous="$1" line deadline
+
+    deadline=$((SECONDS + 5))
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        line="$(awk '$1 == "/body.bin" { value = $0 } END { print value }' "$VLOG" 2>/dev/null || true)"
+        if [ -n "$line" ] && [ "$line" != "$previous" ]; then
+            printf '%s\n' "$line"
+            return 0
+        fi
+        sleep 0.05
+    done
+
+    return 1
+}
+
 read_probe_field() {
     local field="$1"
     local body
@@ -91,11 +112,12 @@ DCZ_HEADERS=(
 )
 
 # --- oracle plan --------------------------------------------------------
-# 1  warm-up: plain request serves 200 (readiness)
+# 1  warm-up: plain request serves 200 and emits completed log variables
 # 2  CODEC ERROR (fault_codec=1) on a plain compressing request: the request
 #    fails closed (no 200, connection torn down) rather than serving
-#    corrupt/truncated compressed bytes -- proves the central ZSTD_isError
-#    arm at filter_module.c:2244 is reachable and fails safely
+#    corrupt/truncated compressed bytes and emits no completed log variables
+#    -- proves the central ZSTD_isError arm is reachable, fails safely, and
+#    cannot fabricate a final ratio from its partial counters
 # 3  CODEC_END ERROR (fault_codec_end=1) on the SAME plain request: same
 #    fail-closed assertion at the end-of-frame site specifically
 # 4  CODEC_END ZERO on the 2nd END call (fault_codec_end=1002): forces the
@@ -142,10 +164,15 @@ echo "1..14"
 
 # --- 1: warm-up -----------------------------------------------------------
 WARMUP="$PROBER_PREFIX/warmup.out"
-if fetch /body.bin "$WARMUP" && grep -q '^HTTP/1.1 200' "$WARMUP.hdrs"; then
-    echo "ok 1 - warm-up request served a clean 200"
+WARMUP_VARS=""
+if fetch /body.bin "$WARMUP" \
+    && grep -q '^HTTP/1.1 200' "$WARMUP.hdrs" \
+    && WARMUP_VARS="$(wait_body_var_line '')" \
+    && [[ "$WARMUP_VARS" =~ ^/body.bin\ [0-9]+\.[0-9]{3}\ [1-9][0-9]*\ [1-9][0-9]*$ ]]
+then
+    echo "ok 1 - warm-up request served a clean 200 with completed zstd log variables"
 else
-    echo "not ok 1 - warm-up request did not serve a clean 200"
+    echo "not ok 1 - warm-up request did not serve a clean 200 with completed zstd log variables (vars=${WARMUP_VARS:-missing})"
     FAILED=$((FAILED + 1))
 fi
 
@@ -159,16 +186,20 @@ fi
 ERR_OUT="$PROBER_PREFIX/codec-err.out"
 ARM2_OK=0
 GOT200_2=0
+FAULT_VARS=""
 if arm codec 1; then
     ARM2_OK=1
     if fetch /body.bin "$ERR_OUT" && grep -q '^HTTP/1.1 200' "$ERR_OUT.hdrs" 2>/dev/null; then
         GOT200_2=1
     fi
+    FAULT_VARS="$(wait_body_var_line "$WARMUP_VARS" || true)"
 fi
-if [ "$ARM2_OK" -eq 1 ] && [ "$GOT200_2" -eq 0 ]; then
-    echo "ok 2 - CODEC ERROR (fault_codec=1) made a compressing request fail closed, not serve corrupt output"
+if [ "$ARM2_OK" -eq 1 ] && [ "$GOT200_2" -eq 0 ] \
+    && [ "$FAULT_VARS" = '/body.bin - - -' ]
+then
+    echo "ok 2 - CODEC ERROR (fault_codec=1) failed closed and exposed no completed zstd log variables"
 else
-    echo "not ok 2 - CODEC ERROR did not fail the request (arm_ok=$ARM2_OK; isError arm at ~filter_module.c:2244 not reached, or not fail-closed)"
+    echo "not ok 2 - CODEC ERROR did not fail closed without fabricated log variables (arm_ok=$ARM2_OK; vars=${FAULT_VARS:-missing})"
     FAILED=$((FAILED + 1))
 fi
 disarm codec || true

--- a/ci/t/harness-scenarios/fault-arms/nginx.conf
+++ b/ci/t/harness-scenarios/fault-arms/nginx.conf
@@ -10,6 +10,11 @@ error_log @PREFIX@/logs/error.log info;
 worker_processes 1;
 events { worker_connections 16; }
 http {
+    # The CODEC-error oracle below reads these after nginx enters log phase.
+    # A completed frame has all three values; an aborted one must expose none.
+    log_format zstd_fault_vars "$uri $zstd_ratio $zstd_bytes_in $zstd_bytes_out";
+    access_log @PREFIX@/logs/zstd-vars.log zstd_fault_vars;
+
     server {
         listen 127.0.0.1:@PORT@;
 

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -723,6 +723,8 @@ typedef struct {
     unsigned                     redo:1;
     unsigned                     flush:1;
     unsigned                     done:1;
+    /* A failed stream is terminal but must not look complete to log vars. */
+    unsigned                     aborted:1;
     unsigned                     nomem:1;
 
     /* the 40-byte dcz frame header has been queued on the out chain.
@@ -2133,6 +2135,8 @@ ngx_http_zstd_dcz_negotiate(ngx_http_request_t *r,
                                        &sec_fetch_site_count);
 
     if (avail_dict_h == NULL) {
+        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                       "zstd dcz: skip, no Available-Dictionary header");
         return NULL;
     }
 
@@ -2519,6 +2523,7 @@ ngx_http_zstd_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
 failed:
 
+    ctx->aborted = 1;
     ctx->done = 1;
 
     return NGX_ERROR;
@@ -5744,7 +5749,7 @@ ngx_http_zstd_ratio_variable(ngx_http_request_t *r,
     (void) data;
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_zstd_filter_module);
-    if (ctx == NULL || !ctx->done || ctx->bytes_out == 0) {
+    if (ctx == NULL || ctx->aborted || !ctx->done || ctx->bytes_out == 0) {
         vv->not_found = 1;
         vv->no_cacheable = 1;
         return NGX_OK;
@@ -5785,10 +5790,11 @@ ngx_http_zstd_ratio_variable(ngx_http_request_t *r,
  * $zstd_bytes_in / $zstd_bytes_out — absolute byte counts for the
  * compressed response, complementing $zstd_ratio (which only gives the
  * ratio). `data` is the offsetof() of the ctx field to report, so one
- * handler serves both. Only set once the filter has finished compressing
- * this response (log phase), like $zstd_ratio. no_cacheable tracks that
- * same transition (see ngx_http_zstd_add_variables()'s comment): 1 for
- * a pre-completion not_found result, 0 for the final formatted value.
+ * handler serves both. Only set once the filter has successfully finished
+ * compressing this response (log phase), like $zstd_ratio. no_cacheable
+ * tracks that same transition (see ngx_http_zstd_add_variables()'s comment):
+ * 1 for a pre-completion or aborted not_found result, 0 for the final
+ * formatted value.
  */
 static ngx_int_t
 ngx_http_zstd_bytes_variable(ngx_http_request_t *r,
@@ -5798,7 +5804,7 @@ ngx_http_zstd_bytes_variable(ngx_http_request_t *r,
     ngx_http_zstd_ctx_t  *ctx;
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_zstd_filter_module);
-    if (ctx == NULL || !ctx->done) {
+    if (ctx == NULL || ctx->aborted || !ctx->done) {
         vv->not_found = 1;
         vv->no_cacheable = 1;
         return NGX_OK;

--- a/src/ngx_http_zstd_static_module.c
+++ b/src/ngx_http_zstd_static_module.c
@@ -824,8 +824,8 @@ ngx_http_zstd_static_probe_verdict(const u_char *frame, size_t avail,
                       "zstd static: \"%s\" is not a zstd frame "
                       "(leading bytes 0x%02xd%02xd%02xd%02xd)",
                       path->data,
-                      (ngx_uint_t) frame[0], (ngx_uint_t) frame[1],
-                      (ngx_uint_t) frame[2], (ngx_uint_t) frame[3]);
+                      (unsigned) frame[0], (unsigned) frame[1],
+                      (unsigned) frame[2], (unsigned) frame[3]);
         return NGX_DECLINED;
 
     case NGX_HTTP_ZSTD_STATIC_FRAME_TRUNCATED:


### PR DESCRIPTION
> This sweep closes three observability findings from the A31c audit.

## TL;DR

An interrupted compression used to leave behind numbers that looked like a completed result. This marks that request as aborted, adds the missing fallback trace, and fixes two debug-byte arguments so logs remain trustworthy.

`ngx_http_zstd_ratio_variable()` now rejects aborted contexts, dcz negotiation logs the missing `Available-Dictionary` branch, and static-module byte logging passes promoted unsigned integers to `%02xd`.

**Severity:** `Low` (`observability - incorrect or missing diagnostic output`)

## Verification

- Fault-arms scenario: 14/14 assertions passed, including the completed-request negative control and aborted-request `- - -` variables.
- The guard-removal mutant failed the fault-arms scenario.
- dcz suite: 186/186 assertions passed with fixture timestamps preserved.
- Two independent branch lint passes completed, followed by a clean independent review.
