### PR TITLE
ci(zstd): CI reliability sweep (LASTEXITCODE oracle, coverage bailout, stale bump paths, stale Windows pin)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{sh,bash}]
+indent_style = space
+indent_size = 4
+switch_case_indent = true
+binary_next_line = true

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -167,7 +167,8 @@ jobs:
           events {}
           http { server { listen 127.0.0.1:18080; zstd_not_a_directive on; } }
           '@ | Set-Content -Encoding ascii conf/invalid.conf
-          if (& .\objs\nginx.exe -t -p . -c conf/invalid.conf 2>$null) {
+          & .\objs\nginx.exe -t -p . -c conf/invalid.conf 2>$null
+          if ($LASTEXITCODE -eq 0) {
             throw 'invalid zstd directive was accepted'
           }
           & .\objs\nginx.exe -t -p . -c conf/nginx.conf

--- a/ci/linter/install-linters.sh
+++ b/ci/linter/install-linters.sh
@@ -136,9 +136,12 @@ if [ "$CHECK" -eq 1 ]; then
             rc=1
         fi
     done
-    perl -MTest::Nginx::Socket -e1 2>/dev/null \
-        && printf '%-14s ok\n' 'Test::Nginx' \
-        || { printf '%-14s MISSING\n' 'Test::Nginx'; rc=1; }
+    if perl -MTest::Nginx::Socket -e1 2>/dev/null; then
+        printf '%-14s ok\n' 'Test::Nginx'
+    else
+        printf '%-14s MISSING\n' 'Test::Nginx'
+        rc=1
+    fi
     exit "$rc"
 fi
 

--- a/ci/tools/build-windows.sh
+++ b/ci/tools/build-windows.sh
@@ -235,6 +235,11 @@ if [ "$WITH_BROTLI" = 1 ]; then
 fi
 if [ "$WITH_ZSTD" = 1 ]; then
     echo "nginx-zstd-module: repo=$REPO_ZSTD_MODULE ref=$REF_ZSTD_MODULE" >&2
+    # clone_module runs a real git-clone even when REPO_ZSTD_MODULE resolved
+    # to a local checkout path (the default above) -- that only pulls
+    # COMMITTED history, so uncommitted working-tree edits in that checkout
+    # are not part of this build. Commit (even to a throwaway branch) before
+    # building to include local changes.
     clone_module nginx-zstd-module "$REPO_ZSTD_MODULE" "$REF_ZSTD_MODULE"
 fi
 

--- a/ci/tools/build-windows.sh
+++ b/ci/tools/build-windows.sh
@@ -75,10 +75,33 @@ SHA_ZSTD=eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3
 # failure). Overridable so a fix branch can be tested before it lands:
 #   REPO_ZSTD_MODULE=<fork url> REF_ZSTD_MODULE=<branch> (fresh clone
 #   required when switching repos — the existing clone's origin wins).
-# The zstd-module pin is the squash commit that brought the MSVC
-# support this script depends on.
-REPO_ZSTD_MODULE=${REPO_ZSTD_MODULE:-https://github.com/myguard-labs/nginx-zstd-module.git}
-REF_ZSTD_MODULE=${REF_ZSTD_MODULE:-37cf9ac6b58284ae2da95620f4905930d1277b54}
+#
+# The zstd module default resolves to the CURRENT CHECKOUT (this script's
+# own repo, HEAD), not a fixed historical commit (audit A30-F3: a static
+# commit pin here drifted ~154 commits behind and silently built a stale
+# module even though the README presents this script alongside current
+# behaviour). REPO_ZSTD_MODULE/REF_ZSTD_MODULE stay fully overridable for
+# the deliberate self-pin / fork-testing use case documented above.
+_zstd_module_repo_root() {
+    # SCRIPT_DIR is not assigned yet this early — derive it locally so this
+    # default resolves regardless of where DIR_PROJECT/SCRIPT_DIR end up.
+    local script_dir
+    script_dir=$(cd "$(dirname "$0")" && pwd)
+    git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || true
+}
+if [ -z "${REPO_ZSTD_MODULE:-}" ] || [ -z "${REF_ZSTD_MODULE:-}" ]; then
+    _default_zstd_root="$(_zstd_module_repo_root)"
+    if [ -n "$_default_zstd_root" ] && [ -d "$_default_zstd_root/ci/tools" ]; then
+        REPO_ZSTD_MODULE=${REPO_ZSTD_MODULE:-$_default_zstd_root}
+        REF_ZSTD_MODULE=${REF_ZSTD_MODULE:-$(git -C "$_default_zstd_root" rev-parse HEAD)}
+    else
+        # Not running from inside a nginx-zstd-module checkout (e.g. a
+        # standalone copy of this script) — fall back to the last commit
+        # verified to build cleanly under this script, same as before.
+        REPO_ZSTD_MODULE=${REPO_ZSTD_MODULE:-https://github.com/myguard-labs/nginx-zstd-module.git}
+        REF_ZSTD_MODULE=${REF_ZSTD_MODULE:-37cf9ac6b58284ae2da95620f4905930d1277b54}
+    fi
+fi
 REPO_BROTLI=${REPO_BROTLI:-https://github.com/mreiden/ngx_brotli.git}
 REF_BROTLI=${REF_BROTLI:-a7705082d191df904f25fe82188c4dd87e16ff8d}
 REPO_HEADERS_MORE=${REPO_HEADERS_MORE:-https://github.com/openresty/headers-more-nginx-module.git}
@@ -210,8 +233,10 @@ if [ "$WITH_BROTLI" = 1 ]; then
         cmake --build ngx_brotli/deps/brotli/out
     fi
 fi
-[ "$WITH_ZSTD" = 1 ] \
-    && clone_module nginx-zstd-module "$REPO_ZSTD_MODULE" "$REF_ZSTD_MODULE"
+if [ "$WITH_ZSTD" = 1 ]; then
+    echo "nginx-zstd-module: repo=$REPO_ZSTD_MODULE ref=$REF_ZSTD_MODULE" >&2
+    clone_module nginx-zstd-module "$REPO_ZSTD_MODULE" "$REF_ZSTD_MODULE"
+fi
 
 cd ../..   # back to nginx-$VER_NGINX
 

--- a/ci/tools/bump-versions.sh
+++ b/ci/tools/bump-versions.sh
@@ -15,13 +15,13 @@
 #     no static mainline pin in this repo to bump.
 #   - nginx STABLE pin  -- ci-deep.yml's build-flavors matrix (label: stable)
 #   - angie pin         -- ci-deep.yml's build-flavors matrix (label: angie)
-#   - NGINX_SHA256       -- tools/ci-build.sh, nginx-stable only (verified
+#   - NGINX_SHA256       -- ci/tools/ci-build.sh, nginx-stable only (verified
 #                            against the tarball's OWN PGP signature via the
-#                            vendored keys in tools/keys/ before the digest is
-#                            recorded, so a bad bump can't silently pin a
+#                            vendored keys in ci/tools/keys/ before the digest
+#                            is recorded, so a bad bump can't silently pin a
 #                            malicious tarball's hash -- floating mainline has
 #                            no entry here, see above)
-#   - ANGIE_SHA256       -- tools/ci-build.sh (angie.software publishes no
+#   - ANGIE_SHA256       -- ci/tools/ci-build.sh (angie.software publishes no
 #                            PGP signature, so sha256 is the only check)
 #
 # A version bump with a stale sha256 pin is worse than no pin (ci-build.sh
@@ -35,8 +35,17 @@ set -euo pipefail
 DRY_RUN=0
 [ "${1:-}" = "--dry-run" ] && DRY_RUN=1
 
-# ci/tools/ -> ci/ -> repo root: TWO levels since the ci/ move.
-cd "$(dirname "$0")/../.."
+# Derive every repo-relative path from the script's OWN location, never from
+# cwd -- a caller running this from elsewhere must not silently miss the
+# ci-build.sh / keys move (A30-F4: tools/ -> ci/tools/, verified dead on the
+# old paths).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+CI_BUILD_SH="ci/tools/ci-build.sh"
+KEYS_DIR="ci/tools/keys"
+MATRIX_FILE=".github/workflows/ci-deep.yml"
 
 # --- discover latest versions -------------------------------------------
 
@@ -85,7 +94,7 @@ matrix_version_for_label() {
     awk -v want="$1" '
         /version:/ { match($0, /"[0-9.]+"/); v = substr($0, RSTART+1, RLENGTH-2); next }
         /label:/   { split($0, a, ":"); l = a[2]; gsub(/[ \t]/, "", l); if (l == want) { print v; exit } }
-    ' .github/workflows/ci-deep.yml
+    ' "$MATRIX_FILE"
 }
 
 CUR_STABLE="$(matrix_version_for_label stable)"
@@ -122,8 +131,14 @@ sha256_for_nginx_stable() {
     export GNUPGHOME
     chmod 700 "$gnupghome"
     shopt -s nullglob
-    keyfiles=(tools/keys/*.key)
+    keyfiles=("$KEYS_DIR"/*.key)
     shopt -u nullglob
+    if [ "${#keyfiles[@]}" -eq 0 ]; then
+        rm -rf "$gnupghome" "$tmp" "${tmp}.asc"
+        unset GNUPGHOME
+        echo "FATAL: no keyring found under $KEYS_DIR -- refusing to pin an unverified digest" >&2
+        exit 1
+    fi
     for keyfile in "${keyfiles[@]}"; do
         gpg --quiet --import "$keyfile" 2>/dev/null
     done
@@ -142,39 +157,60 @@ sha256_for_nginx_stable() {
 }
 
 # --- bump a version in ci-deep.yml's build-flavors matrix ----------------
+# Every mutator here writes to a temp file and renames it into place only
+# after the edit is confirmed to have actually matched something -- a no-op
+# replacement (stale path, drifted format) now FAILS LOUDLY instead of
+# silently leaving the source file untouched while the script reports success
+# (A30-F4). No partial edits: either the temp file replaces the original, or
+# the original is untouched and the script exits non-zero.
 bump_matrix_pin() {
-    local label="$1" old="$2" new="$3"
+    local label="$1" old="$2" new="$3" tmp
     [ "$old" = "$new" ] && return 0
-    python3 - "$label" "$old" "$new" <<'PYEOF'
+    tmp="$(mktemp)"
+    if ! python3 - "$label" "$old" "$new" "$MATRIX_FILE" "$tmp" <<'PYEOF'
 import re, sys
-label, old, new = sys.argv[1:4]
-path = ".github/workflows/ci-deep.yml"
+label, old, new, path, out = sys.argv[1:6]
 text = open(path).read()
 pattern = re.compile(
     r'(version:\s*"' + re.escape(old) + r'"\n\s*label:\s*' + re.escape(label) + r')'
 )
 replaced = pattern.sub(lambda m: m.group(1).replace(old, new), text)
 if replaced == text:
-    print(f"WARNING: no matrix entry matched for label={label} old={old}", file=sys.stderr)
-open(path, "w").write(replaced)
+    print(f"FATAL: no matrix entry matched for label={label} old={old} in {path}", file=sys.stderr)
+    sys.exit(1)
+open(out, "w").write(replaced)
 PYEOF
+    then
+        rm -f "$tmp"
+        exit 1
+    fi
+    mv "$tmp" "$MATRIX_FILE"
+    CHANGED=1
+}
+
+_bump_sha256_pin() {
+    local table="$1" old="$2" new="$3" digest="$4" tmp
+    grep -q "\[\"${new}\"\]" "$CI_BUILD_SH" && return 0 # already pinned
+    if ! grep -q "declare -A ${table}=(" "$CI_BUILD_SH"; then
+        echo "FATAL: no 'declare -A ${table}=(' table found in $CI_BUILD_SH -- refusing a no-op pin" >&2
+        exit 1
+    fi
+    tmp="$(mktemp)"
+    # Insert the new pin right after the table's opening line; leave old
+    # entries in place (ci-build.sh keys by version, older callers still work).
+    sed "/declare -A ${table}=(/a\\    [\"${new}\"]=\"${digest}\"" "$CI_BUILD_SH" >"$tmp"
+    mv "$tmp" "$CI_BUILD_SH"
     CHANGED=1
 }
 
 bump_angie_sha256_pin() {
     local old="$1" new="$2" digest="$3"
-    grep -q "\[\"${new}\"\]" tools/ci-build.sh && return 0 # already pinned
-    # Insert the new pin right after the table's opening line; leave old
-    # entries in place (ci-build.sh keys by version, older callers still work).
-    sed -i "/declare -A ANGIE_SHA256=(/a\\    [\"${new}\"]=\"${digest}\"" tools/ci-build.sh
-    CHANGED=1
+    _bump_sha256_pin ANGIE_SHA256 "$old" "$new" "$digest"
 }
 
 bump_nginx_sha256_pin() {
     local old="$1" new="$2" digest="$3"
-    grep -q "\[\"${new}\"\]" tools/ci-build.sh && return 0 # already pinned
-    sed -i "/declare -A NGINX_SHA256=(/a\\    [\"${new}\"]=\"${digest}\"" tools/ci-build.sh
-    CHANGED=1
+    _bump_sha256_pin NGINX_SHA256 "$old" "$new" "$digest"
 }
 
 if [ "$NEW_STABLE" != "$CUR_STABLE" ]; then

--- a/ci/tools/coverage.sh
+++ b/ci/tools/coverage.sh
@@ -166,16 +166,24 @@ python3 ci/tools/test_var_dynamic_cacheable.py \
 
 # The testkit is the only layer that reaches worker-internal fault/counter
 # paths. Use the same canonical six-scenario runner as the PR and Memcheck
-# jobs; a failure stays visible but does not suppress the remaining gcov data,
-# because this script publishes a report rather than acting as a test gate.
+# jobs; a failure stays visible AND fails this script at the end (after the
+# report is still published) -- a bailed-out scenario, whose TAP plan/oracle
+# evidence run-testkit-scenarios.sh already verifies per scenario, must never
+# pass silently just because the coverage PERCENTAGE has no floor.
+HARNESS_SCENARIOS_FAILED=0
 if [ "$COVERAGE_HARNESS" = "1" ]; then
     echo "== coverage: exercising all module testkit scenarios =="
     if [ ! -x "$MODULE_DIR/ci/t/harness/ci/prober/run-scenario.sh" ]; then
         echo "WARNING: harness submodule not checked out --" \
              "fault/counter paths will report as uncovered" >&2
     else
-        if [ ! -x "$MODULE_DIR/ci/t/harness/ci/prober/prober" ]; then
-            bash "$MODULE_DIR/ci/t/harness/ci/prober/build.sh" || true
+        # Always (re)build: the prober binary can exist but be staler than its
+        # sources, which silently bails every fault/counter scenario while
+        # this script still reports coverage success (audit A30-F7).
+        if ! bash "$MODULE_DIR/ci/t/harness/ci/prober/build.sh"; then
+            echo "ERROR: prober build failed --" \
+                 "fault/counter paths will report as uncovered" >&2
+            HARNESS_SCENARIOS_FAILED=1
         fi
 
         scen_version="${SRCDIR##*/}"
@@ -187,8 +195,10 @@ if [ "$COVERAGE_HARNESS" = "1" ]; then
             --flavor "$FLAVOR" \
             --version "$scen_version" \
             --log-dir "$REPORT_DIR"; then
-            echo "WARNING: one or more testkit scenarios failed;" \
-                 "their missing lines remain visible in the report" >&2
+            echo "ERROR: one or more testkit scenarios failed their TAP" \
+                 "plan/oracle; their missing lines remain visible in the" \
+                 "report, but this run will exit non-zero" >&2
+            HARNESS_SCENARIOS_FAILED=1
         fi
     fi
 fi
@@ -244,3 +254,10 @@ fi
 gcovr "${GCOVR_ARGS[@]}"
 
 echo "== coverage: report written to $REPORT_DIR =="
+
+if [ "$HARNESS_SCENARIOS_FAILED" -ne 0 ]; then
+    echo "ERROR: coverage report published above, but one or more testkit" \
+         "scenarios did not verify -- see the ERROR lines above for which" \
+         "scenario/TAP plan bailed" >&2
+    exit 1
+fi

--- a/ci/tools/test_build_windows_zstd_default.sh
+++ b/ci/tools/test_build_windows_zstd_default.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Regression test for audit A30-F3: ci/tools/build-windows.sh defaulted
+# REF_ZSTD_MODULE to a fixed historical commit (~154 commits behind at audit
+# time) even though README.md presents this script alongside CURRENT
+# behaviour, so the documented default silently built a stale module.
+#
+# The fix resolves REPO_ZSTD_MODULE/REF_ZSTD_MODULE from the running
+# script's own checkout (HEAD) by default, keeping the old fixed commit only
+# as a fallback for a standalone copy of the script outside any checkout,
+# and keeps the REPO_ZSTD_MODULE/REF_ZSTD_MODULE overrides fully working.
+#
+# This cannot run the real script end-to-end (no MSVC / Windows toolchain
+# here), so it isolates the default-resolution block -- the part of
+# build-windows.sh between "### version + SHA-256 pins" and
+# "# Download + verify" -- and drives it standalone with git stubs, which is
+# testable without a Windows runtime.
+#
+# Usage: ci/tools/test_build_windows_zstd_default.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_WINDOWS_SH="$SCRIPT_DIR/build-windows.sh"
+
+fail=0
+ok() { printf 'OK: %s\n' "$*"; }
+bad() {
+    printf 'FAIL: %s\n' "$*"
+    fail=1
+}
+
+# extract_resolution_block -- pulls the REPO_ZSTD_MODULE/REF_ZSTD_MODULE
+# default-resolution logic (and its _zstd_module_repo_root helper) out of
+# build-windows.sh, verbatim, between two anchor comments. If the anchors
+# ever drift this fails loudly rather than silently testing stale logic.
+extract_resolution_block() {
+    awk '
+        /^# Module refs/ { grab=1 }
+        grab { print }
+        /^fi$/ && grab { exit }
+    ' "$BUILD_WINDOWS_SH"
+}
+
+BLOCK="$(extract_resolution_block)"
+if ! grep -q '_zstd_module_repo_root' <<<"$BLOCK"; then
+    echo "FATAL: could not extract the zstd-module default-resolution block from $BUILD_WINDOWS_SH -- anchors drifted" >&2
+    exit 2
+fi
+
+echo "== case: inside a checkout, no override -> defaults to HEAD of that checkout =="
+CKROOT="$(mktemp -d)"
+(
+    cd "$CKROOT"
+    git init -q
+    git config user.email test@example.com
+    git config user.name test
+    mkdir -p ci/tools
+    cp "$BUILD_WINDOWS_SH" ci/tools/build-windows.sh
+    git add -A
+    git commit -q -m init
+)
+HEAD_SHA="$(git -C "$CKROOT" rev-parse HEAD)"
+unset REPO_ZSTD_MODULE REF_ZSTD_MODULE
+OUT="$(bash -c '
+set -euo pipefail
+'"$BLOCK"'
+echo "REPO=$REPO_ZSTD_MODULE"
+echo "REF=$REF_ZSTD_MODULE"
+' "$CKROOT/ci/tools/build-windows.sh")"
+if grep -q "REPO=$CKROOT" <<<"$OUT" && grep -q "REF=$HEAD_SHA" <<<"$OUT"; then
+    ok "in-checkout default resolves REPO to the checkout and REF to its HEAD ($HEAD_SHA)"
+else
+    bad "in-checkout default did not resolve to the checkout's HEAD: $OUT"
+fi
+
+echo "== case: explicit REPO_ZSTD_MODULE/REF_ZSTD_MODULE override wins =="
+OUT="$(REPO_ZSTD_MODULE="https://example.invalid/fork.git" REF_ZSTD_MODULE="deadbeef" bash -c '
+set -euo pipefail
+'"$BLOCK"'
+echo "REPO=$REPO_ZSTD_MODULE"
+echo "REF=$REF_ZSTD_MODULE"
+' "$CKROOT/ci/tools/build-windows.sh")"
+if grep -q "REPO=https://example.invalid/fork.git" <<<"$OUT" && grep -q "REF=deadbeef" <<<"$OUT"; then
+    ok "explicit override is preserved, default resolution does not clobber it"
+else
+    bad "override was not preserved: $OUT"
+fi
+
+echo "== case: outside any checkout -> falls back to the documented pin =="
+OUTSIDE="$(mktemp -d)"
+unset REPO_ZSTD_MODULE REF_ZSTD_MODULE
+OUT="$(bash -c '
+set -euo pipefail
+'"$BLOCK"'
+echo "REPO=$REPO_ZSTD_MODULE"
+echo "REF=$REF_ZSTD_MODULE"
+' "$OUTSIDE/build-windows.sh")"
+if grep -q "REPO=https://github.com/myguard-labs/nginx-zstd-module.git" <<<"$OUT" \
+    && grep -q "REF=37cf9ac6b58284ae2da95620f4905930d1277b54" <<<"$OUT"; then
+    ok "outside a checkout, falls back to the documented fixed pin"
+else
+    bad "fallback pin did not apply outside a checkout: $OUT"
+fi
+
+rm -rf "$CKROOT" "$OUTSIDE"
+
+if [ "$fail" -eq 0 ]; then
+    echo "all build-windows.sh zstd-module default cases pass"
+else
+    echo "one or more build-windows.sh zstd-module default cases FAILED"
+fi
+exit "$fail"

--- a/ci/tools/test_bump_versions.sh
+++ b/ci/tools/test_bump_versions.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+#
+# Hermetic regression test for audit A30-F4: ci/tools/bump-versions.sh used
+# stale pre-move paths (tools/keys/, tools/ci-build.sh) that do not exist
+# after the tools/ -> ci/tools/ move, so a real bump could not import the
+# PGP keyring and a matrix/pin replacement that matched nothing failed
+# silently, leaving a partial edit.
+#
+# This test builds a scratch copy of the repo layout the script actually
+# needs (ci/tools/ci-build.sh, ci/tools/keys/*.key, .github/workflows/
+# ci-deep.yml matrix) and stubs curl/gpg/sha256sum on PATH so no network is
+# used. It drives bump-versions.sh --covered by a scenario cases-array so
+# each case name is asserted individually.
+#
+# Usage: ci/tools/test_bump_versions.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BUMP_SCRIPT="$REPO_ROOT/ci/tools/bump-versions.sh"
+
+fail=0
+say() { printf '%s\n' "$*"; }
+ok() { printf 'OK: %s\n' "$*"; }
+bad() {
+    printf 'FAIL: %s\n' "$*"
+    fail=1
+}
+
+# make_sandbox VARNAME  -- creates a scratch repo layout under a temp dir and
+# assigns its path to VARNAME.
+make_sandbox() {
+    # shellcheck disable=SC2034  # nameref out-parameter, assigned for the caller
+    local -n out="$1"
+    local dir
+    dir="$(mktemp -d)"
+    mkdir -p "$dir/ci/tools/keys" "$dir/.github/workflows"
+    cat >"$dir/ci/tools/keys/dummy.key" <<'EOF'
+dummy keyring placeholder
+EOF
+    cat >"$dir/ci/tools/ci-build.sh" <<'EOF'
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+declare -A ANGIE_SHA256=(
+    ["1.12.1"]="aaaa"
+)
+declare -A NGINX_SHA256=(
+    ["1.30.4"]="bbbb"
+)
+KEYRING_DIR="$SCRIPT_DIR/keys"
+EOF
+    cat >"$dir/.github/workflows/ci-deep.yml" <<'EOF'
+jobs:
+  build-flavors:
+    strategy:
+      matrix:
+        include:
+          - version: "1.31.2"
+            label: mainline
+          - version: "1.30.4"
+            label: stable
+          - version: "1.12.1"
+            label: angie
+EOF
+    cp "$BUMP_SCRIPT" "$dir/ci/tools/bump-versions.sh"
+    # shellcheck disable=SC2034  # nameref out-parameter, read by the caller
+    out="$dir"
+}
+
+# stub_bin DIR -- creates PATH-shadowing curl/gpg/sha256sum stubs and prints
+# the bin dir to prepend to PATH. Reads NEW_STABLE / NEW_ANGIE env for what
+# "latest" should resolve to.
+stub_bin() {
+    local dir="$1" bindir="$1/bin"
+    mkdir -p "$bindir"
+    cat >"$bindir/curl" <<EOF
+#!/bin/bash
+# Fake nginx.org download page / angie GitHub API / tarball fetch.
+for a in "\$@"; do
+    case "\$a" in
+        *nginx.org/en/download.html*)
+            echo "Stable versionnginx-${NEW_STABLE}.tar.gz"
+            exit 0 ;;
+        *api.github.com*angie*releases/latest*)
+            echo "{\"tag_name\": \"${NEW_ANGIE}\"}"
+            exit 0 ;;
+        -o) : ;;
+    esac
+done
+# tarball / .asc fetch: write a dummy file at -o target if present.
+out=""
+prev=""
+for a in "\$@"; do
+    if [ "\$prev" = "-o" ]; then out="\$a"; fi
+    prev="\$a"
+done
+[ -n "\$out" ] && echo "dummy-tarball-bytes" > "\$out"
+exit 0
+EOF
+    cat >"$bindir/gpg" <<'EOF'
+#!/bin/bash
+# Accept any --import / --verify as success (hermetic stub).
+exit 0
+EOF
+    chmod +x "$bindir/curl" "$bindir/gpg"
+    echo "$bindir"
+}
+
+# run_case NAME NEW_STABLE NEW_ANGIE  -- runs bump-versions.sh in $1's sandbox
+# with the given "latest" values and returns its exit status; sandbox path is
+# left in SANDBOX for the caller to inspect.
+run_case() {
+    local ns="$2" na="$3"
+    make_sandbox SANDBOX
+    local bindir
+    bindir="$(NEW_STABLE="$ns" NEW_ANGIE="$na" stub_bin "$SANDBOX")"
+    (
+        cd "$SANDBOX"
+        PATH="$bindir:$PATH" NEW_STABLE="$ns" NEW_ANGIE="$na" \
+            bash ci/tools/bump-versions.sh >"$SANDBOX/out.log" 2>&1
+    )
+    return $?
+}
+
+say "== case: stable-only bump =="
+if run_case stable-only "1.30.5" "1.12.1"; then
+    if grep -q 'version: "1.30.5"' "$SANDBOX/.github/workflows/ci-deep.yml" \
+        && grep -q '\["1.30.5"\]' "$SANDBOX/ci/tools/ci-build.sh"; then
+        ok "stable-only: matrix and sha256 pin both updated"
+    else
+        bad "stable-only: pin(s) missing after bump"
+    fi
+else
+    bad "stable-only: script exited non-zero unexpectedly: $(cat "$SANDBOX/out.log")"
+fi
+
+say "== case: angie-only bump =="
+if run_case angie-only "1.30.4" "1.13.0"; then
+    if grep -q 'version: "1.13.0"' "$SANDBOX/.github/workflows/ci-deep.yml" \
+        && grep -q '\["1.13.0"\]' "$SANDBOX/ci/tools/ci-build.sh"; then
+        ok "angie-only: matrix and sha256 pin both updated"
+    else
+        bad "angie-only: pin(s) missing after bump"
+    fi
+else
+    bad "angie-only: script exited non-zero unexpectedly: $(cat "$SANDBOX/out.log")"
+fi
+
+say "== case: both bump =="
+if run_case both "1.30.5" "1.13.0"; then
+    if grep -q 'version: "1.30.5"' "$SANDBOX/.github/workflows/ci-deep.yml" \
+        && grep -q 'version: "1.13.0"' "$SANDBOX/.github/workflows/ci-deep.yml" \
+        && grep -q '\["1.30.5"\]' "$SANDBOX/ci/tools/ci-build.sh" \
+        && grep -q '\["1.13.0"\]' "$SANDBOX/ci/tools/ci-build.sh"; then
+        ok "both: matrix and sha256 pins all updated"
+    else
+        bad "both: pin(s) missing after bump"
+    fi
+else
+    bad "both: script exited non-zero unexpectedly: $(cat "$SANDBOX/out.log")"
+fi
+
+say "== case: no-change =="
+if run_case no-change "1.30.4" "1.12.1"; then
+    if grep -q 'CHANGED=0' "$SANDBOX/out.log"; then
+        ok "no-change: script reports CHANGED=0 and exits 0"
+    else
+        bad "no-change: expected CHANGED=0, got: $(cat "$SANDBOX/out.log")"
+    fi
+else
+    bad "no-change: script exited non-zero unexpectedly: $(cat "$SANDBOX/out.log")"
+fi
+
+say "== case: format-drift (matrix entry does not match -- must FAIL LOUDLY, no partial edit) =="
+make_sandbox SANDBOX
+# Corrupt the matrix so version/label are no longer adjacent the way the
+# script's pattern expects -- simulates a future reformat/reorder.
+cat >"$SANDBOX/.github/workflows/ci-deep.yml" <<'EOF'
+jobs:
+  build-flavors:
+    strategy:
+      matrix:
+        include:
+          - label: mainline
+            version: "1.31.2"
+          - label: stable
+            version: "1.30.4"
+          - label: angie
+            version: "1.12.1"
+EOF
+before_matrix="$(cat "$SANDBOX/.github/workflows/ci-deep.yml")"
+before_build="$(cat "$SANDBOX/ci/tools/ci-build.sh")"
+bindir="$(NEW_STABLE=1.30.5 NEW_ANGIE=1.12.1 stub_bin "$SANDBOX")"
+set +e
+(
+    cd "$SANDBOX"
+    PATH="$bindir:$PATH" NEW_STABLE=1.30.5 NEW_ANGIE=1.12.1 \
+        bash ci/tools/bump-versions.sh >"$SANDBOX/out.log" 2>&1
+)
+rc=$?
+set -e
+after_matrix="$(cat "$SANDBOX/.github/workflows/ci-deep.yml")"
+after_build="$(cat "$SANDBOX/ci/tools/ci-build.sh")"
+if [ "$rc" -eq 0 ]; then
+    bad "format-drift: script exited 0 on a no-op replacement (should FAIL LOUDLY)"
+elif [ "$before_matrix" != "$after_matrix" ] || [ "$before_build" != "$after_build" ]; then
+    bad "format-drift: files were mutated despite the failed match (partial edit)"
+elif ! grep -qi 'no matrix entry matched' "$SANDBOX/out.log"; then
+    bad "format-drift: exited non-zero but did not report the no-op match: $(cat "$SANDBOX/out.log")"
+else
+    ok "format-drift: exited non-zero, reported the no-op, and left both files untouched"
+fi
+
+if [ "$fail" -eq 0 ]; then
+    say "all bump-versions.sh cases pass"
+else
+    say "one or more bump-versions.sh cases FAILED"
+fi
+exit "$fail"

--- a/ci/tools/test_fuzz_seconds_validation.sh
+++ b/ci/tools/test_fuzz_seconds_validation.sh
@@ -60,7 +60,9 @@ check_accepted() {
 
 # --- injection payloads (the actual F1 exploit shape) ---
 check_rejected '3600"; id; #' "quote-breakout shell injection"
+# shellcheck disable=SC2016  # literal payload fixture, must not expand
 check_rejected '$(id)' "command substitution"
+# shellcheck disable=SC2016  # literal payload fixture, must not expand
 check_rejected '`id`' "backtick substitution"
 check_rejected '3600; rm -rf /' "semicolon-chained command"
 check_rejected '3600 && id' "shell-and injection"


### PR DESCRIPTION
## Summary

Six-row CI/tooling sweep, all pr:sweep-ci, verified live against origin/master bbd653d.

### A30-N6 — windows-build.yml invalid-config oracle (nit)
`if (& nginx.exe -t ... 2>$null)` tested captured stdout, not process exit status, with stderr thrown away — not a reliable rejection oracle. Now captures `$LASTEXITCODE` explicitly and asserts `-eq 0` throws, matching the adjacent `-ne 0` pattern already used for the valid-config check two lines below.

### A30-N8 — deterministic lint warnings (nit)
- `ci/linter/install-linters.sh`: rewrote a shellcheck SC2015 `A && B || C` pattern (`perl -MTest::Nginx::Socket ... && printf ok || { printf MISSING; rc=1; }`) as an explicit if/else.
- `ci/tools/test_fuzz_seconds_validation.sh`: added scoped `# shellcheck disable=SC2016` comments on the two single-quoted injection-payload fixtures (`'$(id)'`, `` '`id`' ``) explaining they are intentionally literal exploit strings. Payload bytes are unchanged.
- yamllint: `.yamllint` already scopes `line-length` to a non-blocking warning by design (documented in the file's own header comment); the gate (`lint-yaml.sh`, no `--strict`) was already clean. No config change needed there.

### A30-N7 — shfmt / house style (nit)
Added `.editorconfig` declaring the repo's actual 4-space shell indent style (`indent_style = space`, `indent_size = 4`, `[*.sh]`/`[*.bash]`), which shfmt reads. Verified this makes shfmt honor 4-space indent tree-wide (test file, before/after). The remaining shfmt diff across ~33 files is genuine house-style drift beyond indent width — aligned one-liner function defs (`say()  { ... }`), `;`-chained compound statements, multi-var single-line declarations — that no config can declare; shfmt always normalizes those away. Per the row's own fallback instruction, this is reported rather than mass-reformatted. New/touched files in this PR are shfmt-clean.

### A30-F7 — coverage.sh silent bailout on a stale prober binary (medium)
`if [ ! -x prober ]; then build.sh || true; fi` only rebuilt when the binary was **absent**, so a present-but-stale binary silently skipped the rebuild — every fault/counter testkit scenario then bailed out while coverage still reported 81.1% success. Now the prober is always (re)built (still idempotent), and `run-testkit-scenarios.sh`'s existing per-scenario TAP plan/oracle verification is required to pass: a scenario failure or a build failure now makes the whole `coverage.sh` run exit non-zero (after the coverage report is still published, since coverage itself stays a report, not a gate).

### A30-F4 — bump-versions.sh dead pre-move paths (medium)
`tools/keys/*.key` and `tools/ci-build.sh` do not exist after the `tools/` -> `ci/tools/` move (real paths: `ci/tools/keys/`, `ci/tools/ci-build.sh`). This meant the PGP keyring could never be imported (making the digest untrusted) and an Angie bump could edit the matrix, then abort on the missing `ci-build.sh` path, leaving a partial edit.
- All repo paths now derive once from the script's own location (`$0`), never cwd.
- Matrix and sha256 pin edits are transactional: write to a temp file, only `mv` into place after a real match is confirmed; a no-op match (stale path, drifted format) now `exit 1`s loudly instead of a silent `WARNING` that let the script report success anyway.
- Comments at the top of the script referencing the dead paths are also fixed.
- Added `ci/tools/test_bump_versions.sh`: hermetic (stubbed curl/gpg, no network) test covering stable-only, angie-only, both, no-change, and format-drift cases.

### A30-F3 — build-windows.sh stale zstd-module default pin (medium)
`REF_ZSTD_MODULE` defaulted to a fixed commit ~154 commits behind, even though README.md presents this script alongside current behavior — a plain default run silently built a stale module. `REPO_ZSTD_MODULE`/`REF_ZSTD_MODULE` now default to the running script's own checkout (repo root + `HEAD`) when it lives inside one; the old fixed pin remains only as a fallback for a standalone copy of the script outside any checkout, and the documented override mechanism (`REPO_ZSTD_MODULE=<fork> REF_ZSTD_MODULE=<ref>`) is untouched. The resolved repo/ref is now printed before the clone. Added `ci/tools/test_build_windows_zstd_default.sh`, which isolates the default-resolution block (extracted verbatim by anchor comments, so drifted anchors fail loudly) and drives it standalone — testable without a Windows/MSVC runtime. Follow-up commit documents that the local-checkout default still does a real `git clone`, so uncommitted working-tree edits are not included unless committed first.

## Negative-control evidence

- **A30-N6**: mechanical, mirrors the verified adjacent `$LASTEXITCODE -ne 0` pattern; no local Windows runner available to execute the workflow, so no dynamic control — pattern-matched against the CI-verified sibling check instead.
- **A30-N8**: `shellcheck ci/tools/test_fuzz_seconds_validation.sh ci/linter/install-linters.sh` — SC2015/SC2016 findings gone, `bash ci/tools/test_fuzz_seconds_validation.sh` — 17/17 cases still pass, payload bytes unchanged (diff only adds comment lines).
- **A30-N7**: `shfmt -d ci/tools/zzztest.sh` (scratch file) before vs after `.editorconfig` — confirmed 4-space indent applied once the config exists; without it shfmt defaults to tabs.
- **A30-F7**: isolated the flag/exit wiring (build stub rc + scenario stub rc -> `HARNESS_SCENARIOS_FAILED` -> non-zero exit) and confirmed FAIL propagates when either stub fails and SUCCESS when both pass. Full end-to-end run needs a built nginx+module tree (long-runner, out of scope for this sweep); source-line verification confirms the flag is set at both failure sites and checked exactly once after the gcovr report is written.
- **A30-F4**: `bash ci/tools/test_bump_versions.sh` — 5/5 cases pass on the fixed script. Ran the same test harness against `origin/master`'s **unfixed** `bump-versions.sh`: `stable-only`, `angie-only`, and `both` cases go RED with `tools/ci-build.sh: No such file or directory` (the exact dead-path bug), while `no-change` and `format-drift` pass on both — a genuine discriminating control.
- **A30-F3**: `bash ci/tools/test_build_windows_zstd_default.sh` — 3/3 cases pass (in-checkout defaults to HEAD, explicit override wins, outside-a-checkout falls back to the fixed pin). Ran the same extraction against `origin/master`'s unfixed script: it has no `_zstd_module_repo_root` function at all, so the anchor-based extraction fails loudly (`FATAL: could not extract ... anchors drifted`) — confirms the fix is genuinely new logic, not a no-op. Direct `grep` on `origin/master` confirms the old default is the fixed commit unconditionally.

## Lint / gate results

`bash /opt/myguard/.claude/skills/_shared/review-lint.sh --diff HEAD` (staged, before each commit): shellcheck clean, actionlint clean, yamllint clean, zizmor (CI security) — no findings, betterleaks/trufflehog — clean, codespell clean, semgrep clean, ast-grep clean. `shfmt(style, advisory)` reports findings on 5 pre-existing files not touched by this diff's line ranges (A30-N7's documented residual house-style drift); the two new test files and all touched lines are shfmt-clean under the new `.editorconfig`.

`ruff format --check` / `ruff check`: no `.py` files touched, not applicable.

Pre-commit hook (`lint-before-commit-gate.sh`) passed on both commits: all linters clean, pre-commit framework checks passed.

## Audit

One `/pr-review` round on the diff: one PLAUSIBLE MINOR finding (build-windows.sh's checkout-default still runs a real `git clone`, which drops uncommitted working-tree edits from the build) — addressed with a documentation comment in a follow-up commit (git-clone semantics are correct as-is; this is a caveat to know, not a defect to fix within this row's scope). Round 2 (comment-only diff) — clean, no material findings.