### PR TITLE
sweep: repair pre-move command paths and shfmt drift

### DIFF
--- a/.github/scripts/configure-msvc.sh
+++ b/.github/scripts/configure-msvc.sh
@@ -11,9 +11,9 @@ zstd_root=$(cygpath -m \
 
 ZSTD_INC="$zstd_root/include" ZSTD_LIB="$zstd_root/lib" \
     ./configure \
-        --crossbuild=win32 \
-        --with-cc=cl \
-        --with-cc-opt='-MT -DFD_SETSIZE=1024' \
-        --with-pcre="$module_dir/pcre2-$PCRE2_VERSION" \
-        --with-zlib="$module_dir/zlib-$ZLIB_VERSION" \
-        --add-module="$module_dir"
+    --crossbuild=win32 \
+    --with-cc=cl \
+    --with-cc-opt='-MT -DFD_SETSIZE=1024' \
+    --with-pcre="$module_dir/pcre2-$PCRE2_VERSION" \
+    --with-zlib="$module_dir/zlib-$ZLIB_VERSION" \
+    --add-module="$module_dir"

--- a/ci/fuzz/README.md
+++ b/ci/fuzz/README.md
@@ -62,8 +62,8 @@ from upstream `src/core/ngx_string.{h,c}` with citations.
 ## Run locally
 
 ```bash
-bash fuzz/build.sh          # needs clang with libFuzzer
-cd fuzz
+bash ci/fuzz/build.sh          # needs clang with libFuzzer
+cd ci/fuzz
 ./fuzz_accept_encoding -max_total_time=60 corpus/
 ./fuzz_dcz -max_total_time=60 corpus_dcz/
 ```

--- a/ci/fuzz/build.sh
+++ b/ci/fuzz/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Build the Accept-Encoding and dcz-digest libFuzzer targets.
-# Usage: fuzz/build.sh [accept-encoding-output-binary] [dcz-output-binary]
+# Usage: ci/fuzz/build.sh [accept-encoding-output-binary] [dcz-output-binary]
 #
 # Requires clang with libFuzzer (clang >= 6). CFLAGS/CC overridable for
 # OSS-Fuzz / ClusterFuzzLite, which pass their own sanitizer flags.

--- a/ci/fuzz/extract_dcz.sh
+++ b/ci/fuzz/extract_dcz.sh
@@ -42,8 +42,8 @@ awk '
     }
 ' "$SRC" >"$OUT"
 
-if ! grep -q 'ngx_http_zstd_dcz_decode_digest' "$OUT" ||
-    [ "$(tail -n1 "$OUT")" != "}" ]; then
+if ! grep -q 'ngx_http_zstd_dcz_decode_digest' "$OUT" \
+    || [ "$(tail -n1 "$OUT")" != "}" ]; then
     echo "✗ failed to extract ngx_http_zstd_dcz_decode_digest() from $SRC" >&2
     echo "  (function signature/layout changed? update extract_dcz.sh)" >&2
     rm -f "$OUT"

--- a/ci/tools/benchmark.py
+++ b/ci/tools/benchmark.py
@@ -9,9 +9,9 @@ request overhead, so the numbers are stable and reproducible across
 machines (throughput scales with CPU; ratio does not).
 
 Usage:
-    python3 tools/benchmark.py                 # human table
-    python3 tools/benchmark.py --json results.json
-    python3 tools/benchmark.py --levels 1,3,9,19 --repeat 5
+    python3 ci/tools/benchmark.py                 # human table
+    python3 ci/tools/benchmark.py --json results.json
+    python3 ci/tools/benchmark.py --levels 1,3,9,19 --repeat 5
 
 Exit non-zero only on harness error (missing zstd/gzip), never on a
 "slow" result — this is measurement, not a pass/fail gate.

--- a/ci/tools/build-windows.sh
+++ b/ci/tools/build-windows.sh
@@ -24,7 +24,7 @@
 #      curl); all sources and the build land in the workspace.
 #
 # Module toggles (env or edit here):
-#   WITH_ZSTD=1 WITH_BROTLI=1 WITH_HEADERS_MORE=1 ./tools/build-windows.sh
+#   WITH_ZSTD=1 WITH_BROTLI=1 WITH_HEADERS_MORE=1 ./ci/tools/build-windows.sh
 #
 # Every downloaded tarball is pinned by SHA-256; bumping a VER_* means
 # updating its SHA_* alongside (sha256sum <tarball>).


### PR DESCRIPTION
Two cheap ledger rows. Documentation paths and shell formatting only, no
behaviour change anywhere.

When the helper scripts moved into `ci/`, their own usage text stayed behind.
Anyone copying a command out of a README or a `Usage:` line got a path that no
longer exists. I fixed the paths so every advertised command runs as written.

## AUD2-m1, pre-move command paths

The `tools/` to `ci/tools/` and `fuzz/` to `ci/fuzz/` moves left five usage
strings pointing at the old roots:

- `ci/fuzz/README.md`, the "Run locally" block. The `cd fuzz` line had to move
  with `bash fuzz/build.sh` or the block stops being internally consistent.
- `ci/fuzz/build.sh`, the `Usage:` line
- `ci/tools/benchmark.py`, three `Usage:` examples
- `ci/tools/build-windows.sh`, the module-toggle example

Each target now resolves from the repository root.

## AUD2-n6, shfmt drift

`shfmt -d` flagged two scripts: a continuation-line indent in
`.github/scripts/configure-msvc.sh`, and an end-of-line `||` in
`ci/fuzz/extract_dcz.sh`. Formatting only, and `bash -n` is clean on both
before and after.

I kept this to the two files the row named. A full-tree `shfmt -w` would
rewrite about 38 more, `ci/tools/build-windows.sh` most of all, and no CI job
invokes shfmt at all, so there is no declared project style that reformatting
would bring the tree into line with. Picking one by fiat across 40 files is a
decision that deserves its own PR rather than a ride on this one.

## AUD2-n7, assessed and deliberately left alone

The same row asked me to clear the yamllint 120-column warnings. Its SC2015
half is already fixed on master.

I am not touching the line-length half, because the project already decided
this one. `.yamllint` sets `line-length` to `level: warning` and says why:
inline `run:` shell and `${{ }}` expressions legitimately run long.
`ci/linter/lint-yaml.sh` omits `--strict` on purpose so those warnings never
gate. Thirteen of the sixteen warnings sit inside `run: |` block scalars, where
yamllint's `disable-line` pragma does nothing, so the only mechanism that
silences them is a file-wide `disable rule:line-length`. That would retire a
live lens across five workflows to clear a warning the config already declares
acceptable. The line-length half of the row should be closed as invalid.

## Checking it

`shfmt -d` on the two scripts and `ci/linter/lint-yaml.sh` both come back
clean. `review-lint.sh --diff master` reports a pylint R0914 on
`benchmark.py:74` and shfmt drift in `build-windows.sh`; both reproduce on
master untouched.
