### PR TITLE
fix: start without an http block (#284 follow-up)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -769,6 +769,14 @@ jobs:
           ls -la "$MATRIX_DIR/objs/$MATRIX_FLAVOR"
           "$MATRIX_DIR/objs/$MATRIX_FLAVOR" -V 2>&1
 
+      - name: Module must not veto an http-less configuration
+        env:
+          MATRIX_DIR: ${{ matrix.dir }}
+          MATRIX_FLAVOR: ${{ matrix.flavor }}
+        run: |
+          bash "$GITHUB_WORKSPACE"/ci/tools/test_no_http_block.sh \
+            "$MATRIX_DIR/objs/$MATRIX_FLAVOR"
+
       - name: Upload server binary artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:

--- a/ci/tools/test_no_http_block.sh
+++ b/ci/tools/test_no_http_block.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# An nginx that carries this module must still start without an http{}
+# block: a stream-only or mail-only deployment compiles the module in
+# (distribution builds enable every module) and configures none of it.
+# The #284 init-module hook treated the absent http main conf as an
+# error, so such a binary failed nginx -t -- and, because init-module
+# failures are silent, with no diagnostic at all.
+set -eu
+
+nginx_bin=${1:?usage: test_no_http_block.sh <path-to-nginx-binary>}
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/no-http-block.XXXXXX")
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/logs"
+
+printf '%s\n' \
+    'pid logs/nginx.pid; error_log logs/error.log; events {}' \
+    > "$work/nohttp.conf"
+
+# The regression gate: an http-less configuration must validate.
+if ! "$nginx_bin" -t -p "$work" -c nohttp.conf; then
+    echo 'FAIL: an http-less configuration was refused' >&2
+    exit 1
+fi
+
+# Sanity control on the same binary: a configured http block still
+# validates, so the pass above is the no-op branch, not a disabled
+# check. (The refusal arms themselves need a runtime libzstd older
+# than the build headers; ci/tests/unit/test_version_policy.c covers
+# the policy table.)
+printf '%s\n' \
+    'pid logs/nginx.pid; error_log logs/error.log; events {}' \
+    'http { zstd on; }' \
+    > "$work/http.conf"
+"$nginx_bin" -t -p "$work" -c http.conf
+
+echo 'OK: http-less configuration validates'

--- a/src/ngx_http_zstd_filter_module.c
+++ b/src/ngx_http_zstd_filter_module.c
@@ -6059,7 +6059,14 @@ ngx_http_zstd_init_module(ngx_cycle_t *cycle)
     zmcf = ngx_http_cycle_get_module_main_conf(cycle,
                                                 ngx_http_zstd_filter_module);
     if (zmcf == NULL) {
-        return NGX_ERROR;
+        /*
+         * No http block in this configuration -- a stream-only or
+         * mail-only nginx that happens to carry the module. Nothing is
+         * configured, so there is no feature floor to enforce; treating
+         * this as an error kept such a binary from starting at all,
+         * and with no diagnostic (init-module failures are silent).
+         */
+        return NGX_OK;
     }
 
     policy = ngx_http_zstd_version_policy(ZSTD_VERSION_NUMBER, runtime,


### PR DESCRIPTION
## TL;DR

An nginx that carries this module refuses to start without an `http {}` block — and silently. Found while porting #284's runtime floors to the compression branch; one-line fix plus a binary-level regression gate.

## The bug

#284's init-module hook treats an absent http main conf as an error:

```c
    zmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_zstd_filter_module);
    if (zmcf == NULL) {
        return NGX_ERROR;
    }
```

With no `http {}` block, that main conf is NULL — a stream-only or mail-only deployment whose distribution build compiles the module in and configures none of it. `nginx -t` then prints "syntax is ok" and exits non-zero with **no diagnostic**, because init-module failures are silent. Reproduced on a master build with a bare `events {}` config before writing the fix.

An absent http block means nothing is configured, so there is no feature floor to enforce: the hook now returns `NGX_OK` there, with the rationale in a comment.

## The test

`ci/tools/test_no_http_block.sh` runs against the built binary: an events-only configuration must validate (red on the pre-fix binary — "syntax is ok" then a bare refusal), and a configured-http control on the same binary proves the pass is the no-op branch rather than a disabled check. The refusal arms themselves need a runtime libzstd older than the build headers, which no CI runner can stage — `ci/tests/unit/test_version_policy.c` already covers the policy table, so this gate covers only what the unit cannot: the hook's wiring into a real cycle. Wired into the matrix build job beside the binary verification, so both flavors gate on it.

## Testing

Fail-first red on the unfixed binary; after the fix (rebased onto #298): the script passes both directions and the full `ci/t/00-filter.t` run is green.
