### PR TITLE
fix(ci): scan probe test consumers

### DIFF
--- a/ci/tools/test_probe_header_seam.sh
+++ b/ci/tools/test_probe_header_seam.sh
@@ -5,46 +5,74 @@ root=$(cd "$(dirname "$0")/../.." && pwd)
 
 # Production must consume the authoritative header, not a copy.
 grep -Fq '#include "ngx_http_zstd_frame_probe.h"' \
-    "$root/src/ngx_http_zstd_static_module.c"
+	"$root/src/ngx_http_zstd_static_module.c"
 
 check_definition() {
-    expected=$1
-    fn=$2
-    shift 2
+	expected=$1
+	fn=$2
+	tree=$3
 
-    defs=$(grep -r -n -h "^$fn(" "$@" || true)
-    sites=$(grep -r -l "^$fn(" "$@" | sort || true)
-    count=$(printf '%s\n' "$defs" | grep -c . || true)
+	if ! defs=$(grep -r -n -h "^$fn(" \
+		"$tree/src" "$tree/filter" "$tree/static" "$tree/ci"); then
+		echo "probe seam: could not find $fn definitions" >&2
+		return 1
+	fi
 
-    if [ "$count" -ne 1 ] || [ "$sites" != "$expected" ]; then
-        echo "probe seam: unexpected definition sites for $fn:" >&2
-        echo "$sites" >&2
-        echo "probe seam: expected 1 definition, found $count" >&2
-        return 1
-    fi
+	if ! sites=$(grep -r -l "^$fn(" \
+		"$tree/src" "$tree/filter" "$tree/static" "$tree/ci"); then
+		echo "probe seam: could not find $fn definition sites" >&2
+		return 1
+	fi
+
+	count=$(printf '%s\n' "$defs" | wc -l)
+
+	if [ "$count" -ne 1 ] || [ "$sites" != "$expected" ]; then
+		echo "probe seam: unexpected definition sites for $fn:" >&2
+		echo "$sites" >&2
+		echo "probe seam: expected 1 definition, found $count" >&2
+		return 1
+	fi
 }
 
 # Each probe function is defined exactly once in the tree. A second
 # column-0 definition anywhere in the module sources is the
 # synchronized-copy drift #270 removed coming back -- possible while
 # the unit tests keep exercising only the header.
-for fn in ngx_http_zstd_static_probe_frame ngx_http_zstd_static_probe_reuse
-do
-    check_definition "$root/src/ngx_http_zstd_frame_probe.h" "$fn" \
-        "$root/src" "$root/filter" "$root/static"
+for fn in ngx_http_zstd_static_probe_frame ngx_http_zstd_static_probe_reuse; do
+	check_definition "$root/src/ngx_http_zstd_frame_probe.h" "$fn" \
+		"$root"
 done
 
-# Detection control: the definition pattern must actually catch a
-# planted duplicate, or the checks above pass vacuously.
+# Detection control: redirect the real unit fixture to a copied probe
+# implementation under ci/. The fixture must stay green while the seam
+# check turns red, reproducing the drift this gate exists to catch.
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
-cp "$root/src/ngx_http_zstd_frame_probe.h" "$tmp/planted.h"
-printf '\nngx_http_zstd_static_probe_frame(const u_char *hdr, size_t n)\n' \
-    >> "$tmp/planted.h"
-if check_definition "$tmp/planted.h" ngx_http_zstd_static_probe_frame \
-        "$tmp/planted.h" >/dev/null 2>&1; then
-    echo 'probe seam: detection control failed to match a duplicate' >&2
-    exit 1
+mkdir -p "$tmp/src" "$tmp/filter" "$tmp/static" "$tmp/ci/tools"
+cp "$root/src/ngx_http_zstd_frame_probe.h" \
+	"$tmp/src/ngx_http_zstd_frame_probe.h"
+cp "$root/src/ngx_http_zstd_frame_probe.h" \
+	"$tmp/ci/tools/generated_static_probe.inc"
+sed 's|#include "../../src/ngx_http_zstd_frame_probe.h"|#include "generated_static_probe.inc"|' \
+	"$root/ci/tools/test_static_probe_unit.c" \
+	>"$tmp/ci/tools/test_static_probe_unit.c"
+
+if ! grep -Fq '#include "generated_static_probe.inc"' \
+	"$tmp/ci/tools/test_static_probe_unit.c"; then
+	echo 'probe seam: detection control did not redirect the unit fixture' >&2
+	exit 1
+fi
+
+cc=${CC:-cc}
+"$cc" -std=gnu99 -Wall -Wextra -Werror -O1 \
+	-I "$tmp/ci/tools" -o "$tmp/test_static_probe_unit" \
+	"$tmp/ci/tools/test_static_probe_unit.c"
+"$tmp/test_static_probe_unit" >/dev/null
+
+if check_definition "$tmp/src/ngx_http_zstd_frame_probe.h" \
+	ngx_http_zstd_static_probe_frame "$tmp" >/dev/null 2>&1; then
+	echo 'probe seam: detection control missed a copied CI implementation' >&2
+	exit 1
 fi
 
 echo 'probe header seam: PASS'


### PR DESCRIPTION
## TL;DR

The seam check could still miss a copied implementation used only by tests, allowing the old drift to return while CI stayed green. This follow-up makes that blind spot part of the check itself.

In code terms: scan CI consumers for probe definitions and redirect the real static-probe fixture to a copied header as a negative control.

**Severity:** Low (test integrity — CI could miss a duplicated probe implementation)

Follow-up to the requested change on #288.

## Testing

- `ci/tools/test_probe_header_seam.sh`
- `ci/tools/test_static_probe_unit.sh` in GNU99 and C89 modes
- Mutation control: removing `ci/` from both scans makes the seam test fail
- ShellCheck, shfmt, Semgrep, ast-grep, secret scans, and CodeRabbit CLI
- Independent branch review: no findings
