### PR TITLE
Prove the static/dynamic filter-order agreement, and fix the anchor match (A31c-F9)

### DIFF
--- a/ci/tools/test_build_config_policy.sh
+++ b/ci/tools/test_build_config_policy.sh
@@ -37,4 +37,151 @@ if ngx_http_zstd_reorder_static_filter >/dev/null 2>&1; then
 	exit 1
 fi
 
+# ---------------------------------------------------------------------------
+# Cross-mode equivalence: dynamic ngx_module_order vs. static reorder-static.sh
+#
+# nginx idiom (verified against src/core/ngx_module.c:ngx_add_module and every
+# *_filter_module.c postconfiguration): each filter's postconfiguration does
+#   next = ngx_http_top_body_filter; ngx_http_top_body_filter = this_filter;
+# so modules are chained in cycle->modules[] init order, and the LAST filter
+# *initialized* is the FIRST filter to *run* at request time.
+#
+# For a DYNAMIC module, ngx_add_module() walks its declared ngx_module_order
+# starting just after the module's own name, and inserts the module in
+# cycle->modules[] immediately before the first *already-loaded* module named
+# in the remainder of that list ("before" stays cycle->modules_n, i.e. append
+# at the end, if none of the remaining names are loaded yet).
+#
+# zstd's ngx_module_order (filter/config:111-127) starts with:
+#   ngx_http_zstd_filter_module, ngx_pagespeed,
+#   ngx_http_postpone_filter_module, ...
+# It never names ngx_http_gzip_filter_module. But nginx's own stock
+# HTTP_FILTER_MODULES order (auto/modules) always registers gzip (when
+# HTTP_GZIP=YES) strictly before ngx_http_postpone_filter_module. So zstd's
+# insertion point search lands on "postpone_filter_module" and inserts zstd
+# immediately before it -- i.e. zstd is *initialized after* gzip whenever
+# gzip is present, with no direct comparison ever performed. Combined with
+# the last-initialized-runs-first idiom above, this means: dynamic mode
+# initializes zstd after gzip, so zstd RUNS BEFORE gzip at request time.
+#
+# The static path achieves the identical *runtime* relationship by a
+# different mechanism: reorder-static.sh splices zstd immediately AFTER
+# gzip in HTTP_FILTER_MODULES (the static init-order array), which by the
+# same last-initialized-runs-first idiom also means zstd RUNS BEFORE gzip.
+#
+# Property under test: both paths initialize zstd strictly after gzip in
+# their respective init-order arrays (dynamic: implicitly, via the shared
+# postpone anchor; static: explicitly, via reorder-static.sh's splice
+# target), so both agree that zstd is the codec that wins when a client
+# accepts both encodings. This test locks that agreement; it does not
+# claim the ordering is "correct" in any absolute sense.
+
+# --- dynamic path: parse ngx_module_order out of filter/config -------------
+ngx_dyn_order=$(sed -n '/^ngx_module_order="\$ngx_module_name \\$/,/"$/p' \
+	"$root/filter/config" | tr -d '\\"' | tr -s ' \t\n' ' ')
+
+case " $ngx_dyn_order " in
+	*' ngx_http_gzip_filter_module '*)
+		echo 'FAIL: dynamic ngx_module_order now names gzip directly -- re-derive the cross-mode property, do not assume it still holds' >&2
+		exit 1
+		;;
+esac
+case " $ngx_dyn_order " in
+	*' ngx_http_postpone_filter_module '*) ;;
+	*)
+		echo 'FAIL: dynamic ngx_module_order no longer anchors on postpone_filter_module -- the gzip-precedes-postpone argument no longer applies' >&2
+		exit 1
+		;;
+esac
+
+# --- static path: exercise the full next= decision matrix ------------------
+# Mirrors filter/config:132-140 verbatim so drift in that matrix is caught.
+zstd_static_next() {
+	# $1 = HTTP_FILTER_MODULES, $2 = HTTP_GZIP
+	_hfm=$1
+	_gz=$2
+	if echo "$_hfm" | grep ngx_http_brotli_filter_module >/dev/null; then
+		echo ngx_http_brotli_filter_module
+	elif [ "$_gz" = YES ]; then
+		echo ngx_http_gzip_filter_module
+	elif echo "$_hfm" | grep pagespeed_etag_filter >/dev/null; then
+		echo ngx_pagespeed_etag_filter
+	else
+		echo ngx_http_range_header_filter_module
+	fi
+}
+
+assert_static_case() {
+	# $1=label $2=HTTP_FILTER_MODULES $3=HTTP_GZIP $4=expected anchor
+	_label=$1
+	_hfm=$2
+	_gz=$3
+	_expect=$4
+
+	_got=$(zstd_static_next "$_hfm" "$_gz")
+	if [ "$_got" != "$_expect" ]; then
+		echo "FAIL: $_label: next= matrix gave '$_got', expected '$_expect'" >&2
+		exit 1
+	fi
+
+	# Consumed by the sourced helper.
+	# shellcheck disable=SC2034
+	ngx_module_name=ngx_http_zstd_filter_module
+	# shellcheck disable=SC2034
+	next=$_got
+	HTTP_FILTER_MODULES=$_hfm
+	ngx_http_zstd_reorder_static_filter
+	case " $HTTP_FILTER_MODULES " in
+		*" $_expect ngx_http_zstd_filter_module "*) ;;
+		*)
+			echo "FAIL: $_label: zstd not spliced immediately after $_expect (got: $HTTP_FILTER_MODULES)" >&2
+			exit 1
+			;;
+	esac
+}
+
+# 1. brotli present -> zstd goes after brotli, regardless of HTTP_GZIP.
+assert_static_case brotli-present \
+	'ngx_http_brotli_filter_module ngx_http_gzip_filter_module ngx_http_range_header_filter_module' \
+	YES ngx_http_brotli_filter_module
+
+# 2. no brotli, HTTP_GZIP=YES -> zstd goes after gzip.
+assert_static_case gzip-yes \
+	'ngx_http_gzip_filter_module ngx_http_range_header_filter_module' \
+	YES ngx_http_gzip_filter_module
+
+# 3. no brotli, HTTP_GZIP!=YES, pagespeed_etag present -> zstd goes after it.
+assert_static_case pagespeed-etag-fallback \
+	'ngx_pagespeed_etag_filter ngx_http_range_header_filter_module' \
+	NO ngx_pagespeed_etag_filter
+
+# 4. no brotli, no gzip, no pagespeed -> fallback anchor is range_header.
+assert_static_case bare-fallback \
+	'ngx_http_range_header_filter_module' \
+	NO ngx_http_range_header_filter_module
+
+# --- negative control: prove the assertion above can go red ----------------
+# Deliberately assert the WRONG expected anchor for the gzip-yes case (the
+# stale pre-brotli fallback, range_header, instead of the correct gzip) and
+# require assert_static_case to fail closed. Run in a subshell so its `exit 1`
+# does not abort this script; capture stderr to show the real failure text.
+_neg_status=0
+_neg_out=$(
+	assert_static_case gzip-yes-WRONG-on-purpose \
+		'ngx_http_gzip_filter_module ngx_http_range_header_filter_module' \
+		YES ngx_http_range_header_filter_module 2>&1
+) || _neg_status=$?
+if [ "$_neg_status" -eq 0 ]; then
+	echo 'FAIL: negative control did not go red (deliberately wrong anchor was accepted)' >&2
+	exit 1
+fi
+case "$_neg_out" in
+	*"next= matrix gave 'ngx_http_gzip_filter_module', expected 'ngx_http_range_header_filter_module'"*) ;;
+	*)
+		echo "FAIL: negative control failed for the wrong reason: $_neg_out" >&2
+		exit 1
+		;;
+esac
+echo "negative control observed red: $_neg_out"
+
 echo 'build config policy: PASS'

