### PR TITLE
test(zstd): cover legacy Accept-Encoding branch-equivalence (A30-F1)

### DIFF
--- a/ci/tests/unit/test_accept_encoding_legacy.c
+++ b/ci/tests/unit/test_accept_encoding_legacy.c
@@ -2,12 +2,26 @@
  * SPDX-License-Identifier: BSD-2-Clause
  *
  * nginx 1.22.1-shaped regression checks.  Its ngx_table_elt_t has no next
- * member; repeated request headers remain in headers_in.headers. */
+ * member; repeated request headers remain in headers_in.headers.
+ *
+ * This TU is compiled twice by ci/tests/unit/run.sh: once with
+ * -DNGX_ZSTD_LEGACY_SHIM (the pre-1.23.0 shape, exercising the #else branch
+ * of ngx_http_zstd_request_coding_weight() that walks headers_in.headers),
+ * and once without it (the >= 1.23.0 shape, exercising the ->next chain via
+ * ngx_http_zstd_chain_coding_weight()). Every case below therefore runs
+ * under both branches and must agree -- branch-equivalence is the oracle
+ * for A30-F1 ("repeated Accept-Encoding fields must not be dropped on
+ * old-nginx"), since a real second implementation of RFC 9110 comma-joining
+ * does not exist to diff against.
+ */
 #include "../../fuzz/ngx_shim.h"
 #include "../../fuzz/generated_parser.inc"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+
+#define MAX_HEADERS 8
 
 static int failures;
 static int checks;
@@ -24,31 +38,82 @@ check(int ok, const char *what)
     }
 }
 
+/*
+ * Build a headers_in.headers list from `n` (name, value) pairs and decide
+ * ngx_http_zstd_accepts() over it. A NULL name defaults to "Accept-Encoding"
+ * -- pass an explicit non-AE name to interleave an unrelated header, or a
+ * case-varied spelling ("accept-encoding" / "ACCEPT-ENCODING") to prove the
+ * match is case-insensitive (ngx_strncasecmp, matching upstream).
+ */
 static ngx_int_t
-request_decide(const char *first, const char *second)
+request_decide_named(const char *names[], const char *values[], size_t n)
 {
-    ngx_table_elt_t    headers[2];
-    ngx_http_request_t r;
+    ngx_table_elt_t     headers[MAX_HEADERS];
+    ngx_http_request_t  r;
+    size_t               i;
+#if !defined(NGX_ZSTD_LEGACY_SHIM)
+    ngx_table_elt_t     *first_ae = NULL;
+    ngx_table_elt_t     *prev_ae = NULL;
+#endif
+
+    if (n > MAX_HEADERS) {
+        /*
+         * A fixture bug, not a parser result: silently truncating would let
+         * a future over-sized table test fewer headers than the case
+         * claims and still report a pass. Fail loudly instead.
+         */
+        fprintf(stderr, "test fixture error: %zu headers exceeds "
+                "MAX_HEADERS (%d)\n", n, MAX_HEADERS);
+        abort();
+    }
 
     memset(&r, 0, sizeof(r));
     memset(headers, 0, sizeof(headers));
-    headers[0].key.data = (u_char *) "Accept-Encoding";
-    headers[0].key.len = sizeof("Accept-Encoding") - 1;
-    headers[0].value.data = (u_char *) first;
-    headers[0].value.len = strlen(first);
-    headers[1].key.data = (u_char *) "Accept-Encoding";
-    headers[1].key.len = sizeof("Accept-Encoding") - 1;
-    headers[1].value.data = (u_char *) second;
-    headers[1].value.len = strlen(second);
+
+    for (i = 0; i < n; i++) {
+        const char *name = names[i] ? names[i] : "Accept-Encoding";
+
+        headers[i].key.data = (u_char *) name;
+        headers[i].key.len = strlen(name);
+        headers[i].value.data = (u_char *) values[i];
+        headers[i].value.len = strlen(values[i]);
+
 #if !defined(NGX_ZSTD_LEGACY_SHIM)
-    headers[0].next = &headers[1];
+        headers[i].next = NULL;
+
+        if (headers[i].key.len == sizeof("Accept-Encoding") - 1
+            && ngx_strncasecmp(headers[i].key.data,
+                                (u_char *) "Accept-Encoding",
+                                sizeof("Accept-Encoding") - 1) == 0)
+        {
+            if (first_ae == NULL) {
+                first_ae = &headers[i];
+            } else {
+                prev_ae->next = &headers[i];
+            }
+            prev_ae = &headers[i];
+        }
 #endif
+    }
+
     r.main = &r;
-    r.headers_in.accept_encoding = &headers[0];
+#if !defined(NGX_ZSTD_LEGACY_SHIM)
+    r.headers_in.accept_encoding = first_ae;
+#endif
     r.headers_in.headers.part.elts = headers;
-    r.headers_in.headers.part.nelts = 2;
+    r.headers_in.headers.part.nelts = n;
+    r.headers_in.headers.part.next = NULL;
 
     return ngx_http_zstd_accepts(&r);
+}
+
+static ngx_int_t
+request_decide(const char *first, const char *second)
+{
+    const char *names[2]  = { NULL, NULL };
+    const char *values[2] = { first, second };
+
+    return request_decide_named(names, values, 2);
 }
 
 int
@@ -62,6 +127,73 @@ main(void)
           "later explicit zstd allowance wins");
     check(request_decide("zstd;q=1", "zstd;q=0") == NGX_DECLINED,
           "later explicit zstd refusal wins");
