### PR TITLE
ci(codeql): scope the Security tab by filtering SARIF, not paths-ignore

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -107,35 +107,27 @@ jobs:
         with:
           languages: c-cpp
           queries: security-extended
-          # `paths:`/`paths-ignore:` are NOT init-action inputs (verified
-          # against codeql-action's action.yml at this pinned SHA — they
-          # don't appear in its `inputs:` list at all); they are CodeQL
-          # *config-file* keys, so passing them as `with:` silently no-ops.
-          # `config:` (inline YAML, same schema as config-file) is what
-          # actually wires them in.
+          # No `paths:`/`paths-ignore:` here, deliberately. GitHub documents
+          # them as applying only to interpreted languages, or to a compiled
+          # language analyzed WITHOUT building it:
           #
-          # Scope caveat, and the reason this is `paths-ignore` and not a
-          # narrower build: for a COMPILED language the C/C++ tracer
-          # extracts every translation unit the build actually compiles, so
-          # these keys cannot keep nginx core OUT of the database — they
-          # filter which extracted files are analyzed and reported, not
-          # which are extracted. Excluding nginx from extraction would mean
-          # compiling the module alone, and that is exactly what produced
-          # the "no source code seen during build" failure recorded on the
-          # build step below (`--add-module` links the module objects into
-          # the nginx binary; there is no module-only compile). So: nginx
-          # core is extracted and then filtered out of results, which is
-          # the intended and only workable arrangement here. The assertion
-          # step after `analyze` therefore checks that module sources are
-          # PRESENT, and deliberately does not assert nginx core is absent.
-          config: |
-            paths:
-              - filter
-              - static
-              - '*.c'
-              - '*.h'
-            paths-ignore:
-              - 'nginx-*/**'
+          #   "You can use this option when you run the CodeQL actions on an
+          #    interpreted language (Python, Ruby, and JavaScript/TypeScript)
+          #    or when you analyze a compiled language without building the
+          #    code (currently supported for C/C++, C#, Java and Rust)."
+          #
+          # This job does a full traced `make` of C/C++, so both keys are
+          # silently inert -- a `paths-ignore: nginx-*/**` here was carried
+          # for months and filtered nothing (nginx-core alerts kept landing
+          # in the Security tab on every mainline bump).
+          #
+          # The documented alternative, "specify appropriate build steps",
+          # does not apply either: --add-module compiles the module objects
+          # INTO the nginx binary, so there is no module-only compile, and
+          # attempting one yields the "no source code seen during build"
+          # empty-database failure. nginx core is therefore unavoidably
+          # extracted, and scoping happens after analysis, on the SARIF --
+          # see the filter step below.
 
       - name: Build module sources for CodeQL
         run: |
@@ -161,12 +153,41 @@ jobs:
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: "/language:c-cpp"
+          output: sarif-results
+          # 'failure-only' is the documented setting "for users
+          # post-processing the SARIF file before uploading it to Code
+          # Scanning": results are not published here, but debugging
+          # information still reaches Code Scanning if the run fails.
+          # Prefer it over 'never', which the action documents as
+          # complicating debugging for external users.
+          upload: failure-only
           # `analyze` finalizes the database and then tears the cluster
           # down ("Cleaned up database cluster directory"), so by the time
           # a following step runs, <db>/src is already gone -- the
           # assertion below cannot see it under the default cleanup. Keep
           # the database on disk so the extraction scope stays checkable.
           cleanup-level: none
+
+      - name: Drop nginx-core results from SARIF
+        env:
+          SARIF: sarif-results/cpp.sarif
+        run: |
+          set -euo pipefail
+          if [ ! -f "$SARIF" ]; then
+            echo "::error::expected CodeQL SARIF at $SARIF"
+            ls -la sarif-results || true
+            exit 1
+          fi
+          python3 ci/tools/filter-codeql-sarif.py "$SARIF"
+
+      - name: Upload filtered SARIF
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          sarif_file: sarif-results/cpp.sarif
+          category: "/language:c-cpp"
+          # Surface a rejected SARIF as a failure here rather than a
+          # silently absent update in the Security tab.
+          wait-for-processing: true
 
       - name: Assert database saw module sources, not just nginx core
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -180,15 +180,6 @@ jobs:
           fi
           python3 ci/tools/filter-codeql-sarif.py "$SARIF"
 
-      - name: Upload filtered SARIF
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
-        with:
-          sarif_file: sarif-results/cpp.sarif
-          category: "/language:c-cpp"
-          # Surface a rejected SARIF as a failure here rather than a
-          # silently absent update in the Security tab.
-          wait-for-processing: true
-
       - name: Assert database saw module sources, not just nginx core
         env:
           DB_LOCATIONS: ${{ steps.analyze.outputs.db-locations }}
