### PR TITLE
docs: correct three stale release claims, changelog the ratio fix

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,16 @@
+# Prose lens for this repository's Markdown.
+#
+# Deliberately built on Vale's BUILT-IN checks only (Vale.Terms, Vale.Spelling,
+# Vale.Repetition). No style package is vendored or downloaded, so the lens is
+# self-contained and runs identically in CI, in a fork, and under
+# review-lint.sh's `--no-global` invocation.
+#
+# Spelling is off: this is a systems-programming README full of identifiers
+# (zstd, dcz, refPrefix, CCtx, ngx_*), and a wordlist large enough to silence
+# them would suppress the real misspellings codespell already catches better.
+StylesPath = .vale-styles
+MinAlertLevel = warning
+
+[*.md]
+Vale.Repetition = error
+Vale.Terms = warning

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,16 @@ Changes with http-zstd
 
 Unreleased
 
+    *) Bugfix: "$zstd_ratio" is now exact for the whole 64-bit range of
+       byte counts. The previous form scaled the input count before
+       dividing, so a large enough response overflowed the intermediate
+       and reported a wrong ratio -- for bytes_in near UINT64_MAX it
+       logged 0.000 where the true ratio was 0.999. The variable is now
+       produced by exact integer long division that extracts each of the
+       three fractional digits without an intermediate that can wrap,
+       and is correct for expanding streams as well as shrinking ones.
+       Log output only; no response bytes change.
+
     *) Tests: removed the standalone dcz CDict-vs-refPrefix equivalence
        probes. They were one-off investigation tools, not production-helper
        regression tests, and keeping them under ci/tools made the dcz test

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 # zstd-nginx-module
 
-An nginx module for [Zstandard (zstd)](https://facebook.github.io/zstd/) compression. Zstandard typically achieves better compression ratios than gzip at comparable or faster speeds, making it a good choice for reducing transmitted response sizes.
+An nginx module for [Zstandard (zstd)](https://facebook.github.io/zstd/) compression. Zstandard typically achieves substantially better compression ratios than gzip, making it a good choice for reducing transmitted response sizes. Throughput depends on the level and payload: at the low levels recommended for web traffic, zstd trades some encode speed for that ratio -- see the [measured benchmark table](#benchmarks) rather than assuming a general speed win.
 
 This is a hardened fork: every PR is exercised against **nginx mainline**, the filter/static suites and runtime regressions run under **ASAN/UBSAN**, flawfinder/semgrep/clang-tidy run on every change, and a weekly deep pass fuzzes both parser targets and additionally covers **nginx stable** and **[Angie](https://angie.software/)** (see [Testing & CI](#testing--ci)).
 
@@ -1465,12 +1465,16 @@ setup and the `git ls-files` trap: [CONTRIBUTING.md](CONTRIBUTING.md).
 Reproduce with `python3 ci/tools/benchmark.py` (drives the `zstd`/`gzip`
 CLIs linked against the same libzstd/zlib on the machine that runs it).
 Compression **ratio** for a given library/input/settings combination is
-stable across runs and machines; **throughput** is not — it scales with
-CPU and varies run to run, so treat any MB/s figure as a rough range,
-not a point value. These numbers come from the CLI codecs directly:
-they exclude nginx's own filter, context, buffering, and flush
-overhead, so they are not a measurement of module throughput. Figures
-below: **libzstd 1.5.5**, single core, `--repeat 3`, best wall-time.
+stable across runs and machines, but not necessarily across libzstd
+versions — encoder heuristics change between releases while staying
+format-compatible, so expect the ratios below to shift somewhat on the
+recommended 1.5.7 rather than the 1.5.5 measured here. **Throughput** is
+not stable at all: it scales with CPU and varies run to run, so treat
+any MB/s figure as a rough range, not a point value. These numbers come
+from the CLI codecs directly: they exclude nginx's own filter, context,
+buffering, and flush overhead, so they are not a measurement of module
+throughput. Figures below: **libzstd 1.5.5**, single core, `--repeat 3`,
+best wall-time.
 
 For nginx request-path measurements, `ci/tools/ab_bench.py` keeps its existing
 plain-zstd workload by default and accepts `--workload dcz` for a focused RFC
@@ -1535,8 +1539,10 @@ What changed is the module's per-response *overhead* inside nginx:
   churn under load — not as a different ratio or a different CLI MB/s
   figure. The trade is a higher per-request memory floor (~256 KB);
   see [`zstd_buffers`](#zstd_buffers).
-* **`$zstd_ratio` now computes with a single division** instead of two
-  — a log-path micro-cost, no effect on the response itself.
+* **`$zstd_ratio` is computed by exact integer long division**, so it
+  stays correct for byte counts near the 64-bit range and for streams
+  that expand rather than shrink — a log-path cost only, no effect on
+  the response itself.
 * **`zstd_long` (off by default)** can materially improve ratio on
   large, internally repetitive bodies that exceed the match window —
   but only when explicitly enabled, and the gain is workload-specific,


### PR DESCRIPTION
Release-prep documentation accuracy pass. No code changes.

## What was wrong

**The intro contradicted our own benchmark table.** README's opening sentence
claimed zstd compresses "at comparable or faster speeds" than gzip. The measured
table further down disagrees on three of its four rows: gzip-6 beats zstd-1 and
zstd-3 on the JSON payload (72 MB/s vs 52 and 43), on the JS payload (108 vs 87
and 78), and on the small HTML fixture (29 vs 12). The document already knew
this -- the prose right under the table says "Throughput is the opposite in this
table ... Choose zstd here for the ratio ..., not for raw CLI speed." A reader
who stops after the intro got the inverse of what we measured. The intro now
claims only the ratio win and links to the table.

**A "recent changes" bullet described code that no longer exists.** It said
`$zstd_ratio` "now computes with a single division" instead of two. The overflow
fix replaced that with an iterative exact long division extracting three
fractional digits, so both halves of the sentence were stale.

**Ratio stability was overstated.** The benchmark preamble called compression
ratio "stable across runs and machines" with no version qualifier. Encoder
heuristics change between libzstd releases while staying format-compatible, and
this matters concretely here: the table is measured on 1.5.5 while we recommend
deploying 1.5.7.

**The `$zstd_ratio` overflow fix shipped with no CHANGES entry.** It is a
user-visible correction to a logged variable -- for `bytes_in` near `UINT64_MAX`
the old form logged `0.000` where the true ratio was `0.999` -- which is exactly
the class the surrounding entries record. It now has one.

## Also

Adds `.vale.ini` so the prose lens actually runs against this repository instead
of reporting itself as a coverage gap in the delivery lint gate. It uses Vale's
built-in checks only, with no vendored or downloaded style package, so it
behaves identically in a fork and under `--no-global`. Spelling stays off:
codespell already covers it and does not fight the `zstd`/`dcz`/`CCtx`/`ngx_*`
identifier vocabulary.

## Validation

- `ci/tools/test_docs_ci_drift.sh` green.
- All README `](#anchor)` targets resolve (checked before and after; the new
  benchmark-table link included).
- `review-lint.sh --diff HEAD`: every lens clean, **zero coverage gaps** -- the
  previously-skipped `vale` lens now runs, and was negative-controlled (a
  planted repeated word fires `Vale.Repetition`).
- CodeRabbit reviewed the branch; its one finding (a sentence left without a
  predicate by the first edit) is fixed in this diff.