### PR TITLE
docs(zstd): narrow zstd_bypass_vary contract to the bypass fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -974,11 +974,18 @@ server {
 **Default:** `—`
 **Context:** `http, server, location`
 
-Appends `field-name` to the response `Vary` header on every response from
-the location (both the compressed and the bypassed-identity variant), so a
-shared cache keys on the request header that drives a header/cookie-based
-[`zstd_bypass`](#zstd_bypass). Use it whenever a bypass predicate reads a
-request header or cookie:
+Appends `field-name` to the response `Vary` header on every response for
+which this module actually reaches the `zstd_bypass` decision — both the
+compressed variant and the bypassed-identity variant — so a shared cache
+keys on the request header that drives a header/cookie-based
+[`zstd_bypass`](#zstd_bypass). A response declined earlier by an
+eligibility gate (ineligible status, already encoded, below
+`zstd_min_length`, above `zstd_max_length`, header-only, content type not
+in [`zstd_types`](#zstd_types), or `Cache-Control: no-transform`) never
+reaches that decision: it would be served identity regardless of the
+bypass predicate, so no bypass-driven variance exists to declare and this
+directive adds no `Vary` field to it. Use it whenever a bypass predicate
+reads a request header or cookie:
 
 ```nginx
 server {

--- a/ci/t/00-filter.t
+++ b/ci/t/00-filter.t
@@ -1927,6 +1927,7 @@ Vary: X-No-Compression, Accept-Encoding
 GET /filter
 --- more_headers
 Accept-Encoding: zstd
+X-No-Compression: 1
 --- response_headers
 Content-Encoding:
 !Vary
@@ -1955,6 +1956,7 @@ Content-Encoding:
 GET /filter
 --- more_headers
 Accept-Encoding: zstd
+X-No-Compression: 1
 --- response_headers
 Content-Encoding:
 !Vary

--- a/ci/t/00-filter.t
+++ b/ci/t/00-filter.t
@@ -1902,6 +1902,67 @@ Vary: X-No-Compression, Accept-Encoding
 
 
 
+=== TEST 68b: below zstd_min_length never reaches the bypass decision, no bypass Vary
+# A31b-F4: zstd_bypass_vary must key only the responses for which this
+# module actually reaches the zstd_bypass fork (the compressed and
+# bypassed-identity variants). A response declined earlier by an
+# eligibility gate -- here, body smaller than zstd_min_length -- would be
+# identity regardless of the bypass predicate's value, so no bypass-driven
+# cache variance exists and no "Vary: X-No-Compression" line is added.
+# Accept-Encoding is still absent: this location has no gzip_vary and the
+# module's own Vary: Accept-Encoding push also sits below this gate.
+--- config
+    location /filter {
+        zstd on;
+        zstd_types text/plain;
+        zstd_min_length 60k;
+        zstd_bypass      $http_x_no_compression;
+        zstd_bypass_vary X-No-Compression;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test;
+    }
+    location /test {
+        root $TEST_NGINX_PERL_PATH/suite/;
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+Content-Encoding:
+!Vary
+--- no_error_log
+[error]
+
+
+
+=== TEST 68c: content type outside zstd_types never reaches the bypass decision, no bypass Vary
+# A31b-F4 negative control for the content-type eligibility gate: same
+# claim as TEST 68b, different gate. The fixture is served as text/plain
+# by default; restricting zstd_types to a type it does not match makes the
+# content-type gate the one that declines, above the bypass_vary push.
+--- config
+    location /filter {
+        zstd on;
+        zstd_types application/json;
+        zstd_bypass      $http_x_no_compression;
+        zstd_bypass_vary X-No-Compression;
+        proxy_pass http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test;
+    }
+    location /test {
+        root $TEST_NGINX_PERL_PATH/suite/;
+    }
+--- request
+GET /filter
+--- more_headers
+Accept-Encoding: zstd
+--- response_headers
+Content-Encoding:
+!Vary
+--- no_error_log
+[error]
+
+
+
 === TEST 69: quoted-string in coding-name position does not fabricate zstd
 # A quoted-string can never be a valid coding. With the name scan not
 # stopping at '"', the comma inside `"a,zstd "` split the element and the


### PR DESCRIPTION
The README said `zstd_bypass_vary` adds its field to every response from the
location. It only adds it to responses that actually reach the bypass
decision: a request that gets turned away earlier for being too small, the
wrong content type, or otherwise ineligible never asks whether the bypass
predicate fired, so there is nothing to declare varying on. I narrowed the
doc to say that instead of moving the code, because the code already matches
every other Vary push in this filter: each one sits exactly at the point
where its own invariant stops holding, and eligibility-gate rejections are
invariant with respect to the bypass predicate.

`ngx_http_zstd_header_filter()` pushes the operator-named field at
`src/ngx_http_zstd_filter_module.c:1676`, below all nine eligibility gates
and above the `zstd_bypass` check at line 1727. A response declined by an
eligibility gate would be identity regardless of what the bypass predicate
says, so moving the push above those gates would just add `Vary`
fragmentation to responses a shared cache never needs to key on that header.

Added TEST 68b and TEST 68c to `ci/t/00-filter.t`: a location with
`zstd_bypass_vary` set and the bypass predicate true, where the response is
declined first by `zstd_min_length` (68b) and by `zstd_types` (68c). Both
assert `Content-Encoding:` absent and `!Vary`.

Ran the negative control by hand: hoisted the push above the eligibility
gates, rebuilt the module, reran the suite. Both new tests failed on `header
Vary not present in the raw headers`; reverting the hoist brought them back
green. Full suite is 1404/1404 with the fix in place.

CodeRabbit flagged that the first draft of 68b/68c left `X-No-Compression`
unset, so the bypass predicate was false and the tests couldn't tell "no
Vary because ineligible" from "no Vary because bypass never fired". Fixed in
the second commit; both requests now set the header so the predicate is
true, and the tests still pass.