+
+    /* A30-F1: reversed order of the named case. */
+    check(request_decide("zstd;q=0", "*") == NGX_DECLINED,
+          "A30-F1 reversed: explicit zstd;q=0 first, wildcard second, still declines");
+
+    /* A30-F1: partial q rather than exact zero. */
+    check(request_decide("zstd;q=0.5", "zstd;q=0") == NGX_DECLINED,
+          "A30-F1: zstd;q=0.5 then zstd;q=0 -- later explicit weight wins, declines");
+    check(request_decide("zstd;q=0", "zstd;q=0.5") == NGX_OK,
+          "A30-F1: zstd;q=0 then zstd;q=0.5 -- later explicit weight wins, accepts");
+
+    /* Wildcard only, no explicit token anywhere. */
+    check(request_decide("*", "gzip") == NGX_OK,
+          "A30-F1: wildcard-only field (no explicit zstd token) accepts via '*'");
+
+    /* Explicit token only, no wildcard anywhere. */
+    check(request_decide("zstd", "gzip") == NGX_OK,
+          "A30-F1: explicit-token-only field accepts, no wildcard involved");
+
+    /* Three occurrences. */
+    {
+        const char *names3[3]  = { NULL, NULL, NULL };
+        const char *values3[3] = { "*", "gzip", "zstd;q=0" };
+
+        check(request_decide_named(names3, values3, 3) == NGX_DECLINED,
+              "A30-F1: three occurrences, explicit zstd;q=0 last overrides "
+              "earlier wildcard");
+    }
+
+    /* Four occurrences, zstd only on the last one. */
+    {
+        const char *names4[4]  = { NULL, NULL, NULL, NULL };
+        const char *values4[4] = { "gzip", "br", "identity", "zstd" };
+
+        check(request_decide_named(names4, values4, 4) == NGX_OK,
+              "A30-F1: four occurrences, explicit zstd on the fourth accepts");
+    }
+
+    /* An occurrence with an empty value interleaved. */
+    {
+        const char *namesE[3]  = { NULL, NULL, NULL };
+        const char *valuesE[3] = { "", "zstd;q=0", "*" };
+
+        check(request_decide_named(namesE, valuesE, 3) == NGX_DECLINED,
+              "A30-F1: empty-value occurrence contributes nothing; explicit "
+              "zstd;q=0 still overrides the later wildcard");
+    }
+
+    /* A non-Accept-Encoding header interleaved between two AE occurrences. */
+    {
+        const char *namesX[3]  = { NULL, "X-Requested-With", NULL };
+        const char *valuesX[3] = { "*", "XMLHttpRequest", "zstd;q=0" };
+
+        check(request_decide_named(namesX, valuesX, 3) == NGX_DECLINED,
+              "A30-F1: named case with an unrelated header interleaved "
+              "between the two Accept-Encoding lines still declines");
+    }
+
+    /* Case-varied header names must still be recognised as Accept-Encoding. */
+    {
+        const char *namesC[2]  = { "accept-encoding", "ACCEPT-ENCODING" };
+        const char *valuesC[2] = { "*", "zstd;q=0" };
+
+        check(request_decide_named(namesC, valuesC, 2) == NGX_DECLINED,
+              "A30-F1: case-varied header names ('accept-encoding' / "
+              "'ACCEPT-ENCODING') still match and the named case declines");
+    }
 
     printf("\n%d/%d checks passed\n", checks - failures, checks);
     return failures ? 1 : 0;


### PR DESCRIPTION
## Summary

A30-F1 asked for coverage proving repeated `Accept-Encoding` header fields
are preserved on nginx 1.9.11-1.22.x. Investigation found the production
code already correct: `ngx_http_zstd_request_coding_weight()` in
`src/ngx_http_zstd_common.h` has an `#if (nginx_version >= 1023000)` modern
branch delegating to `ngx_http_zstd_chain_coding_weight()`, and an `#else`
legacy branch that walks `r->headers_in.headers` applying the identical
explicit-token-beats-wildcard precedence. No production code needed to
change.

What was missing was coverage: `ci/tests/unit/test_accept_encoding_legacy.c`
existed and was already wired into `ci/tests/unit/run.sh` (compiled twice --
once with `NGX_ZSTD_LEGACY_SHIM` against the pre-1.23 `headers_in.headers`
walk, once without it against the `->next` chain -- so both storage shapes
run the same table and must agree), but it only carried four cases.

This PR extends that fixture with:
- the named case reversed (`zstd;q=0` first, `*` second)
- `zstd;q=0.5` then `zstd;q=0`, and the reverse
- wildcard-only and explicit-token-only fields
- three and four occurrences
- an occurrence with an empty value
- a non-Accept-Encoding header interleaved between two AE occurrences
- case-varied header names (`accept-encoding`, `ACCEPT-ENCODING`)

Also fixed (CodeRabbit finding): the fixture builder silently truncated a
case table over `MAX_HEADERS` instead of failing loudly.

## Integration leg

CI has no nginx-1.22.1-pinned leg to extend -- `build-test.yml` resolves
and builds against latest nginx only. Standing one up was judged
disproportionate for this row: the dual-shim unit fixture is the stronger
oracle here anyway, since it asserts the exact branch taken rather than
inferring it from a live proxy's response.

## Test plan

- [x] `bash ci/tests/unit/run.sh` -- full suite green, both shim shapes,
      14/14 legacy-fixture checks passed under each
- [x] Mutation: swapped explicit-token/wildcard precedence in the legacy
      `#else` branch -- 7 of 14 checks (including the named case) went red;
      restoring the source made all 14 green again
- [x] `.claude/skills/_shared/review-lint.sh --diff HEAD` clean
- [x] `coderabbit review --agent --uncommitted --include-untracked` --
      1 finding, fixed, re-ran clean (0 findings)