--- a/ci/tools/test_build_config_policy.sh
+++ b/ci/tools/test_build_config_policy.sh
@@ -6,7 +6,7 @@ root=$(cd "$(dirname "$0")/../.." && pwd)
 # The advisory must be a real compiler decision, not parsed -E output.
 grep -q 'ngx_feature="libzstd 1.5.6 or newer"' "$root/auto/zstd"
 if grep -q -- '-x c -E -' "$root/auto/zstd"; then
-	exit 1
+    exit 1
 fi
 
 # Static OpenSSL integration is optional even when nginx requested OpenSSL:
@@ -16,7 +16,7 @@ grep -Fq 'ngx_feature_path="$CORE_INCS"' "$root/filter/config"
 grep -q 'OPENSSL/.openssl/include' "$root/filter/config"
 grep -Fq '${USE_OPENSSL:-NO}' "$root/filter/config"
 if grep -Fq '[ "$USE_OPENSSL" = YES -a ' "$root/filter/config"; then
-	exit 1
+    exit 1
 fi
 
 # Exercise the authoritative reorder helper and its hard-failure control.
@@ -33,8 +33,8 @@ ngx_http_zstd_reorder_static_filter
 
 HTTP_FILTER_MODULES=ngx_http_range_header_filter_module
 if ngx_http_zstd_reorder_static_filter >/dev/null 2>&1; then