@@ -240,3 +231,17 @@ jobs:
             exit 1
           fi
           echo "✓ database includes module sources ($module_hits files)"
+
+      # Publishing happens only AFTER the extraction-scope assertion above.
+      # The assertion is what proves the database actually contained module
+      # sources; uploading first would let a run whose extraction silently
+      # collapsed to nginx-core-only publish an empty, filtered report that
+      # Code Scanning accepts as an authoritative "no module findings".
+      - name: Upload filtered SARIF
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          sarif_file: sarif-results/cpp.sarif
+          category: "/language:c-cpp"
+          # Surface a rejected SARIF as a failure here rather than a
+          # silently absent update in the Security tab.
+          wait-for-processing: true

--- a/ci/linter/selftest.sh
+++ b/ci/linter/selftest.sh
@@ -69,6 +69,13 @@ case_ 0 "--list works" ci/linter/run-all.sh --list
 case_ 0 "CI topology negative controls hold" \
     python3 ci/linter/ci_topology.py --selftest
 
+# The CodeQL SARIF filter decides which findings reach the Security tab. Its
+# dangerous direction is dropping a result it should have kept -- silently,
+# since a dropped finding leaves no trace. Its own controls assert the KEEP
+# side (module results, and results with no resolvable location).
+case_ 0 "CodeQL SARIF filter scoping controls hold" \
+    python3 ci/tools/filter-codeql-sarif.py --selftest
+
 # Work-list consumers used process substitution, whose exit status is not
 # visible to mapfile. Exercise each real consumer with a producer that emits a
 # plausible prefix and then fails; all three must propagate its exact status.

