### PR TITLE
docs(zstd): state which build path enables -DZSTD_STATIC_LINKING_ONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,21 @@ load_module modules/ngx_http_zstd_static_module.so;
 
 * Both `ngx_http_zstd_filter_module` and `ngx_http_zstd_static_module` are compiled together.
 * If you are using a custom zstd installation, set `ZSTD_INC` (path to `zstd.h`) and `ZSTD_LIB` (path to the library) before running `configure`. If unset, the system-installed zstd is used.
+* **This plain `./configure` line does not enable `-DZSTD_STATIC_LINKING_ONLY`.**
+  With no `ZSTD_INC`/`ZSTD_LIB` set, `auto/zstd` goes straight to
+  auto-discovery (dynamic linking, then pkg-config), and neither of those
+  paths ever defines the flag — it is only ever added when `ZSTD_INC` and
+  `ZSTD_LIB` are both set *and* they resolve to a static `libzstd.a`
+  (`zstd_static.lib` on MSVC) at that exact location. There is no configure
+  flag that turns it on directly. A build produced by the command above
+  therefore does **not** have the experimental memory-estimator API
+  compiled in: `zstd_max_cctx_memory` will fail `nginx -t` with
+  `"zstd_max_cctx_memory" requires the module to be built with
+  -DZSTD_STATIC_LINKING_ONLY ...`, and the implicit no-budget advisory
+  (see [Directives](#directives)) silently does not run. To get the flag,
+  point `ZSTD_INC`/`ZSTD_LIB` at a static libzstd build before running
+  `configure`; see [`zstd_max_cctx_memory`](#zstd_max_cctx_memory) and
+  [Compatibility](#compatibility) for the full requirement.
 * **Windows:** MSVC builds the modules statically into `nginx.exe`; MinGW-w64
   can also build them as dynamic `.so`-named PE DLLs. The SHA-pinned
   [`ci/tools/build-windows.sh`](ci/tools/build-windows.sh) assembles the MSVC build
@@ -232,10 +247,13 @@ Notes on the libzstd floor — these are enforced in code, not assumed:
   1.4.0 floor above is unaffected and unchanged.
 * **`zstd_max_cctx_memory`** additionally requires the module to be
   built with `-DZSTD_STATIC_LINKING_ONLY` so libzstd's experimental
-  memory-estimator API is available. The project's production and CI
-  builds enable that flag; without it, the directive is rejected at
-  config load with a clear, actionable error rather than silently
-  no-op'd.
+  memory-estimator API is available. This project's own CI opts into
+  that flag by pointing `ZSTD_INC`/`ZSTD_LIB` at a static libzstd (see
+  [Installation](#installation)) — it is **not** the outcome of the
+  plain `./configure --add-dynamic-module=...` command documented
+  above, which auto-discovers a dynamic libzstd and never defines the
+  flag. Without it, the directive is rejected at config load with a
+  clear, actionable error rather than silently no-op'd.
 
 "CI-verified" means the PR or weekly deep workflow builds and runs the full
 test suite against that exact version (see [Testing & CI](#testing--ci)). Other
@@ -722,7 +740,7 @@ location /api/bulk-export {
 **Syntax:** `zstd_max_cctx_memory size;`
 **Default:** `—` (no budget enforced; see [the advisory](#implicit-advisory-when-no-budget-is-set) below)
 **Context:** `http, server, location`
-**Requires:** module built with `-DZSTD_STATIC_LINKING_ONLY` against libzstd ≥ 1.4.0 (the project's production and CI builds do; see [Compatibility](#compatibility)).
+**Requires:** module built with `-DZSTD_STATIC_LINKING_ONLY` against libzstd ≥ 1.4.0. This is **not** the result of the plain `./configure --add-dynamic-module=...` command in [Installation](#installation) — that auto-discovers a dynamic libzstd and never defines the flag. It is only set when `ZSTD_INC`/`ZSTD_LIB` point at a static libzstd build; see [Installation](#installation) and [Compatibility](#compatibility).
 
 Asserts at **config load** that the combined zstd parameters configured
 for the location (`zstd_comp_level`, `zstd_window_log`, `zstd_long`,

--- a/ci/tools/test_docs_ci_drift.sh
+++ b/ci/tools/test_docs_ci_drift.sh
@@ -111,6 +111,37 @@ if [ -f SECURITY.md ] && grep -q 'AGENTS\.md' SECURITY.md; then
     fail=1
 fi
 
+# --- README's -DZSTD_STATIC_LINKING_ONLY claim must match auto/zstd's
+# actual behavior (audit A31b-F5): the flag is committed to CFLAGS only
+# inside the `ZSTD_INC`/`ZSTD_LIB` static-archive branch (auto/zstd's
+# "we try the static library first" section) -- auto-discovery (no
+# ZSTD_INC/ZSTD_LIB) and pkg-config never define it. The documented plain
+# `./configure --add-dynamic-module=...` command therefore does not carry
+# the flag, so README.md must say so explicitly rather than imply the
+# flag is just "on" for anyone following the docs. This is a docs-drift
+# regression test, not a build-behavior change: it never touches
+# auto/zstd or the release build flags. ---
+# shellcheck disable=SC2016  # literal grep pattern: $ZSTD_INC/$ must not expand
+if ! grep -q '^[[:space:]]*ngx_zstd_opt_I="-I\$ZSTD_INC -DZSTD_STATIC_LINKING_ONLY"$' auto/zstd; then
+    echo "FAIL: auto/zstd no longer stages -DZSTD_STATIC_LINKING_ONLY in the ZSTD_INC/ZSTD_LIB static-archive branch the way this test expects -- update auto/zstd's staging line or this test together with README.md's Installation/Compatibility wording"
+    fail=1
+fi
+if grep -q 'auto-discovery' auto/zstd \
+    && grep -A2 '# auto-discovery: prefer dynamic linking' auto/zstd \
+       | grep -q 'DZSTD_STATIC_LINKING_ONLY'; then
+    echo "FAIL: auto/zstd's auto-discovery branch now defines -DZSTD_STATIC_LINKING_ONLY -- README.md's 'plain ./configure does not enable it' claim is stale and must be rewritten to match"
+    fail=1
+fi
+# shellcheck disable=SC2016  # literal README phrase, backticks must not run
+if ! grep -Fq 'does not enable `-DZSTD_STATIC_LINKING_ONLY`' README.md; then
+    echo "FAIL: README.md Installation section no longer states that the plain ./configure command does not enable -DZSTD_STATIC_LINKING_ONLY (audit A31b-F5 regression)"
+    fail=1
+fi
+if grep -Fq 'production and CI builds enable that flag' README.md; then
+    echo "FAIL: README.md re-introduced the 'production and CI builds enable that flag' phrasing, which reads as the flag being on by default rather than requiring ZSTD_INC/ZSTD_LIB pointed at a static libzstd (audit A31b-F5 regression)"
+    fail=1
+fi
+
 # --- CONTRIBUTING.md's -Werror claim about the fuzz harness must match
 # reality: only assert this if a fuzz build step actually exists and does
 # NOT pass -Werror, since a future CI change legitimately flipping this on

--- a/ci/tools/test_docs_ci_drift.sh
+++ b/ci/tools/test_docs_ci_drift.sh
@@ -126,10 +126,17 @@ if ! grep -q '^[[:space:]]*ngx_zstd_opt_I="-I\$ZSTD_INC -DZSTD_STATIC_LINKING_ON
     echo "FAIL: auto/zstd no longer stages -DZSTD_STATIC_LINKING_ONLY in the ZSTD_INC/ZSTD_LIB static-archive branch the way this test expects -- update auto/zstd's staging line or this test together with README.md's Installation/Compatibility wording"
     fail=1
 fi
-if grep -q 'auto-discovery' auto/zstd \
-    && grep -A2 '# auto-discovery: prefer dynamic linking' auto/zstd \
-       | grep -q 'DZSTD_STATIC_LINKING_ONLY'; then
-    echo "FAIL: auto/zstd's auto-discovery branch now defines -DZSTD_STATIC_LINKING_ONLY -- README.md's 'plain ./configure does not enable it' claim is stale and must be rewritten to match"
+# Extract the WHOLE auto-discovery `else` branch (from its marker comment to
+# the closing `fi` at the same indent) rather than a fixed window, so the flag
+# cannot be reintroduced anywhere inside it and still pass this test.
+zstd_autodisco_branch=$(
+    sed -n '/^    # auto-discovery: prefer dynamic linking/,/^fi$/p' auto/zstd
+)
+if [ -z "$zstd_autodisco_branch" ]; then
+    echo "FAIL: could not locate auto/zstd's auto-discovery branch (the '# auto-discovery: prefer dynamic linking' marker or its closing 'fi' moved) -- update this test together with auto/zstd and README.md"
+    fail=1
+elif printf '%s\n' "$zstd_autodisco_branch" | grep -q 'DZSTD_STATIC_LINKING_ONLY'; then
+    echo "FAIL: auto/zstd's auto-discovery branch now mentions -DZSTD_STATIC_LINKING_ONLY -- README.md's 'plain ./configure does not enable it' claim is stale and must be rewritten to match"
     fail=1
 fi
 # shellcheck disable=SC2016  # literal README phrase, backticks must not run


### PR DESCRIPTION
## What

`README.md` presented `-DZSTD_STATIC_LINKING_ONLY` as effectively the state of a normal build ("the project's production and CI builds enable that flag"). It is not: the documented `./configure --add-dynamic-module=...` line, with no `ZSTD_INC`/`ZSTD_LIB` set, goes straight to `auto/zstd`'s auto-discovery branch (dynamic, then pkg-config), and neither path defines the flag. The define is committed to `CFLAGS` only at `auto/zstd:108`, inside the `ZSTD_INC`/`ZSTD_LIB` static-archive branch, and only once that archive is confirmed.

Consequence for anyone following the docs: `zstd_max_cctx_memory` hard-fails `nginx -t`, and the implicit no-budget advisory silently never runs.

Audit row A31b-F5.

## Approach

Documentation only, plus a drift guard. `auto/zstd`, the release artifact flags and the build logic are deliberately untouched — the finding is explicit that the docs are wrong, not the build. The opt-in static path remains documented and supported.

- **Installation** now states plainly that the plain `./configure` line does not enable the flag, that there is no configure switch for it, how the gap manifests, and how to opt in.
- **Compatibility** and the **`zstd_max_cctx_memory`** directive entry drop the "production and CI builds enable that flag" framing for the actual condition.
- `ci/tools/test_docs_ci_drift.sh` gains assertions anchoring the README claim to `auto/zstd`'s real staging line and to the auto-discovery branch never defining the flag, so the wording cannot silently drift back.

## Verification

- `ci/tools/test_docs_ci_drift.sh` green on the branch.
- Negative controls, each red then reverted: removing the README claim; removing the `auto/zstd` staging line; injecting `-DZSTD_STATIC_LINKING_ONLY` into the pkg-config fallback deep inside the auto-discovery branch.
- That last control is why the second commit exists — the first version of the check only looked two lines past the marker comment and would have passed. It now extracts the whole branch and also fails if the markers themselves move.
- `review-lint.sh --branch origin/master`: clean. `shfmt` reports pre-existing whole-file indentation drift in `test_docs_ci_drift.sh`, unrelated to this diff and tracked separately as A30-N7.
- CodeRabbit reviewed the branch; the drift-scoping finding is fixed in the second commit.