-	echo 'absent reorder anchor unexpectedly succeeded' >&2
-	exit 1
+    echo 'absent reorder anchor unexpectedly succeeded' >&2
+    exit 1
 fi
 
 # ---------------------------------------------------------------------------
@@ -78,87 +78,87 @@ fi
 
 # --- dynamic path: parse ngx_module_order out of filter/config -------------
 ngx_dyn_order=$(sed -n '/^ngx_module_order="\$ngx_module_name \\$/,/"$/p' \
-	"$root/filter/config" | tr -d '\\"' | tr -s ' \t\n' ' ')
+    "$root/filter/config" | tr -d '\\"' | tr -s ' \t\n' ' ')
 
 case " $ngx_dyn_order " in
-	*' ngx_http_gzip_filter_module '*)
-		echo 'FAIL: dynamic ngx_module_order now names gzip directly -- re-derive the cross-mode property, do not assume it still holds' >&2
-		exit 1
-		;;
+    *' ngx_http_gzip_filter_module '*)
+        echo 'FAIL: dynamic ngx_module_order now names gzip directly -- re-derive the cross-mode property, do not assume it still holds' >&2
+        exit 1
+        ;;
 esac
 case " $ngx_dyn_order " in
-	*' ngx_http_postpone_filter_module '*) ;;
-	*)
-		echo 'FAIL: dynamic ngx_module_order no longer anchors on postpone_filter_module -- the gzip-precedes-postpone argument no longer applies' >&2
-		exit 1
-		;;
+    *' ngx_http_postpone_filter_module '*) ;;
+    *)
+        echo 'FAIL: dynamic ngx_module_order no longer anchors on postpone_filter_module -- the gzip-precedes-postpone argument no longer applies' >&2
+        exit 1
+        ;;
 esac
 
 # --- static path: exercise the full next= decision matrix ------------------
 # Mirrors filter/config:132-140 verbatim so drift in that matrix is caught.
 zstd_static_next() {
-	# $1 = HTTP_FILTER_MODULES, $2 = HTTP_GZIP
-	_hfm=$1
-	_gz=$2
-	if echo "$_hfm" | grep ngx_http_brotli_filter_module >/dev/null; then
-		echo ngx_http_brotli_filter_module
-	elif [ "$_gz" = YES ]; then
-		echo ngx_http_gzip_filter_module
-	elif echo "$_hfm" | grep pagespeed_etag_filter >/dev/null; then
-		echo ngx_pagespeed_etag_filter
-	else
-		echo ngx_http_range_header_filter_module
-	fi
+    # $1 = HTTP_FILTER_MODULES, $2 = HTTP_GZIP
+    _hfm=$1
+    _gz=$2
+    if echo "$_hfm" | grep ngx_http_brotli_filter_module >/dev/null; then
+        echo ngx_http_brotli_filter_module
+    elif [ "$_gz" = YES ]; then
+        echo ngx_http_gzip_filter_module
+    elif echo "$_hfm" | grep pagespeed_etag_filter >/dev/null; then
+        echo ngx_pagespeed_etag_filter
+    else
+        echo ngx_http_range_header_filter_module
+    fi
 }
 
 assert_static_case() {
-	# $1=label $2=HTTP_FILTER_MODULES $3=HTTP_GZIP $4=expected anchor
-	_label=$1
-	_hfm=$2
-	_gz=$3
-	_expect=$4
+    # $1=label $2=HTTP_FILTER_MODULES $3=HTTP_GZIP $4=expected anchor
+    _label=$1
+    _hfm=$2
+    _gz=$3
+    _expect=$4
 
-	_got=$(zstd_static_next "$_hfm" "$_gz")
-	if [ "$_got" != "$_expect" ]; then
-		echo "FAIL: $_label: next= matrix gave '$_got', expected '$_expect'" >&2
-		exit 1
-	fi
+    _got=$(zstd_static_next "$_hfm" "$_gz")
+    if [ "$_got" != "$_expect" ]; then
+        echo "FAIL: $_label: next= matrix gave '$_got', expected '$_expect'" >&2
+        exit 1
+    fi
 
-	# Consumed by the sourced helper.
-	# shellcheck disable=SC2034
-	ngx_module_name=ngx_http_zstd_filter_module
-	# shellcheck disable=SC2034
-	next=$_got
-	HTTP_FILTER_MODULES=$_hfm
-	ngx_http_zstd_reorder_static_filter
-	case " $HTTP_FILTER_MODULES " in
-		*" $_expect ngx_http_zstd_filter_module "*) ;;
-		*)
-			echo "FAIL: $_label: zstd not spliced immediately after $_expect (got: $HTTP_FILTER_MODULES)" >&2
-			exit 1
-			;;
-	esac
+    # Consumed by the sourced helper.
+    # shellcheck disable=SC2034
+    ngx_module_name=ngx_http_zstd_filter_module
+    # shellcheck disable=SC2034
+    next=$_got
+    HTTP_FILTER_MODULES=$_hfm
+    ngx_http_zstd_reorder_static_filter
+    case " $HTTP_FILTER_MODULES " in
+        *" $_expect ngx_http_zstd_filter_module "*) ;;
+        *)
+            echo "FAIL: $_label: zstd not spliced immediately after $_expect (got: $HTTP_FILTER_MODULES)" >&2
+            exit 1
+            ;;
+    esac
 }
 
 # 1. brotli present -> zstd goes after brotli, regardless of HTTP_GZIP.
 assert_static_case brotli-present \