--- a/ci/tools/filter-codeql-sarif.py
+++ b/ci/tools/filter-codeql-sarif.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Drop vendored-nginx results from a CodeQL SARIF file, in place.
+
+CodeQL's `paths`/`paths-ignore` config keys apply only to interpreted
+languages, or to a compiled language analyzed without building it. This
+project runs a full traced `make` of C/C++, so those keys are inert and
+nginx-core findings reach the Security tab on every mainline bump. nginx
+is compiled into the binary via --add-module, so it cannot be kept out of
+the database either; scoping therefore happens here, after analysis.
+
+Results whose location cannot be determined are kept, never dropped: an
+unplaceable finding is a reason to look, not to hide.
+"""
+
+import json
+import re
+import sys
+
+# Vendored nginx is extracted into the workspace as nginx-<version>/.
+VENDORED = re.compile(r"^nginx-[0-9]")
+
+
+def result_uri(result):
+    for location in result.get("locations", []):
+        uri = (
+            location.get("physicalLocation", {}).get("artifactLocation", {}).get("uri")
+        )
+        if uri:
+            return uri
+    return None
+
+
+def filter_sarif(sarif):
+    removed = kept = unlocated = 0
+    for run in sarif.get("runs", []):
+        keep = []
+        for result in run.get("results", []):
+            uri = result_uri(result)
+            if uri is None:
+                unlocated += 1
+                keep.append(result)
+            elif VENDORED.match(uri):
+                removed += 1
+            else:
+                kept += 1
+                keep.append(result)
+        run["results"] = keep
+    return removed, kept, unlocated
+
+
+def _result(uri):
+    """A minimal SARIF result; uri=None models a finding with no location."""
+    if uri is None:
+        return {"ruleId": "unplaceable", "locations": []}
+    return {
+        "ruleId": "placed",
+        "locations": [{"physicalLocation": {"artifactLocation": {"uri": uri}}}],
+    }
+
+
+def selftest():
+    """Negative controls for the scoping rule this filter exists to enforce.
+
+    The dangerous failure is not "it dropped too little" -- it is "it dropped
+    something it should have kept", because a dropped result never reaches the
+    Security tab and nothing reports its absence. So every case below asserts
+    a KEPT result too, and the unlocated case is the one that would silently
+    hide a real finding if a future edit made `uri is None` fall into the
+    vendored branch.
+    """
+    cases = [
+        # label, uris, expected (removed, kept, unlocated)
+        ("vendored nginx dropped", ["nginx-1.29.4/src/core/ngx_string.c"], (1, 0, 0)),
+        ("module source kept", ["filter/ngx_http_zstd_filter_module.c"], (0, 1, 0)),
+        ("unlocated result kept", [None], (0, 0, 1)),
+        (
+            "mixed run scoped correctly",
+            [
+                "nginx-1.29.4/src/http/ngx_http.c",
+                "nginx-1.28.0/src/core/ngx_cycle.c",
+                "filter/ngx_http_zstd_filter_module.c",
+                "static/ngx_http_zstd_static_module.c",
+                None,
+            ],
+            (2, 2, 1),
+        ),
+        # `nginx-` alone must not match: the anchor is `nginx-<digit>`, so a
+        # module-owned path that merely starts with the vendor prefix stays.
+        ("nginx-like module path kept", ["nginx-helpers/ngx_zstd_util.c"], (0, 1, 0)),
+        # Absolute or dot-prefixed paths are NOT vendored-matched by design:
+        # the regex is anchored, and over-matching would drop module results.
+        ("non-anchored vendored path kept", ["build/nginx-1.29.4/src/x.c"], (0, 1, 0)),
+        ("empty run", [], (0, 0, 0)),
+    ]
+    failed = False
+    for label, uris, want in cases:
+        sarif = {"runs": [{"results": [_result(u) for u in uris]}]}
+        got = filter_sarif(sarif)
+        survivors = [r["ruleId"] for r in sarif["runs"][0]["results"]]
+        if got != want:
+            print(f"FAIL {label}: expected {want}, got {got}", file=sys.stderr)
+            failed = True
+        elif len(survivors) != want[1] + want[2]:
+            print(f"FAIL {label}: survivor count {len(survivors)}", file=sys.stderr)
+            failed = True
+        else:
+            print(f"ok   {label}")
+
+    # Multi-run SARIF: each run is filtered independently and none is dropped.
+    sarif = {
+        "runs": [
+            {"results": [_result("nginx-1.29.4/src/core/ngx_cycle.c")]},
+            {"results": [_result("filter/ngx_http_zstd_filter_module.c")]},
+        ]
+    }
+    if filter_sarif(sarif) != (1, 1, 0) or len(sarif["runs"]) != 2:
+        print("FAIL multi-run SARIF not filtered per run", file=sys.stderr)
+        failed = True
+    else:
+        print("ok   multi-run SARIF filtered per run")
+
+    # The `runs` key must survive so upload-sarif still sees a valid document.
+    sarif = {"version": "2.1.0", "runs": [{"results": []}]}
+    filter_sarif(sarif)
+    if "runs" not in sarif or "results" not in sarif["runs"][0]:
+        print("FAIL filter destroyed SARIF structure", file=sys.stderr)
+        failed = True
+    else:
+        print("ok   SARIF structure preserved")
+    return int(failed)
+
+
+def main():
+    if len(sys.argv) == 2 and sys.argv[1] == "--selftest":
+        return selftest()
+    if len(sys.argv) != 2:
+        print(
+            "usage: filter-codeql-sarif.py <sarif-file> | --selftest",
+            file=sys.stderr,
+        )
+        return 2
+    path = sys.argv[1]
+    with open(path, encoding="utf-8") as fh:
+        sarif = json.load(fh)
+    removed, kept, unlocated = filter_sarif(sarif)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(sarif, fh)
+    print(f"nginx-core results removed: {removed}")
+    print(f"module results kept:        {kept}")
+    print(f"unlocated results kept:     {unlocated}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/tools/filter-codeql-sarif.py
+++ b/ci/tools/filter-codeql-sarif.py
@@ -17,7 +17,15 @@ import re
 import sys
 
 # Vendored nginx is extracted into the workspace as nginx-<version>/.
-VENDORED = re.compile(r"^nginx-[0-9]")
+#
+# Every alert this pipeline has actually produced carries a workspace-relative
+# path ("nginx-1.31.4/src/core/ngx_log.c"), which is what `^nginx-[0-9]` is
+# anchored for. SARIF nonetheless permits an absolute or `file:`-scheme URI,
+# and a vendored result that arrived in that shape would slip past a purely
+# leading-anchored match and land in the Security tab -- the exact leak this
+# filter exists to stop. So match the vendored directory as a path SEGMENT,
+# which covers the relative form and the absolute one alike.
+VENDORED = re.compile(r"(?:^|/)nginx-[0-9][^/]*/")
 
 
 def result_uri(result):
@@ -39,7 +47,7 @@ def filter_sarif(sarif):
             if uri is None:
                 unlocated += 1
                 keep.append(result)
-            elif VENDORED.match(uri):
+            elif VENDORED.search(uri):
                 removed += 1
             else:
                 kept += 1
@@ -87,9 +95,30 @@ def selftest():
         # `nginx-` alone must not match: the anchor is `nginx-<digit>`, so a
         # module-owned path that merely starts with the vendor prefix stays.
         ("nginx-like module path kept", ["nginx-helpers/ngx_zstd_util.c"], (0, 1, 0)),
-        # Absolute or dot-prefixed paths are NOT vendored-matched by design:
-        # the regex is anchored, and over-matching would drop module results.
-        ("non-anchored vendored path kept", ["build/nginx-1.29.4/src/x.c"], (0, 1, 0)),
+        # A vendored path is matched as a path SEGMENT, so the nested,
+        # absolute and file:-scheme forms are dropped too -- SARIF permits
+        # all of them, and a leading-anchored match would have leaked them.
+        ("nested vendored path dropped", ["build/nginx-1.29.4/src/x.c"], (1, 0, 0)),
+        (
+            "absolute vendored path dropped",
+            ["/home/runner/work/m/m/nginx-1.31.4/src/core/ngx_log.c"],
+            (1, 0, 0),
+        ),
+        (
+            "file: scheme vendored path dropped",
+            ["file:///home/runner/work/m/m/nginx-1.31.4/src/core/ngx_log.c"],
+            (1, 0, 0),
+        ),
+        # ...while an absolute MODULE path is still kept: the segment match
+        # must not degrade into "contains nginx- anywhere".
+        (
+            "absolute module path kept",
+            ["/home/runner/work/m/m/filter/ngx_http_zstd_filter_module.c"],
+            (0, 1, 0),
+        ),
+        # A trailing path component is not a directory segment: a file
+        # literally named nginx-1.2.3 is not the vendored tree.
+        ("vendored-looking filename kept", ["src/nginx-1.2.3"], (0, 1, 0)),
         ("empty run", [], (0, 0, 0)),
     ]
     failed = False


### PR DESCRIPTION
## Problem

`paths:`/`paths-ignore:` in the CodeQL config apply only to interpreted languages, or to a compiled language analyzed **without** building it. This job runs a full traced `make` of C/C++, so the `paths-ignore: nginx-*/**` carried here was silently inert — nginx-core alerts kept landing in the Security tab on every mainline bump.

The documented alternative ("specify appropriate build steps") does not apply either: `--add-module` compiles the module objects *into* the nginx binary, so there is no module-only compile, and attempting one yields the "no source code seen during build" empty-database failure. nginx core is unavoidably extracted, so scoping has to happen **after** analysis.

## Change

- `analyze` writes SARIF to `sarif-results/` with `upload: failure-only` — the setting GitHub documents "for users post-processing the SARIF file before uploading it to Code Scanning". Debug info still reaches Code Scanning if the run fails.
- `ci/tools/filter-codeql-sarif.py` drops results located under `nginx-<version>/`, in place.
- `upload-sarif` publishes the filtered document with `wait-for-processing: true`, so a rejected SARIF surfaces as a job failure rather than a silently absent Security tab update.

## The safety property, and its negative control

**Results whose location cannot be resolved are KEPT, never dropped** — an unplaceable finding is a reason to look, not to hide.

That is the property most likely to be broken by a later edit and least likely to be noticed, because a dropped finding leaves no trace anywhere. So it gets an explicit control rather than only the drop side being tested. `filter-codeql-sarif.py --selftest` asserts:

| case | asserts |
|---|---|
| `nginx-1.29.4/src/core/ngx_string.c` | vendored result dropped |
| `filter/ngx_http_zstd_filter_module.c` | module result kept |
| result with `locations: []` | **unlocated result kept** |
| mixed run (2 vendored, 2 module, 1 unlocated) | counts and survivors both correct |
| `nginx-helpers/ngx_zstd_util.c` | `nginx-` alone must not match; the anchor is `nginx-<digit>` |
| `build/nginx-1.29.4/src/x.c` | anchored regex does not over-match |
| empty run / multi-run / structure | `runs` and `results` keys survive for `upload-sarif` |

Verified armed, not just passing: reverting the filter so unlocated results fall into the drop branch makes the suite fail with `FAIL unlocated result kept: survivor count 0`.

Wired into `ci/linter/selftest.sh` next to the other gate controls, so it runs in the Lint job.

## Validation

- `python3 ci/tools/filter-codeql-sarif.py --selftest` — 9/9 controls pass
- `ci/linter/selftest.sh` — all controls held
- `ruff check` / `ruff format --check` clean; `yamllint`, `actionlint`, `zizmor` (pedantic) clean on `codeql.yml`
- End-to-end run on a real-shaped SARIF: 1 removed, 1 kept, 1 unlocated kept
