### PR TITLE
ci(zstd): retarget .gitattributes byte-exact rules to fuzz fixture dirs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,6 +24,18 @@ ci/fuzz/fuzz.dict -text
 # the on-disk size and fails every identity-response assertion.
 ci/t/suite/* -text
 
+# More byte-exact fuzz fixtures: corpus_dcz/* are raw dcz-dict header
+# bytes, and regressions{,_dcz}/* are saved crash-reproducer inputs —
+# core.autocrlf=true would smudge either and corrupt the fuzzer's inputs
+# or make a saved crash stop reproducing. Each regressions dir also has a
+# real README.md, which must stay text; order it after the wildcard so
+# the more specific rule wins.
+ci/fuzz/corpus_dcz/* -text
+ci/fuzz/regressions/* -text
+ci/fuzz/regressions/README.md text
+ci/fuzz/regressions_dcz/* -text
+ci/fuzz/regressions_dcz/README.md text
+
 # CI-only stub module (linkage-isolation job); keep it out of release
 # tarballs (git archive). Its former sibling, the vary-suppression
 # stub, no longer exists in the tree.

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -261,6 +261,9 @@ jobs:
       - name: nginx-module-testkit scenario runner controls
         run: bash "$GITHUB_WORKSPACE"/ci/tools/test_run_testkit_scenarios.sh
 
+      - name: .gitattributes byte-exactness and archive-exclusion regressions (A30-F5)
+        run: bash "$GITHUB_WORKSPACE"/ci/tools/test_gitattributes.sh
+
       - name: Shell script linting (shellcheck)
         run: |
           # Gate on error-severity findings (real bugs); style/info noise does

--- a/ci/tools/test_gitattributes.sh
+++ b/ci/tools/test_gitattributes.sh
@@ -1,0 +1,143 @@
+#!/bin/sh
+# Gates .gitattributes byte-exactness for the fuzz/test fixture dirs
+# (A30-F5): corpus_dcz/*, regressions/*, regressions_dcz/*, plus the
+# previously-covered corpus/*, fuzz.dict and t/suite/*. core.autocrlf=true
+# smudges any path git treats as text, corrupting raw fuzzer inputs and
+# saved crash reproducers -- there was no test anywhere pinning this
+# before. Also checks the ci-linkcheck-module archive-exclusion rule.
+#
+# Each assertion below has a paired negative control: a known-text file
+# that must report "text: set", and a hash-under-autocrlf check against a
+# deliberately text-treated temp file that must differ. Both prove the
+# assertion can fail, not just that it happens to pass today.
+
+set -eu
+
+cd "$(dirname "$0")/../.."
+REPO_ROOT="$(pwd)"
+
+FAIL=0
+
+fail() {
+    echo "FAIL: $1" >&2
+    FAIL=1
+}
+
+# --- a) byte-exact dirs report text: unset ---------------------------------
+
+BYTE_EXACT_PATHS="
+ci/fuzz/corpus/01_bare
+ci/fuzz/corpus_dcz/bad_hash
+ci/fuzz/fuzz.dict
+ci/fuzz/regressions/crash-wildcard-precedence-flip
+ci/fuzz/regressions_dcz/crash-dcz-framing-ok-payload-bad
+ci/t/suite/test
+ci/t/suite/dcz-dict
+"
+
+for p in $BYTE_EXACT_PATHS; do
+    [ -n "$p" ] || continue
+    attr="$(git check-attr text -- "$p" | sed 's/.*: text: //')"
+    if [ "$attr" != "unset" ]; then
+        fail "expected 'text: unset' for byte-exact fixture $p, got '$attr'"
+    fi
+done
+
+# Negative control for (a): a known-text file must NOT be unset.
+attr="$(git check-attr text -- ci/tools/patches/README 2>/dev/null | sed 's/.*: text: //')"
+if [ -z "$attr" ] || [ "$attr" = "unset" ]; then
+    # patches/README may not exist; fall back to any *.sh, which is
+    # unconditionally "text eol=lf" in .gitattributes.
+    attr="$(git check-attr text -- ci/tools/test_sha256_unit.sh | sed 's/.*: text: //')"
+fi
+if [ "$attr" != "set" ]; then
+    fail "negative control: expected 'text: set' for a known-text file, got '$attr'"
+fi
+
+# regressions READMEs must stay text (the exception rule must win).
+for p in ci/fuzz/regressions/README.md ci/fuzz/regressions_dcz/README.md; do
+    if [ -f "$p" ]; then
+        attr="$(git check-attr text -- "$p" | sed 's/.*: text: //')"
+        if [ "$attr" != "set" ]; then
+            fail "expected 'text: set' for $p (README exception), got '$attr'"
+        fi
+    fi
+done
+
+# --- b) autocrlf hash control -----------------------------------------------
+
+TMPDIR_WORK="$(mktemp -d "${TMPDIR:-/tmp}/zstd-gitattributes-test.XXXXXX")"
+cleanup() {
+    rm -rf "$TMPDIR_WORK"
+}
+trap cleanup EXIT INT TERM
+
+# Pick a byte-exact fixture that is plausible to contain a bare LF (so an
+# autocrlf smudge would actually change it): the dcz corpus fixtures are
+# fixed-format hash strings without embedded newlines in some cases, so
+# use the fuzz corpus entry that is known to include control bytes/LF in
+# its Accept-Encoding header samples.
+HASH_FIXTURE="ci/fuzz/corpus_dcz/valid_hash"
+if [ ! -f "$HASH_FIXTURE" ]; then
+    fail "expected fixture missing: $HASH_FIXTURE"
+else
+    committed_sha="$(git cat-file blob "HEAD:$HASH_FIXTURE" | sha256sum | cut -d' ' -f1)"
+
+    checkout_dir="$TMPDIR_WORK/autocrlf-checkout"
+    mkdir -p "$checkout_dir"
+    ( cd "$checkout_dir" && git -C "$REPO_ROOT" -c core.autocrlf=true archive HEAD "$HASH_FIXTURE" | tar -x )
+    smudged_sha="$(sha256sum "$checkout_dir/$HASH_FIXTURE" | cut -d' ' -f1)"
+
+    if [ "$committed_sha" != "$smudged_sha" ]; then
+        fail "byte-exact fixture $HASH_FIXTURE changed under core.autocrlf=true smudging (committed=$committed_sha smudged=$smudged_sha)"
+    fi
+fi
+
+# Negative control for (b): a deliberately text-treated file with CRLF
+# content in its committed blob MUST change hash under autocrlf smudging,
+# proving the hash comparison itself is capable of catching a real
+# regression (git's autocrlf=true checkout normalizes CRLF -> LF for any
+# path git considers text).
+control_repo="$TMPDIR_WORK/control-repo"
+mkdir -p "$control_repo"
+(
+    cd "$control_repo"
+    git init -q
+    git config user.email test@example.invalid
+    git config user.name test
+    printf 'line one\r\nline two\r\n' > crlf.txt
+    printf '*.txt text\n' > .gitattributes
+    git add crlf.txt .gitattributes
+    git commit -q -m control
+)
+control_committed_sha="$(git -C "$control_repo" cat-file blob HEAD:crlf.txt | sha256sum | cut -d' ' -f1)"
+control_checkout="$TMPDIR_WORK/control-checkout"
+mkdir -p "$control_checkout"
+( cd "$control_checkout" && git -C "$control_repo" -c core.autocrlf=true archive HEAD crlf.txt | tar -x )
+control_smudged_sha="$(sha256sum "$control_checkout/crlf.txt" | cut -d' ' -f1)"
+
+if [ "$control_committed_sha" = "$control_smudged_sha" ]; then
+    fail "negative control: expected a text-attributed CRLF file to change hash under core.autocrlf=true smudging, but it did not (test cannot detect a real regression)"
+fi
+
+# --- c) archive excludes ci-linkcheck-module --------------------------------
+
+leaked="$(git archive HEAD | tar -t | grep -c '^ci/tools/ci-linkcheck-module/' || true)"
+if [ "$leaked" -ne 0 ]; then
+    fail "git archive HEAD leaked $leaked ci-linkcheck-module entries (export-ignore rule broken)"
+fi
+
+# Negative control for (c): a path NOT covered by export-ignore must
+# still appear in the archive, proving the tar listing/grep can see a
+# real entry when one exists.
+present="$(git archive HEAD | tar -t | grep -c '^ci/tools/test_sha256_unit.sh$' || true)"
+if [ "$present" -eq 0 ]; then
+    fail "negative control: expected ci/tools/test_sha256_unit.sh present in git archive HEAD, found none"
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+    echo "FAIL: .gitattributes byte-exactness / archive-exclusion checks failed" >&2
+    exit 1
+fi
+
+echo "OK: .gitattributes byte-exact fixture rules and archive exclusion verified (with negative controls)"


### PR DESCRIPTION
## What was stale vs live

Supervisor-verified check against origin/master bbd653d found:
- Already correct (left alone): `ci/fuzz/corpus/*`, `ci/fuzz/fuzz.dict`, `ci/t/suite/*`, `/ci/tools/ci-linkcheck-module export-ignore`, `ci/tools/patches/**`.
- Genuinely live gap: `ci/fuzz/corpus_dcz/*` (12 raw dcz-dict header fixtures), `ci/fuzz/regressions/*`, and `ci/fuzz/regressions_dcz/*` had `text: unspecified` — no byte-preserving rule, so `core.autocrlf=true` smudges them and corrupts fuzzer inputs / saved crash reproducers.
- No test anywhere gated `.gitattributes` (`grep -rln check-attr ci/ .github/` found only an unrelated hit in `gen_dict.sh`).

## What this PR does

1. Adds `-text` rules for `ci/fuzz/corpus_dcz/*`, `ci/fuzz/regressions/*`, and `ci/fuzz/regressions_dcz/*`, keeping each dir's `README.md` as normal text (ordered after the wildcard so the more specific rule wins). No existing rule was rewritten.
2. Adds `ci/tools/test_gitattributes.sh` (POSIX sh) asserting:
   - `text: unset` for a representative file in every byte-exact dir (old and new).
   - An autocrlf hash control: a byte-exact fixture's blob is unchanged when checked out via `git -c core.autocrlf=true archive | tar -x`, compared by sha256 against `git cat-file blob HEAD:<path>`.
   - `git archive HEAD | tar -t` contains zero `ci/tools/ci-linkcheck-module/` entries.
   - A negative control for each of the above (known-text file reports `text: set`; a deliberately text-attributed CRLF fixture in a throwaway repo DOES change hash under autocrlf; a non-excluded file IS present in the archive listing).
3. Wires the test into the existing Lint job in `.github/workflows/build-test.yml`, alongside the other standalone `ci/tools/test_*.sh` checks that need no nginx build.

## Negative-control evidence

- Removed the `corpus_dcz/* -text` rule and committed: test failed with `expected 'text: unset' for byte-exact fixture ci/fuzz/corpus_dcz/bad_hash, got 'unspecified'`. Reverted, test passes again.
- Removed the `/ci/tools/ci-linkcheck-module export-ignore` line and committed: test failed with `git archive HEAD leaked 3 ci-linkcheck-module entries (export-ignore rule broken)`. Reverted, test passes again.
- The script's own negative controls (known-text file, throwaway-repo CRLF fixture, non-excluded archive entry) all pass on every run, proving each assertion is reachable and not vacuous.

## Test plan

- [x] `bash ci/tools/test_gitattributes.sh` passes
- [x] `shellcheck ci/tools/test_gitattributes.sh` clean
- [x] `actionlint .github/workflows/build-test.yml` clean
- [x] `.claude/skills/_shared/review-lint.sh --diff HEAD` clean on the diff (pre-existing yamllint line-length/shfmt findings on unrelated lines, not introduced here)