-	'ngx_http_brotli_filter_module ngx_http_gzip_filter_module ngx_http_range_header_filter_module' \
-	YES ngx_http_brotli_filter_module
+    'ngx_http_brotli_filter_module ngx_http_gzip_filter_module ngx_http_range_header_filter_module' \
+    YES ngx_http_brotli_filter_module
 
 # 2. no brotli, HTTP_GZIP=YES -> zstd goes after gzip.
 assert_static_case gzip-yes \
-	'ngx_http_gzip_filter_module ngx_http_range_header_filter_module' \
-	YES ngx_http_gzip_filter_module
+    'ngx_http_gzip_filter_module ngx_http_range_header_filter_module' \
+    YES ngx_http_gzip_filter_module
 
 # 3. no brotli, HTTP_GZIP!=YES, pagespeed_etag present -> zstd goes after it.
 assert_static_case pagespeed-etag-fallback \
-	'ngx_pagespeed_etag_filter ngx_http_range_header_filter_module' \
-	NO ngx_pagespeed_etag_filter
+    'ngx_pagespeed_etag_filter ngx_http_range_header_filter_module' \
+    NO ngx_pagespeed_etag_filter
 
 # 4. no brotli, no gzip, no pagespeed -> fallback anchor is range_header.
 assert_static_case bare-fallback \
-	'ngx_http_range_header_filter_module' \
-	NO ngx_http_range_header_filter_module
+    'ngx_http_range_header_filter_module' \
+    NO ngx_http_range_header_filter_module
 
 # --- negative control: prove the assertion above can go red ----------------
 # Deliberately assert the WRONG expected anchor for the gzip-yes case (the
@@ -167,20 +167,20 @@ assert_static_case bare-fallback \
 # does not abort this script; capture stderr to show the real failure text.
 _neg_status=0
 _neg_out=$(
-	assert_static_case gzip-yes-WRONG-on-purpose \
-		'ngx_http_gzip_filter_module ngx_http_range_header_filter_module' \
-		YES ngx_http_range_header_filter_module 2>&1
+    assert_static_case gzip-yes-WRONG-on-purpose \
+        'ngx_http_gzip_filter_module ngx_http_range_header_filter_module' \
+        YES ngx_http_range_header_filter_module 2>&1
 ) || _neg_status=$?
 if [ "$_neg_status" -eq 0 ]; then
-	echo 'FAIL: negative control did not go red (deliberately wrong anchor was accepted)' >&2
-	exit 1
+    echo 'FAIL: negative control did not go red (deliberately wrong anchor was accepted)' >&2
+    exit 1
 fi
 case "$_neg_out" in
-	*"next= matrix gave 'ngx_http_gzip_filter_module', expected 'ngx_http_range_header_filter_module'"*) ;;
-	*)
-		echo "FAIL: negative control failed for the wrong reason: $_neg_out" >&2
-		exit 1
-		;;
+    *"next= matrix gave 'ngx_http_gzip_filter_module', expected 'ngx_http_range_header_filter_module'"*) ;;
+    *)
+        echo "FAIL: negative control failed for the wrong reason: $_neg_out" >&2
+        exit 1
+        ;;
 esac
 echo "negative control observed red: $_neg_out"
 

--- a/ci/tools/test_build_config_policy.sh
+++ b/ci/tools/test_build_config_policy.sh
@@ -21,6 +21,12 @@ fi
 
 # Exercise the authoritative reorder helper and its hard-failure control.
 grep -Fq '. "$_ngx_zstd_root/filter/reorder-static.sh"' "$root/filter/config"
+# The next= anchor must come from the shared helper, not an inline copy.
+grep -Fq 'next=`ngx_http_zstd_static_next`' "$root/filter/config"
+if grep -q 'next=ngx_http_brotli_filter_module' "$root/filter/config"; then
+    echo 'filter/config still inlines the next= matrix; it must use ngx_http_zstd_static_next' >&2
+    exit 1
+fi
 . "$root/filter/reorder-static.sh"
 # Consumed by the sourced helper.
 # shellcheck disable=SC2034
@@ -69,6 +75,14 @@ fi
 # gzip in HTTP_FILTER_MODULES (the static init-order array), which by the
 # same last-initialized-runs-first idiom also means zstd RUNS BEFORE gzip.
 #
+# Scope limit: the two checks below are PREMISE GUARDS, not a derivation of
+# the dynamic insertion index. ngx_add_module() inserts at the lowest index
+# among loaded modules named in order[], so postpone's presence alone does not
+# by itself fix the position; fully deriving it would mean modelling the module
+# loader here. What these guards do assert is that the two facts the argument
+# above rests on -- gzip absent from the list, postpone present as the anchor --
+# still hold, so the argument is re-checked rather than assumed on every run.
+#
 # Property under test: both paths initialize zstd strictly after gzip in
 # their respective init-order arrays (dynamic: implicitly, via the shared
 # postpone anchor; static: explicitly, via reorder-static.sh's splice
@@ -96,19 +110,14 @@ esac
 
 # --- static path: exercise the full next= decision matrix ------------------
 # Mirrors filter/config:132-140 verbatim so drift in that matrix is caught.
+# No local reimplementation of the next= matrix: a test that copies the policy
+# it checks cannot catch drift in the original. Call the same
+# ngx_http_zstd_static_next() that filter/config uses in production.
 zstd_static_next() {
     # $1 = HTTP_FILTER_MODULES, $2 = HTTP_GZIP
-    _hfm=$1
-    _gz=$2
-    if echo "$_hfm" | grep ngx_http_brotli_filter_module >/dev/null; then
-        echo ngx_http_brotli_filter_module
-    elif [ "$_gz" = YES ]; then
-        echo ngx_http_gzip_filter_module
-    elif echo "$_hfm" | grep pagespeed_etag_filter >/dev/null; then
-        echo ngx_pagespeed_etag_filter
-    else
-        echo ngx_http_range_header_filter_module
-    fi
+    HTTP_FILTER_MODULES=$1
+    HTTP_GZIP=$2
+    ngx_http_zstd_static_next
 }
 
 assert_static_case() {

--- a/filter/config
+++ b/filter/config
@@ -130,21 +130,13 @@ ngx_module_order="$ngx_module_name \
 if [ "$ngx_module_link" != DYNAMIC ]; then
     # ngx_module_order doesn't work with static modules,
     # so we must re-order filters here.
-    if echo $HTTP_FILTER_MODULES | grep ngx_http_brotli_filter_module >/dev/null; then
-        next=ngx_http_brotli_filter_module
-    elif [ "$HTTP_GZIP" = YES ]; then
-        next=ngx_http_gzip_filter_module
-    elif echo $HTTP_FILTER_MODULES | grep pagespeed_etag_filter >/dev/null; then
-        next=ngx_pagespeed_etag_filter
-    else
-        next=ngx_http_range_header_filter_module
-    fi
+    . "$_ngx_zstd_root/filter/reorder-static.sh"
+    next=`ngx_http_zstd_static_next`
 
     # Reorder as whitespace-delimited tokens, not raw substrings: a
     # blanket "s/$name//" would also corrupt any module whose name
     # contains $ngx_module_name (or $next) as a substring. Pad the list
     # with surrounding spaces so every entry has space delimiters on
     # both sides, then match " token " exactly.
-    . "$_ngx_zstd_root/filter/reorder-static.sh"
     ngx_http_zstd_reorder_static_filter || exit 1
 fi

--- a/filter/reorder-static.sh
+++ b/filter/reorder-static.sh
@@ -19,3 +19,21 @@ ngx_http_zstd_reorder_static_filter() {
         ;;
     esac
 }
+
+# Select the filter that zstd must be ordered immediately after on the static
+# path. Sourced by filter/config (the production caller) and exercised directly
+# by ci/tools/test_build_config_policy.sh, so the test evaluates this policy
+# rather than a copy of it.
+#
+# Reads: $HTTP_FILTER_MODULES, $HTTP_GZIP. Echoes the chosen anchor.
+ngx_http_zstd_static_next() {
+    if echo " $HTTP_FILTER_MODULES " | grep ngx_http_brotli_filter_module >/dev/null; then
+        echo ngx_http_brotli_filter_module
+    elif [ "${HTTP_GZIP:-}" = YES ]; then
+        echo ngx_http_gzip_filter_module
+    elif echo " $HTTP_FILTER_MODULES " | grep pagespeed_etag_filter >/dev/null; then
+        echo ngx_pagespeed_etag_filter
+    else
+        echo ngx_http_range_header_filter_module
+    fi
+}


### PR DESCRIPTION
Closes the A31c-F9 investigation and fixes a real anchor-selection bug found while proving it.

## A31c-F9 — the deliverable was the proof, not a behavior change

A31c-F9 suspected that zstd's position relative to gzip in nginx's filter chain might differ between the static (`--add-module`) and dynamic (`--add-dynamic-module`) builds, because the two paths express ordering through entirely different mechanisms and nothing asserted they agree:

- **dynamic** (`filter/config:111-127`) declares `ngx_module_order`, which never names gzip at all;
- **static** (`filter/config:130-150`) splices zstd after a computed `next=` anchor via `filter/reorder-static.sh`.

**Verdict: the two paths agree.** Filters chain as `next = ngx_http_top_body_filter; ngx_http_top_body_filter = this`, so the last-initialized filter runs first. The dynamic path's `ngx_module_order` anchors on `ngx_http_postpone_filter_module`, and stock nginx always registers gzip before postpone when `HTTP_GZIP=YES`, so `ngx_add_module()` places zstd after gzip — the same relationship the static path creates explicitly. In both modes zstd runs before gzip. No ordering change was needed or made.

That reasoning is now locked in `ci/tools/test_build_config_policy.sh` (already wired at `build-test.yml:253`) rather than left as prose: the dynamic-order premises are re-checked on every run, and the static `next=` decision matrix is exercised across all four branches.

## The bug the proof surfaced

Writing the test showed it was checking a *copy* of the policy — it reimplemented the `next=` matrix locally, so swapping the brotli/gzip precedence in production still passed every case. Extracting the selection into `ngx_http_zstd_static_next()` in `filter/reorder-static.sh`, called by both `filter/config` and the test, then exposed a genuine defect:

**the anchor match used bare substring greps.** A module named `ngx_http_brotli_filter_module_extra` matched the brotli arm, selecting an anchor that is not actually present; `ngx_http_zstd_reorder_static_filter` then failed the build even though gzip was a perfectly valid anchor. This is the same hazard the splice logic already pads against. Fixed by matching whole whitespace-delimited tokens.

The pagespeed arm deliberately keeps its bare *suffix* match, since ngx_pagespeed registers its etag filter under more than one prefix; it is anchored on the trailing space instead.

## Verification

Every assertion was mutation-tested, not merely observed green:

| mutation | result |
|---|---|
| swap brotli/gzip precedence in the helper | red — `brotli-present` fails (silent before this PR) |
| reinline `next=` in `filter/config` | red — new inline-copy guard trips |
| revert the token anchoring | red — `brotli-substring-decoy` fails |
| inject gzip into `ngx_module_order` | red — premise guard fires |
| rename the postpone anchor | red — premise guard fires |

`ci/tools/test_build_config_policy.sh` also carries a self-checking negative control that asserts *why* it failed, not just that it did. `shellcheck --severity=error` (the CI gate) is clean; `test_build_input_manifest.sh` and `ci/linter/selftest.sh` pass.

## Also here

- `filter/config` and `filter/reorder-static.sh` behavior is otherwise unchanged; no nginx rebuild semantics were touched.
- The policy test is normalized to the 4-space indent `.editorconfig` mandates for `*.sh` and that every other `ci/tools/*.sh` already uses.

S31-N3 (the ~557-line `ngx_http_zstd_merge_loc_conf()`) was assessed and **declined**: it is mostly an idiomatic flat run of `ngx_conf_merge_*` calls, its dictionary block's `goto`-based cleanup ordering is load-bearing, and there is no cheap validation path for a C change there short of a full nginx build. Left as documented maintainability debt.